### PR TITLE
Change relaxer invocation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,8 @@ toc::[]
 
 === Changed
 
+* generated mocks don't contain runtime logic any longer
+
 === Deprecated
 
 === Removed

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -22,15 +22,13 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
+import java.lang.StringBuilder
 
 internal interface ProcessorContract {
     data class Relaxer(
@@ -127,7 +125,10 @@ internal interface ProcessorContract {
     }
 
     interface RelaxerGenerator {
-        fun buildRelaxers(relaxer: Relaxer?, useUnitFunRelaxer: Boolean): String
+        fun addRelaxer(
+            relaxerDefinitions: StringBuilder,
+            relaxer: Relaxer?
+        )
     }
 
     interface PropertyGenerator {
@@ -156,7 +157,7 @@ internal interface ProcessorContract {
             mockName: String,
             qualifier: String,
             existingProxies: Set<String>,
-            amountOfGenerics: Int,
+            enableSpy: Boolean,
         ): Pair<List<PropertySpec>, List<FunSpec>>
     }
 
@@ -239,11 +240,6 @@ internal interface ProcessorContract {
             KMockContract::class.java.simpleName
         )
 
-        val UNIT_RELAXER = ClassName(
-            NoopCollector::class.java.packageName,
-            "relaxVoidFunction"
-        )
-
         val NOOP_COLLECTOR_NAME = ClassName(
             NoopCollector::class.java.packageName,
             NoopCollector::class.java.simpleName
@@ -252,19 +248,6 @@ internal interface ProcessorContract {
         val PROXY_FACTORY_NAME = ClassName(
             ProxyFactory::class.java.packageName,
             ProxyFactory::class.java.simpleName
-        )
-
-        val SYNC_FUN_NAME = ClassName(
-            KMockContract::class.java.packageName,
-            "KMockContract.${SyncFunProxy::class.java.simpleName}"
-        )
-        val ASYNC_FUN_NAME = ClassName(
-            KMockContract::class.java.packageName,
-            "KMockContract.${AsyncFunProxy::class.java.simpleName}"
-        )
-        val PROP_NAME = ClassName(
-            KMockContract::class.java.packageName,
-            "KMockContract.${PropertyProxy::class.java.simpleName}"
         )
 
         const val COMMON_INDICATOR = "commonTest"

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockRelaxerGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockRelaxerGenerator.kt
@@ -9,32 +9,12 @@ package tech.antibytes.kmock.processor.mock
 import tech.antibytes.kmock.processor.ProcessorContract
 
 internal class KMockRelaxerGenerator : ProcessorContract.RelaxerGenerator {
-    override fun buildRelaxers(
-        relaxer: ProcessorContract.Relaxer?,
-        useUnitFunRelaxer: Boolean
-    ): String {
-        val unitFunRelaxerStr = if (useUnitFunRelaxer) {
-            "unitFunRelaxer = if (relaxUnitFun) { { ${ProcessorContract.UNIT_RELAXER.simpleName}() } } else { null }"
-        } else {
-            ""
-        }
-
-        val buildInRelaxerStr = if (useUnitFunRelaxer) {
-            "buildInRelaxer = null"
-        } else {
-            ""
-        }
-
-        val relaxerStr = if (relaxer != null) {
-            "relaxer = if (relaxed) { { mockId -> ${relaxer.functionName}(mockId) } } else { null }"
-        } else {
-            "relaxer = null"
-        }
-
-        return if (unitFunRelaxerStr.isEmpty()) {
-            relaxerStr
-        } else {
-            "$unitFunRelaxerStr, $relaxerStr, $buildInRelaxerStr"
+    override fun addRelaxer(
+        relaxerDefinitions: StringBuilder,
+        relaxer: ProcessorContract.Relaxer?
+    ) {
+        if (relaxer != null) {
+            relaxerDefinitions.append("useRelaxerIf(relaxed) { mockId -> ${relaxer.functionName}(mockId) }\n")
         }
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
@@ -763,16 +763,15 @@ class KMockMocksSpec {
         )
         val expected = loadResource("/expected/spy/AllowedRecursive.kt")
 
-        val allowedRecursiveTypes = mapOf(
-            "${KMOCK_PREFIX}recursive_0" to "kotlin.Comparable"
-        )
-
         // When
         val compilerResult = compile(
             provider,
             source,
             isKmp = false,
-            kspArguments = allowedRecursiveTypes
+            kspArguments = mapOf(
+                "${KMOCK_PREFIX}spyOn_0" to "mock.template.spy.AllowedRecursive",
+                "${KMOCK_PREFIX}recursive_0" to "kotlin.Comparable"
+            )
         )
         val actual = resolveGenerated("AllowedRecursiveMock.kt")
 

--- a/kmock-processor/src/test/resources/mock/expected/alias/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/alias/Common.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class AliasCommonMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,12 +21,12 @@ internal class AliasCommonMock(
     relaxed: Boolean = false
 ) : Common {
     public val _foo: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createAsyncFunProxy("mock.template.alias.AliasCommonMock#_foo", spyOn = null,
-        collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createAsyncFunProxy("mock.template.alias.AliasCommonMock#_foo", collector =
+    verifier, freeze = freeze)
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.alias.AliasCommonMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.alias.AliasCommonMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override suspend fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/alias/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/alias/Platform.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class AliasPlatformMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,12 +21,12 @@ internal class AliasPlatformMock(
     relaxed: Boolean = false
 ) : Platform {
     public val _foo: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createAsyncFunProxy("mock.template.alias.AliasPlatformMock#_foo", spyOn = null,
-        collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createAsyncFunProxy("mock.template.alias.AliasPlatformMock#_foo", collector =
+    verifier, freeze = freeze)
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.alias.AliasPlatformMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.alias.AliasPlatformMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override suspend fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/alias/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/alias/Shared.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class AliasSharedMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,12 +21,12 @@ internal class AliasSharedMock(
     relaxed: Boolean = false
 ) : Shared {
     public val _foo: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createAsyncFunProxy("mock.template.alias.AliasSharedMock#_foo", spyOn = null,
-        collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createAsyncFunProxy("mock.template.alias.AliasSharedMock#_foo", collector =
+    verifier, freeze = freeze)
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.alias.AliasSharedMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.alias.AliasSharedMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override suspend fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/async/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/async/Common.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,28 +21,28 @@ internal class CommonMock(
     relaxed: Boolean = false
 ) : Common {
     public val _foo: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createAsyncFunProxy("mock.template.async.CommonMock#_foo", spyOn = null,
-        collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createAsyncFunProxy("mock.template.async.CommonMock#_foo", collector =
+    verifier, freeze = freeze)
 
-    public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.async.CommonMock#_bar", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+    public val _bar: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
+        = ProxyFactory.createAsyncFunProxy("mock.template.async.CommonMock#_bar", collector =
+    verifier, freeze = freeze)
 
-    public val _ozz: KMockContract.SyncFunProxy<Any, (kotlin.IntArray) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.async.CommonMock#_ozz", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+    public val _ozz: KMockContract.AsyncFunProxy<Any, suspend (kotlin.IntArray) -> kotlin.Any> =
+        ProxyFactory.createAsyncFunProxy("mock.template.async.CommonMock#_ozz", collector = verifier,
+            freeze = freeze)
 
-    public val _izz: KMockContract.SyncFunProxy<Any, (Array<out kotlin.Any>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.async.CommonMock#_izz", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+    public val _izz: KMockContract.AsyncFunProxy<Any, suspend (Array<out kotlin.Any>) -> kotlin.Any> =
+        ProxyFactory.createAsyncFunProxy("mock.template.async.CommonMock#_izz", collector = verifier,
+            freeze = freeze)
 
     public override suspend fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 
-    public override fun bar(buzz: Int, bozz: Any): Any = _bar.invoke(buzz, bozz)
+    public override suspend fun bar(buzz: Int, bozz: Any): Any = _bar.invoke(buzz, bozz)
 
-    public override fun ozz(vararg buzz: Int): Any = _ozz.invoke(buzz)
+    public override suspend fun ozz(vararg buzz: Int): Any = _ozz.invoke(buzz)
 
-    public override fun izz(vararg buzz: Any): Any = _izz.invoke(buzz)
+    public override suspend fun izz(vararg buzz: Any): Any = _izz.invoke(buzz)
 
     public fun _clearMock(): Unit {
         _foo.clear()

--- a/kmock-processor/src/test/resources/mock/expected/async/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/async/Platform.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,28 +21,28 @@ internal class PlatformMock(
     relaxed: Boolean = false
 ) : Platform {
     public val _foo: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createAsyncFunProxy("mock.template.async.PlatformMock#_foo", spyOn = null,
-        collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createAsyncFunProxy("mock.template.async.PlatformMock#_foo", collector =
+    verifier, freeze = freeze)
 
-    public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.async.PlatformMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+    public val _bar: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
+        = ProxyFactory.createAsyncFunProxy("mock.template.async.PlatformMock#_bar", collector =
+    verifier, freeze = freeze)
 
-    public val _ozz: KMockContract.SyncFunProxy<Any, (kotlin.IntArray) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.async.PlatformMock#_ozz", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+    public val _ozz: KMockContract.AsyncFunProxy<Any, suspend (kotlin.IntArray) -> kotlin.Any> =
+        ProxyFactory.createAsyncFunProxy("mock.template.async.PlatformMock#_ozz", collector =
+        verifier, freeze = freeze)
 
-    public val _izz: KMockContract.SyncFunProxy<Any, (Array<out kotlin.Any>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.async.PlatformMock#_izz", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+    public val _izz: KMockContract.AsyncFunProxy<Any, suspend (Array<out kotlin.Any>) -> kotlin.Any> =
+        ProxyFactory.createAsyncFunProxy("mock.template.async.PlatformMock#_izz", collector =
+        verifier, freeze = freeze)
 
     public override suspend fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 
-    public override fun bar(buzz: Int, bozz: Any): Any = _bar.invoke(buzz, bozz)
+    public override suspend fun bar(buzz: Int, bozz: Any): Any = _bar.invoke(buzz, bozz)
 
-    public override fun ozz(vararg buzz: Int): Any = _ozz.invoke(buzz)
+    public override suspend fun ozz(vararg buzz: Int): Any = _ozz.invoke(buzz)
 
-    public override fun izz(vararg buzz: Any): Any = _izz.invoke(buzz)
+    public override suspend fun izz(vararg buzz: Any): Any = _izz.invoke(buzz)
 
     public fun _clearMock(): Unit {
         _foo.clear()

--- a/kmock-processor/src/test/resources/mock/expected/async/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/async/Shared.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,16 +21,16 @@ internal class SharedMock(
     relaxed: Boolean = false
 ) : Shared {
     public val _foo: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createAsyncFunProxy("mock.template.async.SharedMock#_foo", spyOn = null,
-        collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createAsyncFunProxy("mock.template.async.SharedMock#_foo", collector =
+    verifier, freeze = freeze)
 
-    public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.async.SharedMock#_bar", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+    public val _bar: KMockContract.AsyncFunProxy<Any, suspend (kotlin.Int, kotlin.Any) -> kotlin.Any>
+        = ProxyFactory.createAsyncFunProxy("mock.template.async.SharedMock#_bar", collector =
+    verifier, freeze = freeze)
 
     public override suspend fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 
-    public override fun bar(buzz: Int, bozz: Any): Any = _bar.invoke(buzz, bozz)
+    public override suspend fun bar(buzz: Int, bozz: Any): Any = _bar.invoke(buzz, bozz)
 
     public fun _clearMock(): Unit {
         _foo.clear()

--- a/kmock-processor/src/test/resources/mock/expected/buildIn/Collision.kt
+++ b/kmock-processor/src/test/resources/mock/expected/buildIn/Collision.kt
@@ -7,13 +7,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CollisionMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,61 +25,54 @@ internal class CollisionMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override val bar: Int
         get() = _bar.onGet()
 
     public val _bar: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_bar", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override val hashCode: String
         get() = _hashCode.onGet()
 
     public val _hashCode: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_hashCode", spyOnGet =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_hashCode", collector =
+        verifier, freeze = freeze)
 
     public override var buzz: Any
         get() = _buzz.onGet()
         set(`value`) = _buzz.onSet(value)
 
     public val _buzz: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_buzz", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
-
-    private val __spyOn: Collision? = spyOn
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.CollisionMock#_buzz", collector =
+        verifier, freeze = freeze)
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CollisionMock#_toString", spyOn = if
-                                                                                                     (spyOn != null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CollisionMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CollisionMock#_equals", spyOn = if
-                                                                                                   (spyOn != null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CollisionMock#_equals", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+        }
 
     public val _hashCodeWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CollisionMock#_hashCodeWithVoid", spyOn
-        = if (spyOn != null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze
-        = freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CollisionMock#_hashCodeWithVoid",
+            collector = verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+        }
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is CollisionMock && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCodeWithVoid.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/buildIn/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/buildIn/Common.kt
@@ -7,13 +7,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,54 +25,47 @@ internal class CommonMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.CommonMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.CommonMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override val bar: Int
         get() = _bar.onGet()
 
     public val _bar: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.CommonMock#_bar", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.CommonMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override var buzz: Any
         get() = _buzz.onGet()
         set(`value`) = _buzz.onSet(value)
 
     public val _buzz: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.CommonMock#_buzz", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
-
-    private val __spyOn: Common? = spyOn
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.CommonMock#_buzz", collector =
+        verifier, freeze = freeze)
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CommonMock#_toString", spyOn = if
-                                                                                                  (spyOn != null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CommonMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CommonMock#_equals", spyOn = if (spyOn
-            != null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CommonMock#_equals", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CommonMock#_hashCode", spyOn = if
-                                                                                                  (spyOn != null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.CommonMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+        }
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is CommonMock && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/buildIn/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/buildIn/Platform.kt
@@ -7,13 +7,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,54 +25,47 @@ internal class PlatformMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.PlatformMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.PlatformMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override val bar: Int
         get() = _bar.onGet()
 
     public val _bar: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.PlatformMock#_bar", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.PlatformMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override var buzz: Any
         get() = _buzz.onGet()
         set(`value`) = _buzz.onSet(value)
 
     public val _buzz: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.PlatformMock#_buzz", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
-
-    private val __spyOn: Platform? = spyOn
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.PlatformMock#_buzz", collector =
+        verifier, freeze = freeze)
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.PlatformMock#_toString", spyOn = if
-                                                                                                    (spyOn != null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.PlatformMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.PlatformMock#_equals", spyOn = if
-                                                                                                  (spyOn != null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.PlatformMock#_equals", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.PlatformMock#_hashCode", spyOn = if
-                                                                                                    (spyOn != null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.PlatformMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+        }
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is PlatformMock && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/buildIn/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/buildIn/Shared.kt
@@ -7,13 +7,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,54 +25,47 @@ internal class SharedMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.SharedMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.SharedMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override val bar: Int
         get() = _bar.onGet()
 
     public val _bar: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.SharedMock#_bar", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.SharedMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override var buzz: Any
         get() = _buzz.onGet()
         set(`value`) = _buzz.onSet(value)
 
     public val _buzz: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.buildIn.SharedMock#_buzz", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
-
-    private val __spyOn: Shared? = spyOn
+        ProxyFactory.createPropertyProxy("mock.template.buildIn.SharedMock#_buzz", collector =
+        verifier, freeze = freeze)
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.SharedMock#_toString", spyOn = if
-                                                                                                  (spyOn != null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.SharedMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.SharedMock#_equals", spyOn = if (spyOn
-            != null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.SharedMock#_equals", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.buildIn.SharedMock#_hashCode", spyOn = if
-                                                                                                  (spyOn != null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.buildIn.SharedMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+        }
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is SharedMock && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/generic/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/Common.kt
@@ -11,13 +11,9 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -34,312 +30,347 @@ internal class CommonMock<K : Any, L>(
         set(`value`) = _template.onSet(value)
 
     public val _template: KMockContract.PropertyProxy<L> =
-        ProxyFactory.createPropertyProxy("mock.template.generic.CommonMock#_template", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.generic.CommonMock#_template", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_fooWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_fooWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_fooWithAny", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_fooWithAny", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blaWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blaWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _blaWithInt: KMockContract.SyncFunProxy<Unit, (kotlin.Int) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blaWithInt", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blaWithInt", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blaWithInts: KMockContract.SyncFunProxy<Unit, (kotlin.IntArray) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blaWithInts", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blaWithInts", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _barWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String>>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.String>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_barWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_barWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _barWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String>>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_barWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _barWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_barWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blubbWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String?>>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.String?>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blubbWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blubbWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _blubbWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String?>>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blubbWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blubbWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blubbWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bussWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _bussWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bussWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bossWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>?>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>?>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bossWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bossWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _bossWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>?>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bossWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bossWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bossWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _buzzWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_buzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_buzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _buzzWithT:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> = ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_buzzWithT",
-        spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        collector = verifier, freeze = freeze) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
 
     public val _buzzWithTs: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_buzzWithTs", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_buzzWithTs", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ozzWithVoid: KMockContract.SyncFunProxy<L, () -> L> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ozzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ozzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _ozzWithL: KMockContract.SyncFunProxy<Unit, (L) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ozzWithL", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ozzWithL", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ozzWithLs: KMockContract.SyncFunProxy<Unit, (Array<out L>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ozzWithLs", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ozzWithLs", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _brassWithVoid:
         KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>, () ->
         kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_brassWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_brassWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _brassWithComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_brassWithComparable", spyOn
-        = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_brassWithComparable",
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _brassWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_brassWithComparables",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blissWithVoid:
         KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?, () ->
         kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _blissWithComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithComparable", spyOn
-        = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithComparable",
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blissWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithComparables",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
         kotlin.String>, () -> kotlin.collections.Map<kotlin.String, kotlin.String>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lossWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lossWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _lossWithCollectionsMap:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.Map<kotlin.String, kotlin.String>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lossWithCollectionsMap",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lossWithCollectionsMaps: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lossWithCollectionsMaps",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _uzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_uzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_uzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _uzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_uzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _uzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_uzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _lzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_lzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _tzzWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _tzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _tzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any?>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _rzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_rzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_rzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _rzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_rzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _rzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_rzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _izzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_izzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_izzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _izzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_izzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _izzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_izzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ossWithAny: KMockContract.SyncFunProxy<Any?, (kotlin.Any?) -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithAny", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithAny", collector =
+        verifier, freeze = freeze)
 
     public val _ossWithAnyAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithAnyAny", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithAnyAny", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ossWithAnyAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithAnyAnys", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithAnyAnys", collector
+        = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _kssWithMockTemplateGenericSomeGeneric: KMockContract.SyncFunProxy<Any, (kotlin.Any) ->
     kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_kssWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _kssWithMockTemplateGenericSomeGenericMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any, kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_kssWithMockTemplateGenericSomeGenericMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _issWithAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_issWithAny", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_issWithAny", collector =
+        verifier, freeze = freeze)
 
     public val _issWithAnyMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_issWithAnyMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T

--- a/kmock-processor/src/test/resources/mock/expected/generic/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/Platform.kt
@@ -11,13 +11,9 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -34,318 +30,354 @@ internal class PlatformMock<K : Any, L>(
         set(`value`) = _template.onSet(value)
 
     public val _template: KMockContract.PropertyProxy<L> =
-        ProxyFactory.createPropertyProxy("mock.template.generic.PlatformMock#_template", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.generic.PlatformMock#_template", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithAny", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithAny", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit>
-        = ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithAnys", spyOn =
-    null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-        relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        = ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithAnys", collector
+    = verifier, freeze = freeze) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blaWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blaWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _blaWithInt: KMockContract.SyncFunProxy<Unit, (kotlin.Int) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blaWithInt", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blaWithInt", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blaWithInts: KMockContract.SyncFunProxy<Unit, (kotlin.IntArray) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blaWithInts", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blaWithInts", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _barWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String>>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.String>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_barWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_barWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _barWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String>>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_barWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _barWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_barWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blubbWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String?>>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.String?>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blubbWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blubbWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _blubbWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String?>>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blubbWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blubbWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blubbWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bussWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _bussWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bussWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bossWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>?>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>?>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bossWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bossWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _bossWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>?>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bossWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bossWithCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bossWithCollectionsLists",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _buzzWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_buzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_buzzWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _buzzWithT:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_buzzWithT", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_buzzWithT", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _buzzWithTs: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_buzzWithTs", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_buzzWithTs", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ozzWithVoid: KMockContract.SyncFunProxy<L, () -> L> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ozzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ozzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _ozzWithL: KMockContract.SyncFunProxy<Unit, (L) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ozzWithL", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ozzWithL", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ozzWithLs: KMockContract.SyncFunProxy<Unit, (Array<out L>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ozzWithLs", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ozzWithLs", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _brassWithVoid:
         KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>, () ->
         kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_brassWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_brassWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _brassWithComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_brassWithComparable",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _brassWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_brassWithComparables",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blissWithVoid:
         KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?, () ->
         kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _blissWithComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithComparable",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blissWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithComparables",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
         kotlin.String>, () -> kotlin.collections.Map<kotlin.String, kotlin.String>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lossWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lossWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _lossWithCollectionsMap:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.Map<kotlin.String, kotlin.String>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lossWithCollectionsMap",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lossWithCollectionsMaps: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lossWithCollectionsMaps",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _uzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_uzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_uzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _uzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_uzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _uzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_uzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _lzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _tzzWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _tzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _tzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any?>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _rzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_rzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_rzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _rzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_rzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _rzzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_rzzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _izzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_izzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_izzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _izzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_izzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _izzWithMockTemplateGenericSomeGenerics: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Any>) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_izzWithMockTemplateGenericSomeGenerics",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ossWithAny: KMockContract.SyncFunProxy<Any?, (kotlin.Any?) -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithAny", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithAny", collector =
+        verifier, freeze = freeze)
 
     public val _ossWithAnyAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithAnyAny", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithAnyAny", collector
+        = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ossWithAnyAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithAnyAnys", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithAnyAnys",
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _kssWithMockTemplateGenericSomeGeneric: KMockContract.SyncFunProxy<Any, (kotlin.Any) ->
     kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_kssWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _kssWithMockTemplateGenericSomeGenericMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any, kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_kssWithMockTemplateGenericSomeGenericMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _issWithAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_issWithAny", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_issWithAny", collector =
+        verifier, freeze = freeze)
 
     public val _issWithAnyMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_issWithAnyMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T

--- a/kmock-processor/src/test/resources/mock/expected/generic/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/Shared.kt
@@ -11,13 +11,9 @@ import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -34,218 +30,237 @@ internal class SharedMock<K : Any, L>(
         set(`value`) = _template.onSet(value)
 
     public val _template: KMockContract.PropertyProxy<L> =
-        ProxyFactory.createPropertyProxy("mock.template.generic.SharedMock#_template", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.generic.SharedMock#_template", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_fooWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_fooWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_fooWithAny", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_fooWithAny", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _blaWithInt: KMockContract.SyncFunProxy<Unit, (kotlin.Int) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithInt", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithInt", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _barWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String>>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_barWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _barWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String>>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.String>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_barWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_barWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _blubbWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String?>>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blubbWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blubbWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String?>>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.String?>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blubbWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blubbWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _bussWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bussWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bussWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bussWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bussWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _bossWithCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>?>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bossWithCollectionsList",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bossWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>?>, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>?>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bossWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bossWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _buzzWithT:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> = ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_buzzWithT",
-        spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        collector = verifier, freeze = freeze) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
 
     public val _buzzWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
         kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_buzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_buzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _ozzWithL: KMockContract.SyncFunProxy<Unit, (L) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ozzWithL", spyOn = null,
-            collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ozzWithL", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ozzWithVoid: KMockContract.SyncFunProxy<L, () -> L> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ozzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ozzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _brassWithComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_brassWithComparable", spyOn
-        = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_brassWithComparable",
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _brassWithVoid:
         KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>, () ->
         kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_brassWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_brassWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _blissWithComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blissWithComparable", spyOn
-        = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blissWithComparable",
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _blissWithVoid:
         KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?, () ->
         kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blissWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blissWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _lossWithCollectionsMap:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.Map<kotlin.String, kotlin.String>) ->
         kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_lossWithCollectionsMap",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
         kotlin.String>, () -> kotlin.collections.Map<kotlin.String, kotlin.String>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_lossWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_lossWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _uzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_uzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _uzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_uzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_uzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _lzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_lzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _lzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_lzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_lzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _tzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_tzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _tzzWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_tzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_tzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _rzzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_rzzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _rzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_rzzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_rzzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _izzWithMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_izzWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _izzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_izzWithVoid", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_izzWithVoid", collector =
+        verifier, freeze = freeze)
 
     public val _ossWithAnyAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ossWithAnyAny", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ossWithAnyAny", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ossWithAny: KMockContract.SyncFunProxy<Any?, (kotlin.Any?) -> kotlin.Any?> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ossWithAny", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ossWithAny", collector =
+        verifier, freeze = freeze)
 
     public val _kssWithMockTemplateGenericSomeGenericMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any, kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_kssWithMockTemplateGenericSomeGenericMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _kssWithMockTemplateGenericSomeGeneric: KMockContract.SyncFunProxy<Any, (kotlin.Any) ->
     kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_kssWithMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _issWithAnyMockTemplateGenericSomeGeneric:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_issWithAnyMockTemplateGenericSomeGeneric",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _issWithAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_issWithAny", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_issWithAny", collector =
+        verifier, freeze = freeze)
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T

--- a/kmock-processor/src/test/resources/mock/expected/overloaded/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/overloaded/Common.kt
@@ -8,13 +8,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -30,65 +26,68 @@ internal class CommonMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.overloaded.CommonMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.overloaded.CommonMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override var hashCode: Int
         get() = _hashCode.onGet()
         set(`value`) = _hashCode.onSet(value)
 
     public val _hashCode: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.overloaded.CommonMock#_hashCode", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.overloaded.CommonMock#_hashCode", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithIntAny: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithIntAny", spyOn
-    = null, collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithIntAny",
+        collector = verifier, freeze = freeze)
 
     public val _fooWithAnyInt: KMockContract.SyncFunProxy<Any, (kotlin.Any, kotlin.Int) -> kotlin.Any>
-        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAnyInt", spyOn
-    = null, collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAnyInt",
+        collector = verifier, freeze = freeze)
 
     public val _fooWithAnyString: KMockContract.SyncFunProxy<Any, (kotlin.Any, kotlin.String) ->
     kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAnyString", spyOn
-        = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAnyString",
+            collector = verifier, freeze = freeze)
 
     public val _fooWithStringAny: KMockContract.SyncFunProxy<Any, (kotlin.String, kotlin.Any) ->
     kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithStringAny", spyOn
-        = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithStringAny",
+            collector = verifier, freeze = freeze)
 
     public val _fooWithStringMockTemplateOverloadedAbc:
         KMockContract.SyncFunProxy<Any, (kotlin.String, mock.template.overloaded.Abc) -> kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithStringMockTemplateOverloadedAbc",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _fooWithFunction1: KMockContract.SyncFunProxy<Any, (kotlin.Function1<kotlin.Any,
         kotlin.Unit>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithFunction1", spyOn
-        = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithFunction1",
+            collector = verifier, freeze = freeze)
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAny", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAny", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithMockTemplateOverloadedCommon:
         KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.Common) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithMockTemplateOverloadedCommon",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithMockTemplateOverloadedLPG:
         KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.LPG) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithMockTemplateOverloadedLPG",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithAnys: KMockContract.SyncFunProxy<Any, (Array<out kotlin.Any>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAnys", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithAnys", collector
+        = verifier, freeze = freeze)
 
     public override fun foo(fuzz: Int, ozz: Any): Any = _fooWithIntAny.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/overloaded/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/overloaded/Platform.kt
@@ -8,13 +8,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -30,65 +26,68 @@ internal class PlatformMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.overloaded.PlatformMock#_foo", spyOnGet =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.overloaded.PlatformMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override var hashCode: Int
         get() = _hashCode.onGet()
         set(`value`) = _hashCode.onSet(value)
 
     public val _hashCode: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.overloaded.PlatformMock#_hashCode", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.overloaded.PlatformMock#_hashCode", collector
+        = verifier, freeze = freeze)
 
     public val _fooWithIntAny: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any>
         = ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithIntAny",
-        spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+        collector = verifier, freeze = freeze)
 
     public val _fooWithAnyInt: KMockContract.SyncFunProxy<Any, (kotlin.Any, kotlin.Int) -> kotlin.Any>
         = ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithAnyInt",
-        spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+        collector = verifier, freeze = freeze)
 
     public val _fooWithAnyString: KMockContract.SyncFunProxy<Any, (kotlin.Any, kotlin.String) ->
     kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithAnyString",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _fooWithStringAny: KMockContract.SyncFunProxy<Any, (kotlin.String, kotlin.Any) ->
     kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithStringAny",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _fooWithStringMockTemplateOverloadedAbc:
         KMockContract.SyncFunProxy<Any, (kotlin.String, mock.template.overloaded.Abc) -> kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithStringMockTemplateOverloadedAbc",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _fooWithFunction1: KMockContract.SyncFunProxy<Any, (kotlin.Function1<kotlin.Any,
         kotlin.Unit>) -> kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithFunction1",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithAny", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithAny", collector
+        = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithMockTemplateOverloadedPlatform:
         KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.Platform) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithMockTemplateOverloadedPlatform",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithMockTemplateOverloadedLPG:
         KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.LPG) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithMockTemplateOverloadedLPG",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithAnys: KMockContract.SyncFunProxy<Any, (Array<out kotlin.Any>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithAnys", spyOn =
-        null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithAnys",
+            collector = verifier, freeze = freeze)
 
     public override fun foo(fuzz: Int, ozz: Any): Any = _fooWithIntAny.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/overloaded/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/overloaded/Shared.kt
@@ -8,13 +8,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -30,61 +26,64 @@ internal class SharedMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.overloaded.SharedMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.overloaded.SharedMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override var hashCode: Int
         get() = _hashCode.onGet()
         set(`value`) = _hashCode.onSet(value)
 
     public val _hashCode: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.overloaded.SharedMock#_hashCode", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.overloaded.SharedMock#_hashCode", collector =
+        verifier, freeze = freeze)
 
     public val _fooWithIntAny: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any>
-        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithIntAny", spyOn
-    = null, collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithIntAny",
+        collector = verifier, freeze = freeze)
 
     public val _fooWithAnyInt: KMockContract.SyncFunProxy<Any, (kotlin.Any, kotlin.Int) -> kotlin.Any>
-        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithAnyInt", spyOn
-    = null, collector = verifier, freeze = freeze, relaxer = null)
+        = ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithAnyInt",
+        collector = verifier, freeze = freeze)
 
     public val _fooWithAnyString: KMockContract.SyncFunProxy<Any, (kotlin.Any, kotlin.String) ->
     kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithAnyString", spyOn
-        = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithAnyString",
+            collector = verifier, freeze = freeze)
 
     public val _fooWithStringAny: KMockContract.SyncFunProxy<Any, (kotlin.String, kotlin.Any) ->
     kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithStringAny", spyOn
-        = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithStringAny",
+            collector = verifier, freeze = freeze)
 
     public val _fooWithStringMockTemplateOverloadedAbc:
         KMockContract.SyncFunProxy<Any, (kotlin.String, mock.template.overloaded.Abc) -> kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithStringMockTemplateOverloadedAbc",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+            collector = verifier, freeze = freeze)
 
     public val _fooWithFunction1: KMockContract.SyncFunProxy<Any, (kotlin.Function1<kotlin.Any,
         kotlin.Unit>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithFunction1", spyOn
-        = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithFunction1",
+            collector = verifier, freeze = freeze)
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithAny", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithAny", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithMockTemplateOverloadedShared:
         KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.Shared) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithMockTemplateOverloadedShared",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithMockTemplateOverloadedLPG:
         KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.LPG) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithMockTemplateOverloadedLPG",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+            collector = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public override fun foo(fuzz: Int, ozz: Any): Any = _fooWithIntAny.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/property/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/property/Common.kt
@@ -7,13 +7,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,23 +25,23 @@ internal class CommonMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.property.CommonMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.CommonMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override val bar: Int
         get() = _bar.onGet()
 
     public val _bar: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.property.CommonMock#_bar", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.CommonMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override var buzz: Any
         get() = _buzz.onGet()
         set(`value`) = _buzz.onSet(value)
 
     public val _buzz: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.property.CommonMock#_buzz", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.CommonMock#_buzz", collector =
+        verifier, freeze = freeze)
 
     public fun _clearMock(): Unit {
         _foo.clear()

--- a/kmock-processor/src/test/resources/mock/expected/property/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/property/Platform.kt
@@ -7,13 +7,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,23 +25,23 @@ internal class PlatformMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.property.PlatformMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.PlatformMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override val bar: Int
         get() = _bar.onGet()
 
     public val _bar: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.property.PlatformMock#_bar", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.PlatformMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override var buzz: Any
         get() = _buzz.onGet()
         set(`value`) = _buzz.onSet(value)
 
     public val _buzz: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.property.PlatformMock#_buzz", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.PlatformMock#_buzz", collector =
+        verifier, freeze = freeze)
 
     public fun _clearMock(): Unit {
         _foo.clear()

--- a/kmock-processor/src/test/resources/mock/expected/property/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/property/Shared.kt
@@ -7,13 +7,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,23 +25,23 @@ internal class SharedMock(
         get() = _foo.onGet()
 
     public val _foo: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.property.SharedMock#_foo", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.SharedMock#_foo", collector =
+        verifier, freeze = freeze)
 
     public override val bar: Int
         get() = _bar.onGet()
 
     public val _bar: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("mock.template.property.SharedMock#_bar", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.SharedMock#_bar", collector =
+        verifier, freeze = freeze)
 
     public override var buzz: Any
         get() = _buzz.onGet()
         set(`value`) = _buzz.onSet(value)
 
     public val _buzz: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("mock.template.property.SharedMock#_buzz", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.property.SharedMock#_buzz", collector =
+        verifier, freeze = freeze)
 
     public fun _clearMock(): Unit {
         _foo.clear()

--- a/kmock-processor/src/test/resources/mock/expected/relaxed/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/relaxed/Common.kt
@@ -7,13 +7,9 @@ import kotlin.Suppress
 import kotlin.Unit
 import mock.template.relaxed.relaxed
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,35 +25,40 @@ internal class CommonMock(
         get() = _buzz.onGet()
 
     public val _buzz: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.relaxed.CommonMock#_buzz", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createPropertyProxy("mock.template.relaxed.CommonMock#_buzz", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _foo: KMockContract.SyncFunProxy<String, (kotlin.Any) -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_foo", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_foo", collector = verifier,
+            freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _oo: KMockContract.SyncFunProxy<String, (Array<out kotlin.Any>) -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_oo", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_oo", collector = verifier,
+            freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _bar: KMockContract.AsyncFunProxy<String, suspend (kotlin.Any) -> kotlin.String> =
-        ProxyFactory.createAsyncFunProxy("mock.template.relaxed.CommonMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createAsyncFunProxy("mock.template.relaxed.CommonMock#_bar", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _ar: KMockContract.AsyncFunProxy<String, suspend (Array<out kotlin.Any>) ->
     kotlin.String> = ProxyFactory.createAsyncFunProxy("mock.template.relaxed.CommonMock#_ar",
-        spyOn = null, collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId ->
-            relaxed(mockId) } } else { null })
+        collector = verifier, freeze = freeze) {
+        useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+    }
 
     public val _buzzWithVoid: KMockContract.SyncFunProxy<Unit, () -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_buzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-        } else { null }, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_buzzWithVoid", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public override fun foo(payload: Any): String = _foo.invoke(payload)
 

--- a/kmock-processor/src/test/resources/mock/expected/relaxed/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/relaxed/Platform.kt
@@ -7,13 +7,9 @@ import kotlin.Suppress
 import kotlin.Unit
 import mock.template.relaxed.relaxed
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,35 +25,40 @@ internal class PlatformMock(
         get() = _buzz.onGet()
 
     public val _buzz: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.relaxed.PlatformMock#_buzz", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createPropertyProxy("mock.template.relaxed.PlatformMock#_buzz", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _foo: KMockContract.SyncFunProxy<String, (kotlin.Any) -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.PlatformMock#_foo", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.PlatformMock#_foo", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _oo: KMockContract.SyncFunProxy<String, (Array<out kotlin.Any>) -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.PlatformMock#_oo", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.PlatformMock#_oo", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _bar: KMockContract.AsyncFunProxy<String, suspend (kotlin.Any) -> kotlin.String> =
-        ProxyFactory.createAsyncFunProxy("mock.template.relaxed.PlatformMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createAsyncFunProxy("mock.template.relaxed.PlatformMock#_bar", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _ar: KMockContract.AsyncFunProxy<String, suspend (Array<out kotlin.Any>) ->
     kotlin.String> = ProxyFactory.createAsyncFunProxy("mock.template.relaxed.PlatformMock#_ar",
-        spyOn = null, collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId ->
-            relaxed(mockId) } } else { null })
+        collector = verifier, freeze = freeze) {
+        useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+    }
 
     public val _buzzWithVoid: KMockContract.SyncFunProxy<Unit, () -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.PlatformMock#_buzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-        } else { null }, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.PlatformMock#_buzzWithVoid", collector
+        = verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public override fun foo(payload: Any): String = _foo.invoke(payload)
 

--- a/kmock-processor/src/test/resources/mock/expected/relaxed/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/relaxed/Shared.kt
@@ -7,13 +7,9 @@ import kotlin.Suppress
 import kotlin.Unit
 import mock.template.relaxed.relaxed
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -29,25 +25,28 @@ internal class SharedMock(
         get() = _buzz.onGet()
 
     public val _buzz: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("mock.template.relaxed.SharedMock#_buzz", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createPropertyProxy("mock.template.relaxed.SharedMock#_buzz", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _foo: KMockContract.SyncFunProxy<String, (kotlin.Any) -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.SharedMock#_foo", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.SharedMock#_foo", collector = verifier,
+            freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _bar: KMockContract.AsyncFunProxy<String, suspend (kotlin.Any) -> kotlin.String> =
-        ProxyFactory.createAsyncFunProxy("mock.template.relaxed.SharedMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-            } else { null })
+        ProxyFactory.createAsyncFunProxy("mock.template.relaxed.SharedMock#_bar", collector =
+        verifier, freeze = freeze) {
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _buzzWithVoid: KMockContract.SyncFunProxy<Unit, () -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.SharedMock#_buzzWithVoid", spyOn =
-        null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-            relaxVoidFunction() } } else { null }, relaxer = if (relaxed) { { mockId -> relaxed(mockId) }
-        } else { null }, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.SharedMock#_buzzWithVoid", collector =
+        verifier, freeze = freeze) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public override fun foo(payload: Any): String = _foo.invoke(payload)
 

--- a/kmock-processor/src/test/resources/mock/expected/spy/Alias.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Alias.kt
@@ -8,13 +8,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class AliasPlatformMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -26,83 +22,130 @@ internal class AliasPlatformMock<K : Any, L>(
     @Suppress("UNUSED_PARAMETER")
     relaxed: Boolean = false
 ) : Platform<K, L> where L : Any, L : Comparable<L> {
+    private val __spyOn: Platform<K, L>? = spyOn
+
     public override var template: L
         get() = _template.onGet()
         set(`value`) = _template.onSet(value)
 
-    public val _template: KMockContract.PropertyProxy<L> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.AliasPlatformMock#_template", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.AliasPlatformMock#_template", spyOnGet =
-        { __spyOn!!.template }, spyOnSet = { __spyOn!!.template = it; Unit }, collector =
-        verifier, freeze = freeze, relaxer = null)}
-
+    public val _template: KMockContract.PropertyProxy<L> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.AliasPlatformMock#_template", collector =
+        verifier, freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.template }
+            useSpyOnSetIf(__spyOn) { value -> __spyOn!!.template = value }
+        }
 
     public override val ozz: Int
         get() = _ozz.onGet()
 
-    public val _ozz: KMockContract.PropertyProxy<Int> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.AliasPlatformMock#_ozz", spyOnGet =
-        null, collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.AliasPlatformMock#_ozz", spyOnGet = {
-            __spyOn!!.ozz }, collector = verifier, freeze = freeze, relaxer = null)}
-
+    public val _ozz: KMockContract.PropertyProxy<Int> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.AliasPlatformMock#_ozz", collector =
+        verifier, freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.ozz }
+        }
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithAny", spyOn = if
-                                                                                                       (spyOn != null) { { payload ->
-            __spyOn!!.foo(payload) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer =
-            null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithAny", collector =
+        verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.foo(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit>
-        = ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithAnys", spyOn =
-    if (spyOn != null) { { payload ->
-        __spyOn!!.foo(*payload) } } else { null }, collector = verifier, freeze = freeze,
-        unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer =
-        null, buildInRelaxer = null)
+        = ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithAnys",
+        collector = verifier, freeze = freeze) {
+        useSpyIf(
+            spy = __spyOn,
+            spyOn = { payload ->
+                __spyOn!!.foo(*payload)
+            }
+        )
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
 
     public val _barWithInt: KMockContract.SyncFunProxy<Any, (kotlin.Int) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_barWithInt", spyOn = if
-                                                                                                       (spyOn != null) { { arg0 ->
-            __spyOn!!.bar(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_barWithInt", collector =
+        verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.bar(arg0)
+                }
+            )
+        }
 
     public val _barWithInts: KMockContract.SyncFunProxy<Any, (kotlin.IntArray) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_barWithInts", spyOn = if
-                                                                                                        (spyOn != null) { { arg0 ->
-            __spyOn!!.bar(*arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_barWithInts", collector
+        = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.bar(*arg0)
+                }
+            )
+        }
 
     public val _buzzWithString: KMockContract.AsyncFunProxy<L, suspend (kotlin.String) -> L> =
-        ProxyFactory.createAsyncFunProxy("mock.template.spy.AliasPlatformMock#_buzzWithString", spyOn
-        = if (spyOn != null) { { arg0 ->
-            __spyOn!!.buzz(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createAsyncFunProxy("mock.template.spy.AliasPlatformMock#_buzzWithString",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.buzz(arg0)
+                }
+            )
+        }
 
     public val _buzzWithStrings: KMockContract.AsyncFunProxy<L, suspend (Array<out kotlin.String>) ->
     L> = ProxyFactory.createAsyncFunProxy("mock.template.spy.AliasPlatformMock#_buzzWithStrings",
-        spyOn = if (spyOn != null) { { arg0 ->
-            __spyOn!!.buzz(*arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer =
-        null)
-
-    private val __spyOn: Platform<K, L>? = spyOn
+        collector = verifier, freeze = freeze) {
+        useSpyIf(
+            spy = __spyOn,
+            spyOn = { arg0 ->
+                __spyOn!!.buzz(*arg0)
+            }
+        )
+    }
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_toString", spyOn = if
-                                                                                                     (spyOn != null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.toString() }
+            )
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_equals", spyOn = if
-                                                                                                   (spyOn != null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_equals", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+            useSpyOnEqualsIf(
+                spy = __spyOn,
+                parent = { other ->
+                    super.equals(other)
+                },
+                mockKlass = AliasPlatformMock::class
+            )
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_hashCode", spyOn = if
-                                                                                                     (spyOn != null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze =
-        freeze, unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.hashCode() }
+            )
+        }
 
     public override fun <T> foo(payload: T): Unit = _fooWithAny.invoke(payload)
 
@@ -118,13 +161,7 @@ internal class AliasPlatformMock<K : Any, L>(
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is AliasPlatformMock<*, *> && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/spy/AllowedRecursive.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/AllowedRecursive.kt
@@ -1,22 +1,20 @@
-package mock.template.generic
+package mock.template.spy
 
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Char
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Int
+import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.sequences.Sequence
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class AllowedRecursiveMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -28,63 +26,181 @@ internal class AllowedRecursiveMock<K : Any, L>(
     @Suppress("UNUSED_PARAMETER")
     relaxed: Boolean = false
 ) : AllowedRecursive<K, L> where L : Any, L : Comparable<L> {
+    private val __spyOn: AllowedRecursive<K, L>? = spyOn
+
     public override var template: L
         get() = _template.onGet()
         set(`value`) = _template.onSet(value)
 
     public val _template: KMockContract.PropertyProxy<L> =
-        ProxyFactory.createPropertyProxy("mock.template.generic.AllowedRecursiveMock#_template",
-            spyOnGet = null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createPropertyProxy("mock.template.spy.AllowedRecursiveMock#_template", collector
+        = verifier, freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.template }
+            useSpyOnSetIf(__spyOn) { value -> __spyOn!!.template = value }
+        }
 
     public val _ossWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_ossWithVoid",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_ossWithVoid",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { @Suppress("UNCHECKED_CAST")
+                __spyOn!!.oss() as kotlin.Comparable<Any?> }
+            )
+        }
 
     public val _ossWithSequencesSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_ossWithSequencesSequence",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_ossWithSequencesSequence",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+
+                    @Suppress("UNCHECKED_CAST")
+                    payload as kotlin.sequences.Sequence<kotlin.Char>
+
+                    @Suppress("UNCHECKED_CAST")
+                    payload as kotlin.CharSequence
+
+                    @Suppress("UNCHECKED_CAST")
+                    payload as kotlin.Comparable<Any?>
+                    __spyOn!!.oss(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _ossWithSequencesSequences: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any>) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_ossWithSequencesSequences",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_ossWithSequencesSequences",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+
+                    @Suppress("UNCHECKED_CAST")
+                    payload as Array<kotlin.sequences.Sequence<kotlin.Char>>
+
+                    @Suppress("UNCHECKED_CAST")
+                    payload as Array<kotlin.CharSequence>
+
+                    @Suppress("UNCHECKED_CAST")
+                    payload as Array<kotlin.Comparable<Any?>>
+                    __spyOn!!.oss(*payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _brassWithVoid: KMockContract.SyncFunProxy<kotlin.Comparable<Any?>, () ->
     kotlin.Comparable<Any?>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_brassWithVoid",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_brassWithVoid",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { @Suppress("UNCHECKED_CAST")
+                __spyOn!!.brass() as kotlin.Comparable<Any?> }
+            )
+        }
 
     public val _brassWithComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<Any?>) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_brassWithComparable",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_brassWithComparable",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.brass(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _brassWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<Any?>>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_brassWithComparables",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_brassWithComparables",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.brass(*payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _issWithVoid: KMockContract.SyncFunProxy<kotlin.Comparable<Any?>, () ->
     kotlin.Comparable<Any?>> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_issWithVoid",
-            spyOn = null, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_issWithVoid",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { @Suppress("UNCHECKED_CAST")
+                __spyOn!!.iss() as kotlin.Comparable<Any?> }
+            )
+        }
 
     public val _issWithComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<Any?>) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_issWithComparable",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_issWithComparable",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.iss(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _issWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<Any?>>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.AllowedRecursiveMock#_issWithComparables",
-            spyOn = null, collector = verifier, freeze = freeze, unitFunRelaxer = if (relaxUnitFun) { {
-                relaxVoidFunction() } } else { null }, relaxer = null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_issWithComparables",
+            collector = verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.iss(*payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_toString", collector
+        = verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.toString() }
+            )
+        }
+
+    public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_equals", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+            useSpyOnEqualsIf(
+                spy = __spyOn,
+                parent = { other ->
+                    super.equals(other)
+                },
+                mockKlass = AllowedRecursiveMock::class
+            )
+        }
+
+    public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AllowedRecursiveMock#_hashCode", collector
+        = verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.hashCode() }
+            )
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> oss(): T where T : Sequence<Char>, T : CharSequence, T :
@@ -113,6 +229,12 @@ internal class AllowedRecursiveMock<K : Any, L>(
     public override fun <T : Comparable<T>> iss(vararg payload: T): Unit =
         _issWithComparables.invoke(payload)
 
+    public override fun toString(): String = _toString.invoke()
+
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
+
+    public override fun hashCode(): Int = _hashCode.invoke()
+
     public fun _clearMock(): Unit {
         _template.clear()
         _ossWithVoid.clear()
@@ -124,5 +246,8 @@ internal class AllowedRecursiveMock<K : Any, L>(
         _issWithVoid.clear()
         _issWithComparable.clear()
         _issWithComparables.clear()
+        _toString.clear()
+        _equals.clear()
+        _hashCode.clear()
     }
 }

--- a/kmock-processor/src/test/resources/mock/expected/spy/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Common.kt
@@ -8,13 +8,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -26,82 +22,130 @@ internal class CommonMock<K : Any, L>(
     @Suppress("UNUSED_PARAMETER")
     relaxed: Boolean = false
 ) : Common<K, L> where L : Any, L : Comparable<L> {
+    private val __spyOn: Common<K, L>? = spyOn
+
     public override var template: L
         get() = _template.onGet()
         set(`value`) = _template.onSet(value)
 
-    public val _template: KMockContract.PropertyProxy<L> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.CommonMock#_template", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.CommonMock#_template", spyOnGet = {
-            __spyOn!!.template }, spyOnSet = { __spyOn!!.template = it; Unit }, collector =
-        verifier, freeze = freeze, relaxer = null)}
-
+    public val _template: KMockContract.PropertyProxy<L> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.CommonMock#_template", collector =
+        verifier, freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.template }
+            useSpyOnSetIf(__spyOn) { value -> __spyOn!!.template = value }
+        }
 
     public override val ozz: Int
         get() = _ozz.onGet()
 
-    public val _ozz: KMockContract.PropertyProxy<Int> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.CommonMock#_ozz", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.CommonMock#_ozz", spyOnGet = {
-            __spyOn!!.ozz }, collector = verifier, freeze = freeze, relaxer = null)}
-
+    public val _ozz: KMockContract.PropertyProxy<Int> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.CommonMock#_ozz", collector = verifier,
+            freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.ozz }
+        }
 
     public val _foo: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_foo", spyOn = if (spyOn !=
-            null) { { payload ->
-            __spyOn!!.foo(payload) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer =
-            null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_foo", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.foo(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _oo: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_oo", spyOn = if (spyOn != null)
-        { { payload ->
-            __spyOn!!.oo(*payload) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer =
-            null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_oo", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.oo(*payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_bar", spyOn = if (spyOn !=
-            null) { { arg0 ->
-            __spyOn!!.bar(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_bar", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.bar(arg0)
+                }
+            )
+        }
 
     public val _ar: KMockContract.SyncFunProxy<Any, (kotlin.IntArray) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_ar", spyOn = if (spyOn != null)
-        { { arg0 ->
-            __spyOn!!.ar(*arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_ar", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.ar(*arg0)
+                }
+            )
+        }
 
     public val _buzz: KMockContract.AsyncFunProxy<L, suspend (kotlin.String) -> L> =
-        ProxyFactory.createAsyncFunProxy("mock.template.spy.CommonMock#_buzz", spyOn = if (spyOn !=
-            null) { { arg0 ->
-            __spyOn!!.buzz(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createAsyncFunProxy("mock.template.spy.CommonMock#_buzz", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.buzz(arg0)
+                }
+            )
+        }
 
     public val _uzz: KMockContract.AsyncFunProxy<L, suspend (Array<out kotlin.String>) -> L> =
-        ProxyFactory.createAsyncFunProxy("mock.template.spy.CommonMock#_uzz", spyOn = if (spyOn !=
-            null) { { arg0 ->
-            __spyOn!!.uzz(*arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
-
-    private val __spyOn: Common<K, L>? = spyOn
+        ProxyFactory.createAsyncFunProxy("mock.template.spy.CommonMock#_uzz", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.uzz(*arg0)
+                }
+            )
+        }
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_toString", spyOn = if (spyOn !=
-            null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.toString() }
+            )
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_equals", spyOn = if (spyOn !=
-            null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_equals", collector = verifier,
+            freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+            useSpyOnEqualsIf(
+                spy = __spyOn,
+                parent = { other ->
+                    super.equals(other)
+                },
+                mockKlass = CommonMock::class
+            )
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_hashCode", spyOn = if (spyOn !=
-            null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.hashCode() }
+            )
+        }
 
     public override fun <T> foo(payload: T): Unit = _foo.invoke(payload)
 
@@ -117,13 +161,7 @@ internal class CommonMock<K : Any, L>(
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is CommonMock<*, *> && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/spy/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Platform.kt
@@ -8,13 +8,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -26,83 +22,130 @@ internal class PlatformMock<K : Any, L>(
     @Suppress("UNUSED_PARAMETER")
     relaxed: Boolean = false
 ) : Platform<K, L> where L : Any, L : Comparable<L> {
+    private val __spyOn: Platform<K, L>? = spyOn
+
     public override var template: L
         get() = _template.onGet()
         set(`value`) = _template.onSet(value)
 
-    public val _template: KMockContract.PropertyProxy<L> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.PlatformMock#_template", spyOnGet =
-        null, spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.PlatformMock#_template", spyOnGet = {
-            __spyOn!!.template }, spyOnSet = { __spyOn!!.template = it; Unit }, collector =
-        verifier, freeze = freeze, relaxer = null)}
-
+    public val _template: KMockContract.PropertyProxy<L> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.PlatformMock#_template", collector =
+        verifier, freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.template }
+            useSpyOnSetIf(__spyOn) { value -> __spyOn!!.template = value }
+        }
 
     public override val ozz: Int
         get() = _ozz.onGet()
 
-    public val _ozz: KMockContract.PropertyProxy<Int> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.PlatformMock#_ozz", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.PlatformMock#_ozz", spyOnGet = {
-            __spyOn!!.ozz }, collector = verifier, freeze = freeze, relaxer = null)}
-
+    public val _ozz: KMockContract.PropertyProxy<Int> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.PlatformMock#_ozz", collector = verifier,
+            freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.ozz }
+        }
 
     public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithAny", spyOn = if
-                                                                                                  (spyOn != null) { { payload ->
-            __spyOn!!.foo(payload) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer =
-            null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithAny", collector =
+        verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.foo(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _fooWithAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit>
-        = ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithAnys", spyOn = if
-                                                                                                     (spyOn != null) { { payload ->
-        __spyOn!!.foo(*payload) } } else { null }, collector = verifier, freeze = freeze,
-        unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer =
-        null, buildInRelaxer = null)
+        = ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithAnys", collector =
+    verifier, freeze = freeze) {
+        useSpyIf(
+            spy = __spyOn,
+            spyOn = { payload ->
+                __spyOn!!.foo(*payload)
+            }
+        )
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
 
     public val _barWithInt: KMockContract.SyncFunProxy<Any, (kotlin.Int) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_barWithInt", spyOn = if
-                                                                                                  (spyOn != null) { { arg0 ->
-            __spyOn!!.bar(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_barWithInt", collector =
+        verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.bar(arg0)
+                }
+            )
+        }
 
     public val _barWithInts: KMockContract.SyncFunProxy<Any, (kotlin.IntArray) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_barWithInts", spyOn = if
-                                                                                                   (spyOn != null) { { arg0 ->
-            __spyOn!!.bar(*arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_barWithInts", collector =
+        verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.bar(*arg0)
+                }
+            )
+        }
 
     public val _buzzWithString: KMockContract.AsyncFunProxy<L, suspend (kotlin.String) -> L> =
-        ProxyFactory.createAsyncFunProxy("mock.template.spy.PlatformMock#_buzzWithString", spyOn = if
-                                                                                                       (spyOn != null) { { arg0 ->
-            __spyOn!!.buzz(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createAsyncFunProxy("mock.template.spy.PlatformMock#_buzzWithString", collector =
+        verifier, freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.buzz(arg0)
+                }
+            )
+        }
 
     public val _buzzWithStrings: KMockContract.AsyncFunProxy<L, suspend (Array<out kotlin.String>) ->
-    L> = ProxyFactory.createAsyncFunProxy("mock.template.spy.PlatformMock#_buzzWithStrings", spyOn
-    = if (spyOn != null) { { arg0 ->
-        __spyOn!!.buzz(*arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer =
-    null)
-
-    private val __spyOn: Platform<K, L>? = spyOn
+    L> = ProxyFactory.createAsyncFunProxy("mock.template.spy.PlatformMock#_buzzWithStrings",
+        collector = verifier, freeze = freeze) {
+        useSpyIf(
+            spy = __spyOn,
+            spyOn = { arg0 ->
+                __spyOn!!.buzz(*arg0)
+            }
+        )
+    }
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_toString", spyOn = if (spyOn
-            != null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.toString() }
+            )
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_equals", spyOn = if (spyOn !=
-            null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_equals", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+            useSpyOnEqualsIf(
+                spy = __spyOn,
+                parent = { other ->
+                    super.equals(other)
+                },
+                mockKlass = PlatformMock::class
+            )
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_hashCode", spyOn = if (spyOn
-            != null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.hashCode() }
+            )
+        }
 
     public override fun <T> foo(payload: T): Unit = _fooWithAny.invoke(payload)
 
@@ -118,13 +161,7 @@ internal class PlatformMock<K : Any, L>(
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is PlatformMock<*, *> && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/spy/Relaxed.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Relaxed.kt
@@ -9,13 +9,9 @@ import kotlin.Suppress
 import kotlin.Unit
 import mock.template.spy.relaxed
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class RelaxedMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -27,71 +23,100 @@ internal class RelaxedMock<K : Any, L>(
     @Suppress("UNUSED_PARAMETER")
     relaxed: Boolean = false
 ) : Relaxed<K, L> where L : Any, L : Comparable<L> {
+    private val __spyOn: Relaxed<K, L>? = spyOn
+
     public override var template: L
         get() = _template.onGet()
         set(`value`) = _template.onSet(value)
 
-    public val _template: KMockContract.PropertyProxy<L> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.RelaxedMock#_template", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = if (relaxed) { {
-                    mockId -> relaxed(mockId) } } else { null })} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.RelaxedMock#_template", spyOnGet = {
-            __spyOn!!.template }, spyOnSet = { __spyOn!!.template = it; Unit }, collector =
-        verifier, freeze = freeze, relaxer = if (relaxed) { { mockId -> relaxed(mockId) } } else
-        { null })}
-
+    public val _template: KMockContract.PropertyProxy<L> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.RelaxedMock#_template", collector =
+        verifier, freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.template }
+            useSpyOnSetIf(__spyOn) { value -> __spyOn!!.template = value }
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public override val ozz: Int
         get() = _ozz.onGet()
 
-    public val _ozz: KMockContract.PropertyProxy<Int> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.RelaxedMock#_ozz", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = if (relaxed) { { mockId ->
-                relaxed(mockId) } } else { null })} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.RelaxedMock#_ozz", spyOnGet = {
-            __spyOn!!.ozz }, collector = verifier, freeze = freeze, relaxer = if (relaxed) { {
-                mockId -> relaxed(mockId) } } else { null })}
-
+    public val _ozz: KMockContract.PropertyProxy<Int> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.RelaxedMock#_ozz", collector = verifier,
+            freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.ozz }
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _foo: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_foo", spyOn = if (spyOn !=
-            null) { { payload ->
-            __spyOn!!.foo(payload) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer = if
-                                                                                                        (relaxed) { { mockId -> relaxed(mockId) } } else { null }, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_foo", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.foo(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_bar", spyOn = if (spyOn !=
-            null) { { arg0 ->
-            __spyOn!!.bar(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = if
-                                                                                                        (relaxed) { { mockId -> relaxed(mockId) } } else { null })
+        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_bar", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.bar(arg0)
+                }
+            )
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _buzz: KMockContract.AsyncFunProxy<L, suspend (kotlin.String) -> L> =
-        ProxyFactory.createAsyncFunProxy("mock.template.spy.RelaxedMock#_buzz", spyOn = if (spyOn !=
-            null) { { arg0 ->
-            __spyOn!!.buzz(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = if
-                                                                                                         (relaxed) { { mockId -> relaxed(mockId) } } else { null })
-
-    private val __spyOn: Relaxed<K, L>? = spyOn
+        ProxyFactory.createAsyncFunProxy("mock.template.spy.RelaxedMock#_buzz", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.buzz(arg0)
+                }
+            )
+            useRelaxerIf(relaxed) { mockId -> relaxed(mockId) }
+        }
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_toString", spyOn = if (spyOn
-            != null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.toString() }
+            )
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_equals", spyOn = if (spyOn !=
-            null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_equals", collector = verifier,
+            freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+            useSpyOnEqualsIf(
+                spy = __spyOn,
+                parent = { other ->
+                    super.equals(other)
+                },
+                mockKlass = RelaxedMock::class
+            )
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_hashCode", spyOn = if (spyOn
-            != null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.hashCode() }
+            )
+        }
 
     public override fun <T> foo(payload: T): Unit = _foo.invoke(payload)
 
@@ -101,13 +126,7 @@ internal class RelaxedMock<K : Any, L>(
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is RelaxedMock<*, *> && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/spy/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Shared.kt
@@ -8,13 +8,9 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
@@ -26,65 +22,96 @@ internal class SharedMock<K : Any, L>(
     @Suppress("UNUSED_PARAMETER")
     relaxed: Boolean = false
 ) : Shared<K, L> where L : Any, L : Comparable<L> {
+    private val __spyOn: Shared<K, L>? = spyOn
+
     public override var template: L
         get() = _template.onGet()
         set(`value`) = _template.onSet(value)
 
-    public val _template: KMockContract.PropertyProxy<L> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.SharedMock#_template", spyOnGet = null,
-            spyOnSet = null, collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.SharedMock#_template", spyOnGet = {
-            __spyOn!!.template }, spyOnSet = { __spyOn!!.template = it; Unit }, collector =
-        verifier, freeze = freeze, relaxer = null)}
-
+    public val _template: KMockContract.PropertyProxy<L> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.SharedMock#_template", collector =
+        verifier, freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.template }
+            useSpyOnSetIf(__spyOn) { value -> __spyOn!!.template = value }
+        }
 
     public override val ozz: Int
         get() = _ozz.onGet()
 
-    public val _ozz: KMockContract.PropertyProxy<Int> = if (spyOn == null) {
-        ProxyFactory.createPropertyProxy("mock.template.spy.SharedMock#_ozz", spyOnGet = null,
-            collector = verifier, freeze = freeze, relaxer = null)} else {
-        ProxyFactory.createPropertyProxy("mock.template.spy.SharedMock#_ozz", spyOnGet = {
-            __spyOn!!.ozz }, collector = verifier, freeze = freeze, relaxer = null)}
-
+    public val _ozz: KMockContract.PropertyProxy<Int> =
+        ProxyFactory.createPropertyProxy("mock.template.spy.SharedMock#_ozz", collector = verifier,
+            freeze = freeze) {
+            useSpyOnGetIf(__spyOn) { __spyOn!!.ozz }
+        }
 
     public val _foo: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_foo", spyOn = if (spyOn !=
-            null) { { payload ->
-            __spyOn!!.foo(payload) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = if (relaxUnitFun) { { relaxVoidFunction() } } else { null }, relaxer =
-            null, buildInRelaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_foo", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { payload ->
+                    __spyOn!!.foo(payload)
+                }
+            )
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_bar", spyOn = if (spyOn !=
-            null) { { arg0 ->
-            __spyOn!!.bar(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_bar", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.bar(arg0)
+                }
+            )
+        }
 
     public val _buzz: KMockContract.AsyncFunProxy<L, suspend (kotlin.String) -> L> =
-        ProxyFactory.createAsyncFunProxy("mock.template.spy.SharedMock#_buzz", spyOn = if (spyOn !=
-            null) { { arg0 ->
-            __spyOn!!.buzz(arg0) } } else { null }, collector = verifier, freeze = freeze, relaxer = null)
-
-    private val __spyOn: Shared<K, L>? = spyOn
+        ProxyFactory.createAsyncFunProxy("mock.template.spy.SharedMock#_buzz", collector = verifier,
+            freeze = freeze) {
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { arg0 ->
+                    __spyOn!!.buzz(arg0)
+                }
+            )
+        }
 
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_toString", spyOn = if (spyOn !=
-            null) { { __spyOn!!.toString() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.toString() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useToStringRelaxer { super.toString() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.toString() }
+            )
+        }
 
     public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_equals", spyOn = if (spyOn !=
-            null) { { other ->
-            __spyOn!!.equals(other) } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { other -> super.equals(other) },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_equals", collector = verifier,
+            freeze = freeze, ignorableForVerification = true) {
+            useEqualsRelaxer { other ->
+                super.equals(other)
+            }
+            useSpyOnEqualsIf(
+                spy = __spyOn,
+                parent = { other ->
+                    super.equals(other)
+                },
+                mockKlass = SharedMock::class
+            )
+        }
 
     public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_hashCode", spyOn = if (spyOn !=
-            null) { { __spyOn!!.hashCode() } } else { null }, collector = verifier, freeze = freeze,
-            unitFunRelaxer = null, relaxer = null, buildInRelaxer = { super.hashCode() },
-            ignorableForVerification = true)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.SharedMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true) {
+            useHashCodeRelaxer { super.hashCode() }
+            useSpyIf(
+                spy = __spyOn,
+                spyOn = { __spyOn!!.hashCode() }
+            )
+        }
 
     public override fun <T> foo(payload: T): Unit = _foo.invoke(payload)
 
@@ -94,13 +121,7 @@ internal class SharedMock<K : Any, L>(
 
     public override fun toString(): String = _toString.invoke()
 
-    public override fun equals(other: Any?): Boolean {
-        return if(other is SharedMock<*, *> && __spyOn != null) {
-            super.equals(other)
-        } else {
-            _equals.invoke(other)
-        }
-    }
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other)
 
     public override fun hashCode(): Int = _hashCode.invoke()
 

--- a/kmock-processor/src/test/resources/mock/expected/sync/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/sync/Common.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class CommonMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,20 +21,20 @@ internal class CommonMock(
     relaxed: Boolean = false
 ) : Common {
     public val _foo: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_foo", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_foo", collector = verifier,
+            freeze = freeze)
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_bar", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_bar", collector = verifier,
+            freeze = freeze)
 
     public val _ozz: KMockContract.SyncFunProxy<Any, (kotlin.IntArray) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_ozz", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_ozz", collector = verifier,
+            freeze = freeze)
 
     public val _izz: KMockContract.SyncFunProxy<Any, (Array<out kotlin.Any>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_izz", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.CommonMock#_izz", collector = verifier,
+            freeze = freeze)
 
     public override fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/sync/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/sync/Platform.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class PlatformMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,20 +21,20 @@ internal class PlatformMock(
     relaxed: Boolean = false
 ) : Platform {
     public val _foo: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_foo", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_foo", collector = verifier,
+            freeze = freeze)
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_bar", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_bar", collector = verifier,
+            freeze = freeze)
 
     public val _ozz: KMockContract.SyncFunProxy<Any, (kotlin.IntArray) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_ozz", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_ozz", collector = verifier,
+            freeze = freeze)
 
     public val _izz: KMockContract.SyncFunProxy<Any, (Array<out kotlin.Any>) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_izz", spyOn = null,
-            collector = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.PlatformMock#_izz", collector = verifier,
+            freeze = freeze)
 
     public override fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/expected/sync/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/sync/Shared.kt
@@ -6,13 +6,9 @@ import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
-import tech.antibytes.kmock.proxy.relaxVoidFunction
 
 internal class SharedMock(
     verifier: KMockContract.Collector = NoopCollector,
@@ -25,12 +21,12 @@ internal class SharedMock(
     relaxed: Boolean = false
 ) : Shared {
     public val _foo: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.SharedMock#_foo", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.SharedMock#_foo", collector = verifier,
+            freeze = freeze)
 
     public val _bar: KMockContract.SyncFunProxy<Any, (kotlin.Int, kotlin.Any) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.sync.SharedMock#_bar", spyOn = null, collector
-        = verifier, freeze = freeze, relaxer = null)
+        ProxyFactory.createSyncFunProxy("mock.template.sync.SharedMock#_bar", collector = verifier,
+            freeze = freeze)
 
     public override fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
 

--- a/kmock-processor/src/test/resources/mock/template/async/Common.kt
+++ b/kmock-processor/src/test/resources/mock/template/async/Common.kt
@@ -13,9 +13,9 @@ import tech.antibytes.kmock.MockCommon
 interface Common {
     suspend fun foo(fuzz: Int, ozz: Any): Any
 
-    fun bar(buzz: Int, bozz: Any): Any = bozz
+    suspend fun bar(buzz: Int, bozz: Any): Any = bozz
 
-    fun ozz(vararg buzz: Int): Any
+    suspend fun ozz(vararg buzz: Int): Any
 
-    fun izz(vararg buzz: Any): Any
+    suspend fun izz(vararg buzz: Any): Any
 }

--- a/kmock-processor/src/test/resources/mock/template/async/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/template/async/Platform.kt
@@ -13,9 +13,9 @@ import tech.antibytes.kmock.Mock
 interface Platform {
     suspend fun foo(fuzz: Int, ozz: Any): dynamic
 
-    fun bar(buzz: Int, bozz: Any): Any = bozz
+    suspend fun bar(buzz: Int, bozz: Any): Any = bozz
 
-    fun ozz(vararg buzz: Int): Any
+    suspend fun ozz(vararg buzz: Int): Any
 
-    fun izz(vararg buzz: Any): Any
+    suspend fun izz(vararg buzz: Any): Any
 }

--- a/kmock-processor/src/test/resources/mock/template/async/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/template/async/Shared.kt
@@ -13,5 +13,5 @@ import tech.antibytes.kmock.MockShared
 interface Shared {
     suspend fun foo(fuzz: Int, ozz: Any): Any
 
-    fun bar(buzz: Int, bozz: Any): Any = bozz
+    suspend fun bar(buzz: Int, bozz: Any): Any = bozz
 }

--- a/kmock-processor/src/test/resources/mock/template/spy/AllowedRecursive.kt
+++ b/kmock-processor/src/test/resources/mock/template/spy/AllowedRecursive.kt
@@ -4,7 +4,7 @@
  * Use of this source code is governed by Apache v2.0
  */
 
-package mock.template.generic
+package mock.template.spy
 
 import tech.antibytes.kmock.Mock
 
@@ -15,6 +15,7 @@ interface AllowedRecursive<K, L> where L : Any, L : Comparable<L>, K : Any {
     fun <T> oss(): T where T : Sequence<Char>, T : CharSequence, T : Comparable<List<T>>
     fun <T> oss(payload: T) where T : Sequence<Char>, T : CharSequence, T : Comparable<List<T>>
     // FIXME: Name is wrong on generated output -> _ossWithSequencesSequences instead of _ossWithSequencesCharSequences
+    // NOTE: This cannot be resolved by the compiler
     fun <T> oss(vararg payload: T) where T : Sequence<Char>, T : CharSequence, T : Comparable<List<T>>
 
     fun <T> brass(): T where T : Comparable<List<T>>

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
@@ -735,10 +735,8 @@ object KMockContract {
         fun <Value> createPropertyProxy(
             id: String,
             collector: Collector = NoopCollector,
-            relaxer: Relaxer<Value>? = null,
             freeze: Boolean = true,
-            spyOnGet: (() -> Value)? = null,
-            spyOnSet: ((Value) -> Unit)? = null
+            relaxationConfiguration: NonIntrusivePropertyConfigurator<Value>.() -> Unit = {}
         ): PropertyProxy<Value>
     }
 

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
@@ -674,7 +674,7 @@ object KMockContract {
         fun onSet(value: Value)
     }
 
-    interface NonIntrusiveConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> {
+    interface NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> {
         fun relaxUnitFunIf(condition: Boolean)
         fun useToStringRelaxer(parent: Any)
         fun useHashCodeRelaxer(parent: Any)
@@ -690,15 +690,15 @@ object KMockContract {
         fun useSpyIf(spy: Any?, spyOn: SideEffect)
     }
 
-    internal data class NonIntrusiveConfiguration<ReturnValue, SideEffect : Function<ReturnValue>>(
-        val unitFunRelaxer: Relaxer<Unit>?,
+    internal data class NonIntrusiveFunConfiguration<ReturnValue, SideEffect : Function<ReturnValue>>(
+        val unitFunRelaxer: Relaxer<ReturnValue?>?,
         val buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>?,
         val relaxer: Relaxer<ReturnValue>?,
         val spyOn: SideEffect?
     )
 
-    internal interface NonIntrusiveConfigurationReceiver<ReturnValue, SideEffect : Function<ReturnValue>> {
-        fun getConfiguration(): NonIntrusiveConfiguration<ReturnValue, SideEffect>
+    internal interface NonIntrusiveFunConfigurationReceiver<ReturnValue, SideEffect : Function<ReturnValue>> {
+        fun getConfiguration(): NonIntrusiveFunConfiguration<ReturnValue, SideEffect>
     }
 
     interface ProxyFactory {
@@ -706,22 +706,16 @@ object KMockContract {
             id: String,
             collector: Collector = NoopCollector,
             ignorableForVerification: Boolean = false,
-            relaxer: Relaxer<ReturnValue>? = null,
-            unitFunRelaxer: Relaxer<ReturnValue?>? = null,
-            buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>? = null,
             freeze: Boolean = true,
-            spyOn: SideEffect? = null,
+            relaxationConfiguration: NonIntrusiveFunConfigurator<ReturnValue, SideEffect>.() -> Unit = {},
         ): SyncFunProxy<ReturnValue, SideEffect>
 
         fun <ReturnValue, SideEffect : Function<ReturnValue>> createAsyncFunProxy(
             id: String,
             collector: Collector = NoopCollector,
             ignorableForVerification: Boolean = false,
-            relaxer: Relaxer<ReturnValue>? = null,
-            unitFunRelaxer: Relaxer<ReturnValue?>? = null,
-            buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>? = null,
             freeze: Boolean = true,
-            spyOn: SideEffect? = null
+            relaxationConfiguration: NonIntrusiveFunConfigurator<ReturnValue, SideEffect>.() -> Unit = {},
         ): AsyncFunProxy<ReturnValue, SideEffect>
 
         fun <Value> createPropertyProxy(

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
@@ -657,7 +657,7 @@ object KMockContract {
          * on invocation.
          * @throws NullPointerException on get if no value was set.
          */
-        var set: (Value) -> Unit
+        var set: Function1<Value, Unit>
 
         /**
          * Invocation of property getter. This is meant for internal use only.
@@ -690,15 +690,29 @@ object KMockContract {
         fun useSpyIf(spy: Any?, spyOn: SideEffect)
     }
 
+    interface NonIntrusivePropertyConfigurator<Value> {
+        fun useRelaxerIf(condition: Boolean, relaxer: Function1<String, Value>)
+        fun useSpyOnGetIf(spy: Any?, spyOn: Function0<Value>)
+        fun useSpyOnSetIf(spy: Any?, spyOn: Function1<Value, Unit>)
+    }
+
+    interface NonIntrusiveConfiguration
+
     internal data class NonIntrusiveFunConfiguration<ReturnValue, SideEffect : Function<ReturnValue>>(
         val unitFunRelaxer: Relaxer<ReturnValue?>?,
         val buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>?,
         val relaxer: Relaxer<ReturnValue>?,
-        val spyOn: SideEffect?
-    )
+        val spyOn: SideEffect?,
+    ) : NonIntrusiveConfiguration
 
-    internal interface NonIntrusiveFunConfigurationReceiver<ReturnValue, SideEffect : Function<ReturnValue>> {
-        fun getConfiguration(): NonIntrusiveFunConfiguration<ReturnValue, SideEffect>
+    internal data class NonIntrusivePropertyConfiguration<Value>(
+        val relaxer: Relaxer<Value>?,
+        val spyOnGet: Function0<Value>?,
+        val spyOnSet: Function1<Value, Unit>?,
+    ) : NonIntrusiveConfiguration
+
+    internal interface NonIntrusiveConfigurationReceiver<Configuration: NonIntrusiveConfiguration> {
+        fun getConfiguration(): Configuration
     }
 
     interface ProxyFactory {

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
@@ -675,7 +675,7 @@ object KMockContract {
     }
 
     interface NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> {
-        fun relaxUnitFunIf(condition: Boolean)
+        fun useUnitFunRelaxerIf(condition: Boolean)
         fun useToStringRelaxer(parent: Any)
         fun useHashCodeRelaxer(parent: Any)
         fun useEqualsRelaxer(parent: Any)

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/KMockContract.kt
@@ -674,24 +674,28 @@ object KMockContract {
         fun onSet(value: Value)
     }
 
-    interface NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> {
-        fun useUnitFunRelaxerIf(condition: Boolean)
-        fun useToStringRelaxer(parent: Any)
-        fun useHashCodeRelaxer(parent: Any)
-        fun useEqualsRelaxer(parent: Any)
+    interface NonIntrusiveConfigurator<ReturnValue> {
         fun useRelaxerIf(condition: Boolean, relaxer: Function1<String, ReturnValue>)
+    }
 
-        fun useSpyOnEqualIf(
+    interface NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> :
+        NonIntrusiveConfigurator<ReturnValue> {
+
+        fun useUnitFunRelaxerIf(condition: Boolean)
+        fun useToStringRelaxer(parent: Function0<String>)
+        fun useHashCodeRelaxer(parent: Function0<Int>)
+        fun useEqualsRelaxer(parent: Function1<Any?, Boolean>)
+
+        fun useSpyOnEqualsIf(
             spy: Any?,
-            parent: Any,
+            parent: Function1<Any?, Boolean>,
             mockKlass: KClass<out Any>,
         )
 
         fun useSpyIf(spy: Any?, spyOn: SideEffect)
     }
 
-    interface NonIntrusivePropertyConfigurator<Value> {
-        fun useRelaxerIf(condition: Boolean, relaxer: Function1<String, Value>)
+    interface NonIntrusivePropertyConfigurator<Value> : NonIntrusiveConfigurator<Value> {
         fun useSpyOnGetIf(spy: Any?, spyOn: Function0<Value>)
         fun useSpyOnSetIf(spy: Any?, spyOn: Function1<Value, Unit>)
     }
@@ -711,7 +715,7 @@ object KMockContract {
         val spyOnSet: Function1<Value, Unit>?,
     ) : NonIntrusiveConfiguration
 
-    internal interface NonIntrusiveConfigurationReceiver<Configuration: NonIntrusiveConfiguration> {
+    internal interface NonIntrusiveConfigurationReceiver<Configuration : NonIntrusiveConfiguration> {
         fun getConfiguration(): Configuration
     }
 

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/FunProxy.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/FunProxy.kt
@@ -217,7 +217,7 @@ abstract class FunProxy<ReturnValue, SideEffect : Function<ReturnValue>>(
     }
 
     protected fun invokeRelaxerOrFail(payload: Any?): ReturnValue {
-        return buildInRelaxer.value?.relax(payload)
+        return buildInRelaxer.value?.invoke(payload)
             ?: unitFunRelaxer.value?.relax(id)
             ?: relaxer.value?.relax(id)
             ?: throw MockError.MissingStub("Missing stub value for $id")

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveConfigurator.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveConfigurator.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.proxy
+
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Relaxer
+import tech.antibytes.kmock.KMockContract.ParameterizedRelaxer
+import tech.antibytes.kmock.KMockContract.NonIntrusiveConfiguration
+import kotlin.reflect.KClass
+
+internal class NonIntrusiveConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> :
+    KMockContract.NonIntrusiveConfigurator<ReturnValue, SideEffect>,
+    KMockContract.NonIntrusiveConfigurationReceiver<ReturnValue, SideEffect> {
+
+    private var unitFunRelaxer: Relaxer<Unit>? = null
+    private var buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>? = null
+    private var relaxer: Relaxer<ReturnValue>? = null
+    private var spyOn: SideEffect? = null
+
+    override fun relaxUnitFunIf(condition: Boolean) {
+        unitFunRelaxer = if (condition) {
+            kmockUnitFunRelaxer
+        } else {
+            null
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun useToStringRelaxer(parent: Any) {
+        buildInRelaxer = ParameterizedRelaxer { parent.toString() as ReturnValue }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun useHashCodeRelaxer(parent: Any) {
+        buildInRelaxer = ParameterizedRelaxer { parent.hashCode() as ReturnValue }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun useEqualsRelaxer(parent: Any) {
+        buildInRelaxer = ParameterizedRelaxer { other -> (parent == other) as ReturnValue }
+    }
+
+    override fun useRelaxerIf(condition: Boolean, relaxer: Function1<String, ReturnValue>) {
+        this.relaxer = if (condition) {
+            Relaxer { mockId -> relaxer.invoke(mockId) }
+        } else {
+            null
+        }
+    }
+
+    override fun useSpyIf(spy: Any?, spyOn: SideEffect) {
+        this.spyOn = if (spy != null) {
+            spyOn
+        } else {
+            null
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun useSpyOnEqualIf(
+        spy: Any?,
+        parent: Any,
+        mockKlass: KClass<out Any>
+    ) {
+        this.spyOn = if (spy != null) {
+            { other: Any? ->
+                val toCompareWith = if (other != null && other::class == mockKlass) {
+                    parent
+                } else {
+                    spy
+                }
+
+                toCompareWith == other
+            } as SideEffect
+        } else {
+            null
+        }
+    }
+
+    override fun getConfiguration(): NonIntrusiveConfiguration<ReturnValue, SideEffect> {
+        return NonIntrusiveConfiguration(
+            unitFunRelaxer = unitFunRelaxer,
+            relaxer = relaxer,
+            buildInRelaxer = buildInRelaxer,
+            spyOn = spyOn,
+        )
+    }
+}

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfigurator.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfigurator.kt
@@ -9,21 +9,23 @@ package tech.antibytes.kmock.proxy
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Relaxer
 import tech.antibytes.kmock.KMockContract.ParameterizedRelaxer
-import tech.antibytes.kmock.KMockContract.NonIntrusiveConfiguration
+import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfiguration
 import kotlin.reflect.KClass
 
-internal class NonIntrusiveConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> :
-    KMockContract.NonIntrusiveConfigurator<ReturnValue, SideEffect>,
-    KMockContract.NonIntrusiveConfigurationReceiver<ReturnValue, SideEffect> {
+// FIXME: CLEAR according to hierarchies
+internal class NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> :
+    KMockContract.NonIntrusiveFunConfigurator<ReturnValue, SideEffect>,
+    KMockContract.NonIntrusiveFunConfigurationReceiver<ReturnValue, SideEffect> {
 
-    private var unitFunRelaxer: Relaxer<Unit>? = null
+    private var unitFunRelaxer: Relaxer<ReturnValue?>? = null
     private var buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>? = null
     private var relaxer: Relaxer<ReturnValue>? = null
     private var spyOn: SideEffect? = null
 
+    @Suppress("UNCHECKED_CAST")
     override fun relaxUnitFunIf(condition: Boolean) {
         unitFunRelaxer = if (condition) {
-            kmockUnitFunRelaxer
+            kmockUnitFunRelaxer as Relaxer<ReturnValue?>?
         } else {
             null
         }
@@ -81,8 +83,8 @@ internal class NonIntrusiveConfigurator<ReturnValue, SideEffect : Function<Retur
         }
     }
 
-    override fun getConfiguration(): NonIntrusiveConfiguration<ReturnValue, SideEffect> {
-        return NonIntrusiveConfiguration(
+    override fun getConfiguration(): NonIntrusiveFunConfiguration<ReturnValue, SideEffect> {
+        return NonIntrusiveFunConfiguration(
             unitFunRelaxer = unitFunRelaxer,
             relaxer = relaxer,
             buildInRelaxer = buildInRelaxer,

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfigurator.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfigurator.kt
@@ -7,9 +7,9 @@
 package tech.antibytes.kmock.proxy
 
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.Relaxer
-import tech.antibytes.kmock.KMockContract.ParameterizedRelaxer
 import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfiguration
+import tech.antibytes.kmock.KMockContract.ParameterizedRelaxer
+import tech.antibytes.kmock.KMockContract.Relaxer
 import kotlin.reflect.KClass
 
 internal class NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> :
@@ -38,18 +38,18 @@ internal class NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<Re
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun useToStringRelaxer(parent: Any) {
-        buildInRelaxer = ParameterizedRelaxer { parent.toString() as ReturnValue }
+    override fun useToStringRelaxer(parent: Function0<String>) {
+        buildInRelaxer = ParameterizedRelaxer { parent.invoke() as ReturnValue }
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun useHashCodeRelaxer(parent: Any) {
-        buildInRelaxer = ParameterizedRelaxer { parent.hashCode() as ReturnValue }
+    override fun useHashCodeRelaxer(parent: Function0<Int>) {
+        buildInRelaxer = ParameterizedRelaxer { parent.invoke() as ReturnValue }
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun useEqualsRelaxer(parent: Any) {
-        buildInRelaxer = ParameterizedRelaxer { other -> (parent == other) as ReturnValue }
+    override fun useEqualsRelaxer(parent: Function1<Any?, Boolean>) {
+        buildInRelaxer = ParameterizedRelaxer { other -> parent.invoke(other) as ReturnValue }
     }
 
     override fun useRelaxerIf(
@@ -64,20 +64,18 @@ internal class NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<Re
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun useSpyOnEqualIf(
+    override fun useSpyOnEqualsIf(
         spy: Any?,
-        parent: Any,
+        parent: Function1<Any?, Boolean>,
         mockKlass: KClass<out Any>
     ) {
         this.spyOn = spy.guardSpy(
             { other: Any? ->
-                val toCompareWith = if (other != null && other::class == mockKlass) {
-                    parent
+                if (other != null && other::class == mockKlass) {
+                    parent.invoke(other)
                 } else {
-                    spy
+                    spy == other
                 }
-
-                toCompareWith == other
             } as SideEffect
         )
     }

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfigurator.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfigurator.kt
@@ -12,7 +12,6 @@ import tech.antibytes.kmock.KMockContract.ParameterizedRelaxer
 import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfiguration
 import kotlin.reflect.KClass
 
-// FIXME: CLEAR according to hierarchies
 internal class NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<ReturnValue>> :
     KMockContract.NonIntrusiveFunConfigurator<ReturnValue, SideEffect>,
     KMockContract.NonIntrusiveFunConfigurationReceiver<ReturnValue, SideEffect> {
@@ -22,8 +21,19 @@ internal class NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<Re
     private var relaxer: Relaxer<ReturnValue>? = null
     private var spyOn: SideEffect? = null
 
+    private fun finalizeRelaxers() {
+        if (unitFunRelaxer != null || buildInRelaxer != null) {
+            relaxer = null
+        }
+
+        if (spyOn != null) {
+            relaxer = null
+            unitFunRelaxer = null
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
-    override fun relaxUnitFunIf(condition: Boolean) {
+    override fun useUnitFunRelaxerIf(condition: Boolean) {
         unitFunRelaxer = if (condition) {
             kmockUnitFunRelaxer as Relaxer<ReturnValue?>?
         } else {
@@ -84,6 +94,8 @@ internal class NonIntrusiveFunConfigurator<ReturnValue, SideEffect : Function<Re
     }
 
     override fun getConfiguration(): NonIntrusiveFunConfiguration<ReturnValue, SideEffect> {
+        finalizeRelaxers()
+
         return NonIntrusiveFunConfiguration(
             unitFunRelaxer = unitFunRelaxer,
             relaxer = relaxer,

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfigurator.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfigurator.kt
@@ -7,8 +7,8 @@
 package tech.antibytes.kmock.proxy
 
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.Relaxer
 import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfiguration
+import tech.antibytes.kmock.KMockContract.Relaxer
 
 internal class NonIntrusivePropertyConfigurator<Value> :
     KMockContract.NonIntrusivePropertyConfigurator<Value>,

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfigurator.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfigurator.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.proxy
+
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Relaxer
+import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfiguration
+
+internal class NonIntrusivePropertyConfigurator<Value> :
+    KMockContract.NonIntrusivePropertyConfigurator<Value>,
+    KMockContract.NonIntrusiveConfigurationReceiver<NonIntrusivePropertyConfiguration<Value>> {
+    private var relaxer: Relaxer<Value>? = null
+    private var spyOnGet: Function0<Value>? = null
+    private var spyOnSet: Function1<Value, Unit>? = null
+
+    private fun finalizeRelaxers() {
+        if (spyOnGet != null || spyOnSet != null) {
+            relaxer = null
+        }
+    }
+
+    override fun useRelaxerIf(condition: Boolean, relaxer: Function1<String, Value>) {
+        this.relaxer = condition.guardRelaxer(relaxer)
+    }
+
+    override fun useSpyOnGetIf(spy: Any?, spyOn: Function0<Value>) {
+        this.spyOnGet = spy.guardSpy(spyOn)
+    }
+
+    override fun useSpyOnSetIf(spy: Any?, spyOn: Function1<Value, Unit>) {
+        this.spyOnSet = spy.guardSpy(spyOn)
+    }
+
+    override fun getConfiguration(): NonIntrusivePropertyConfiguration<Value> {
+        finalizeRelaxers()
+
+        return NonIntrusivePropertyConfiguration(
+            relaxer = relaxer,
+            spyOnGet = spyOnGet,
+            spyOnSet = spyOnSet,
+        )
+    }
+}

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/PropertyProxy.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/PropertyProxy.kt
@@ -40,8 +40,8 @@ internal class PropertyProxy<Value>(
     collector: Collector = NoopCollector,
     relaxer: Relaxer<Value>? = null,
     private val freeze: Boolean = true,
-    private val spyOnGet: (Function0<Value>)? = null,
-    private val spyOnSet: (Function1<Value, Unit>)? = null
+    private val spyOnGet: Function0<Value>? = null,
+    private val spyOnSet: Function1<Value, Unit>? = null
 ) : KMockContract.PropertyProxy<Value> {
     private val provider: AtomicRef<Provider> = atomic(useSpyOrDefault())
 

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/ProxyFactory.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/ProxyFactory.kt
@@ -10,8 +10,9 @@ import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfiguration
+import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfiguration
 import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfigurator
-import tech.antibytes.kmock.KMockContract.Relaxer
+import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfigurator
 import tech.antibytes.kmock.KMockContract.SyncFunProxy
 
 object ProxyFactory : KMockContract.ProxyFactory {
@@ -19,6 +20,16 @@ object ProxyFactory : KMockContract.ProxyFactory {
         relaxationConfiguration: NonIntrusiveFunConfigurator<ReturnValue, SideEffect>.() -> Unit
     ): NonIntrusiveFunConfiguration<ReturnValue, SideEffect> {
         val relaxationConfigurator = NonIntrusiveFunConfigurator<ReturnValue, SideEffect>()
+
+        relaxationConfiguration(relaxationConfigurator)
+
+        return relaxationConfigurator.getConfiguration()
+    }
+
+    private fun <Value> resolvePropertyProxyRelaxers(
+        relaxationConfiguration: NonIntrusivePropertyConfigurator<Value>.() -> Unit
+    ): NonIntrusivePropertyConfiguration<Value> {
+        val relaxationConfigurator = NonIntrusivePropertyConfigurator<Value>()
 
         relaxationConfiguration(relaxationConfigurator)
 
@@ -53,32 +64,34 @@ object ProxyFactory : KMockContract.ProxyFactory {
         freeze: Boolean,
         relaxationConfiguration: NonIntrusiveFunConfigurator<ReturnValue, SideEffect>.() -> Unit
     ): AsyncFunProxy<ReturnValue, SideEffect> {
-        val (unitFunRelaxer, buildInRelaxer, relaxer, spyOn) = resolveFunProxyRelaxers(relaxationConfiguration)
+        val configuration = resolveFunProxyRelaxers(relaxationConfiguration)
 
         return AsyncFunProxy(
             id = id,
             collector = collector,
-            relaxer = relaxer,
-            unitFunRelaxer = unitFunRelaxer,
-            buildInRelaxer = buildInRelaxer,
+            relaxer = configuration.relaxer,
+            unitFunRelaxer = configuration.unitFunRelaxer,
+            buildInRelaxer = configuration.buildInRelaxer,
             freeze = freeze,
-            spyOn = spyOn
+            spyOn = configuration.spyOn
         )
     }
 
     override fun <Value> createPropertyProxy(
         id: String,
         collector: Collector,
-        relaxer: Relaxer<Value>?,
         freeze: Boolean,
-        spyOnGet: (() -> Value)?,
-        spyOnSet: ((Value) -> Unit)?,
-    ): KMockContract.PropertyProxy<Value> = PropertyProxy(
-        id = id,
-        collector = collector,
-        relaxer = relaxer,
-        freeze = freeze,
-        spyOnGet = spyOnGet,
-        spyOnSet = spyOnSet,
-    )
+        relaxationConfiguration: NonIntrusivePropertyConfigurator<Value>.() -> Unit
+    ): KMockContract.PropertyProxy<Value> {
+        val configuration = resolvePropertyProxyRelaxers(relaxationConfiguration)
+
+        return PropertyProxy(
+            id = id,
+            collector = collector,
+            relaxer = configuration.relaxer,
+            freeze = freeze,
+            spyOnGet = configuration.spyOnGet,
+            spyOnSet = configuration.spyOnSet,
+        )
+    }
 }

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/ProxyFactory.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/ProxyFactory.kt
@@ -9,49 +9,62 @@ package tech.antibytes.kmock.proxy
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
-import tech.antibytes.kmock.KMockContract.ParameterizedRelaxer
+import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfiguration
+import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfigurator
 import tech.antibytes.kmock.KMockContract.Relaxer
 import tech.antibytes.kmock.KMockContract.SyncFunProxy
 
 object ProxyFactory : KMockContract.ProxyFactory {
+    private fun <ReturnValue, SideEffect : Function<ReturnValue>> resolveFunProxyRelaxers(
+        relaxationConfiguration: NonIntrusiveFunConfigurator<ReturnValue, SideEffect>.() -> Unit
+    ): NonIntrusiveFunConfiguration<ReturnValue, SideEffect> {
+        val relaxationConfigurator = NonIntrusiveFunConfigurator<ReturnValue, SideEffect>()
+
+        relaxationConfiguration(relaxationConfigurator)
+
+        return relaxationConfigurator.getConfiguration()
+    }
+
     override fun <ReturnValue, SideEffect : Function<ReturnValue>> createSyncFunProxy(
         id: String,
         collector: Collector,
         ignorableForVerification: Boolean,
-        relaxer: Relaxer<ReturnValue>?,
-        unitFunRelaxer: Relaxer<ReturnValue?>?,
-        buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>?,
         freeze: Boolean,
-        spyOn: SideEffect?
-    ): SyncFunProxy<ReturnValue, SideEffect> = SyncFunProxy(
-        id = id,
-        collector = collector,
-        ignorableForVerification = ignorableForVerification,
-        relaxer = relaxer,
-        unitFunRelaxer = unitFunRelaxer,
-        buildInRelaxer = buildInRelaxer,
-        freeze = freeze,
-        spyOn = spyOn
-    )
+        relaxationConfiguration: NonIntrusiveFunConfigurator<ReturnValue, SideEffect>.() -> Unit
+    ): SyncFunProxy<ReturnValue, SideEffect> {
+        val (unitFunRelaxer, buildInRelaxer, relaxer, spyOn) = resolveFunProxyRelaxers(relaxationConfiguration)
+
+        return SyncFunProxy(
+            id = id,
+            collector = collector,
+            ignorableForVerification = ignorableForVerification,
+            relaxer = relaxer,
+            unitFunRelaxer = unitFunRelaxer,
+            buildInRelaxer = buildInRelaxer,
+            freeze = freeze,
+            spyOn = spyOn
+        )
+    }
 
     override fun <ReturnValue, SideEffect : Function<ReturnValue>> createAsyncFunProxy(
         id: String,
         collector: Collector,
         ignorableForVerification: Boolean,
-        relaxer: Relaxer<ReturnValue>?,
-        unitFunRelaxer: Relaxer<ReturnValue?>?,
-        buildInRelaxer: ParameterizedRelaxer<Any?, ReturnValue>?,
         freeze: Boolean,
-        spyOn: SideEffect?
-    ): AsyncFunProxy<ReturnValue, SideEffect> = AsyncFunProxy(
-        id = id,
-        collector = collector,
-        relaxer = relaxer,
-        unitFunRelaxer = unitFunRelaxer,
-        buildInRelaxer = buildInRelaxer,
-        freeze = freeze,
-        spyOn = spyOn
-    )
+        relaxationConfiguration: NonIntrusiveFunConfigurator<ReturnValue, SideEffect>.() -> Unit
+    ): AsyncFunProxy<ReturnValue, SideEffect> {
+        val (unitFunRelaxer, buildInRelaxer, relaxer, spyOn) = resolveFunProxyRelaxers(relaxationConfiguration)
+
+        return AsyncFunProxy(
+            id = id,
+            collector = collector,
+            relaxer = relaxer,
+            unitFunRelaxer = unitFunRelaxer,
+            buildInRelaxer = buildInRelaxer,
+            freeze = freeze,
+            spyOn = spyOn
+        )
+    }
 
     override fun <Value> createPropertyProxy(
         id: String,

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/ProxyFactory.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/ProxyFactory.kt
@@ -10,8 +10,8 @@ import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfiguration
-import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfiguration
 import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfigurator
+import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfiguration
 import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfigurator
 import tech.antibytes.kmock.KMockContract.SyncFunProxy
 

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/RelaxtionGuard.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/RelaxtionGuard.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.proxy
+
+import tech.antibytes.kmock.KMockContract.Relaxer
+
+internal fun <ReturnValue> Boolean.guardRelaxer(relaxer: Function1<String, ReturnValue>): Relaxer<ReturnValue>? {
+    return if (this) {
+        Relaxer { mockId -> relaxer.invoke(mockId) }
+    } else {
+        null
+    }
+}
+
+internal fun <ReturnValue, SideEffect : Function<ReturnValue>> Any?.guardSpy(spyOn: SideEffect): SideEffect? {
+    return if (this != null) {
+        spyOn
+    } else {
+        null
+    }
+}

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/RelaxtionGuard.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/RelaxtionGuard.kt
@@ -17,6 +17,7 @@ internal fun <ReturnValue> Boolean.guardRelaxer(relaxer: Function1<String, Retur
 }
 
 internal fun <ReturnValue, SideEffect : Function<ReturnValue>> Any?.guardSpy(spyOn: SideEffect): SideEffect? {
+    println("hier")
     return if (this != null) {
         spyOn
     } else {

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxer.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxer.kt
@@ -6,6 +6,7 @@
 
 package tech.antibytes.kmock.proxy
 
-import tech.antibytes.kmock.KMockContract.Relaxer
-
-internal val kmockUnitFunRelaxer: Relaxer<Unit> = Relaxer { /* Do nothing */ }
+@Suppress("UNUSED_PARAMETER")
+internal fun kmockUnitFunRelaxer(id: String) {
+    /* Do nothing */
+}

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxer.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxer.kt
@@ -6,14 +6,6 @@
 
 package tech.antibytes.kmock.proxy
 
-/**
- * Relaxer for functions which return Unit
- * @param T actual type of the return value.
- */
-inline fun <reified T> relaxVoidFunction(): T? {
-    return if (T::class == Unit::class) {
-        Unit as T
-    } else {
-        null
-    }
-}
+import tech.antibytes.kmock.KMockContract.Relaxer
+
+internal val kmockUnitFunRelaxer: Relaxer<Unit> = Relaxer { /* Do nothing */ }

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveConfiguratorSpec.kt
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.proxy
+
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.NonIntrusiveConfiguration
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.fulfils
+import tech.antibytes.util.test.isNot
+import tech.antibytes.util.test.mustBe
+import tech.antibytes.util.test.sameAs
+import kotlin.js.JsName
+import kotlin.test.Test
+
+class NonIntrusiveConfiguratorSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    @JsName("fn0")
+    fun `It fulfils NonIntrusiveConfigurator`() {
+        NonIntrusiveConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveConfigurator::class
+    }
+
+    @Test
+    @JsName("fn1")
+    fun `It fulfils NonIntrusiveConfigurationReceiver`() {
+        NonIntrusiveConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveConfigurationReceiver::class
+    }
+
+    @Test
+    @JsName("fn2")
+    fun `Given getConfiguration is called while nothing else was invoked it returns the default configuration`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+
+        // When
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusiveConfiguration(
+            unitFunRelaxer = null,
+            buildInRelaxer = null,
+            relaxer = null,
+            spyOn = null
+        )
+    }
+
+    @Test
+    @JsName("fn3")
+    fun `Given getConfiguration is called after relaxUnitFunIf while its condition is falsum it returns a configuration without the unitFunRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+
+        // When
+        configurator.relaxUnitFunIf(false)
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusiveConfiguration(
+            unitFunRelaxer = null,
+            buildInRelaxer = null,
+            relaxer = null,
+            spyOn = null
+        )
+    }
+
+    @Test
+    @JsName("fn4")
+    fun `Given getConfiguration is called after relaxUnitFunIf while its condition is verum it returns a configuration with the unitFunRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+
+        // When
+        configurator.relaxUnitFunIf(true)
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.unitFunRelaxer sameAs kmockUnitFunRelaxer
+    }
+
+    @Test
+    @JsName("fn5")
+    fun `Given getConfiguration is called after relaxUnitFunIf while its condition falsum after a verum it returns a configuration without unitFunRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+
+        // When
+        configurator.relaxUnitFunIf(true)
+        configurator.relaxUnitFunIf(false)
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.unitFunRelaxer mustBe null
+    }
+
+    @Test
+    @JsName("fn6")
+    fun `Given getConfiguration is called after useToStringRelaxer is called with a subject it returns a configuration with a buildInRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<String, () -> String>()
+
+        // When
+        val subject: Any = fixture.fixture()
+
+        configurator.useToStringRelaxer(subject)
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.buildInRelaxer isNot null
+        actual.buildInRelaxer?.invoke(null) mustBe subject.toString()
+    }
+
+    @Test
+    @JsName("fn7")
+    fun `Given getConfiguration is called after useHashCodeRelaxer is called with a subject it returns a configuration with a buildInRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Int, () -> Int>()
+
+        // When
+        val subject: Any = fixture.fixture()
+
+        configurator.useHashCodeRelaxer(subject)
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.buildInRelaxer isNot null
+        actual.buildInRelaxer?.invoke(null) mustBe subject.hashCode()
+    }
+
+    @Test
+    @JsName("fn8")
+    fun `Given getConfiguration is called after useEqualsRelaxer is called with a subject it returns a configuration with a buildInRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Boolean, () -> Boolean>()
+
+        // When
+        val subject: Any = fixture.fixture()
+
+        configurator.useEqualsRelaxer(subject)
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.buildInRelaxer isNot null
+        actual.buildInRelaxer?.invoke(subject) mustBe true
+        actual.buildInRelaxer?.invoke(fixture.fixture()) mustBe false
+    }
+
+    @Test
+    @JsName("fn9")
+    fun `Given getConfiguration is called after useRelaxerIf while its condition is falsum it returns a configuration without the relaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Int, () -> Int>()
+
+        // When
+        configurator.useRelaxerIf(false) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusiveConfiguration(
+            unitFunRelaxer = null,
+            buildInRelaxer = null,
+            relaxer = null,
+            spyOn = null
+        )
+    }
+
+    @Test
+    @JsName("fn10")
+    fun `Given getConfiguration is called after useRelaxerIf while its condition is verum it returns a configuration without the relaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Int, () -> Int>()
+        val expected: Int = fixture.fixture()
+
+        // When
+        configurator.useRelaxerIf(true) { expected }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.relaxer isNot null
+        actual.relaxer!!.relax(fixture.fixture()) mustBe expected
+    }
+
+    @Test
+    @JsName("fn11")
+    fun `Given getConfiguration is called after useRelaxerIf while its condition falsum after a verum it returns a configuration without the relaxer`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+
+        // When
+        configurator.useRelaxerIf(true) { fixture.fixture() }
+        configurator.useRelaxerIf(false) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.relaxer mustBe null
+    }
+
+    @Test
+    @JsName("fn12")
+    fun `Given getConfiguration is called after useSpyOnEqualIf while its spy is null it returns a configuration without spyOn`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+
+        // When
+        configurator.useSpyOnEqualIf(
+            null,
+            fixture.fixture(),
+            MockOfMocks::class
+        )
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusiveConfiguration(
+            unitFunRelaxer = null,
+            buildInRelaxer = null,
+            relaxer = null,
+            spyOn = null
+        )
+    }
+
+    @Test
+    @JsName("fn13")
+    fun `Given getConfiguration is called after useSpyOnEqualIf while its spy is not null it returns a configuration with spyOn which uses the subjectToSpyOn`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+        val expected: Boolean = fixture.fixture()
+        var spyWasCalled = false
+        val subjectToSpyOn = MockOfMocks(
+            equals = {
+                spyWasCalled = true
+                expected
+            }
+        )
+
+        // When
+        configurator.useSpyOnEqualIf(
+            subjectToSpyOn,
+            fixture.fixture(),
+            MockOfMocks::class
+        )
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.spyOn isNot null
+        actual.spyOn?.invoke(fixture.fixture()) mustBe expected
+        spyWasCalled mustBe true
+    }
+
+    @Test
+    @JsName("fn14")
+    fun `Given getConfiguration is called after useSpyOnEqualIf while its spy is not null it returns a configuration with spyOn which uses its parent when invoked with another mock of the same Class`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+        val subjectToSpyOn: Any = fixture.fixture()
+        val expected: Boolean = fixture.fixture()
+        var parentWasCalled = false
+        val parent: Any = MockOfMocks(
+            equals = {
+                parentWasCalled = true
+                expected
+            }
+        )
+        val otherMock = MockOfMocks { !expected }
+
+        // When
+        configurator.useSpyOnEqualIf(
+            subjectToSpyOn,
+            parent,
+            MockOfMocks::class
+        )
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.spyOn isNot null
+        actual.spyOn?.invoke(otherMock) mustBe expected
+        parentWasCalled mustBe true
+    }
+
+    @Test
+    @JsName("fn15")
+    fun `Given getConfiguration is called after useSpyIf while its spy is null it returns a configuration without spyOn`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+
+        // When
+        configurator.useSpyIf(null) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusiveConfiguration(
+            unitFunRelaxer = null,
+            buildInRelaxer = null,
+            relaxer = null,
+            spyOn = null
+        )
+    }
+
+    @Test
+    @JsName("fn16")
+    fun `Given getConfiguration is called after useSpyIf while its spy is not null it returns a configuration with spyOn`() {
+        // Given
+        val configurator = NonIntrusiveConfigurator<Any, (Any) -> Any>()
+        var capturedValue: Any? = null
+        val expected: Any = fixture.fixture()
+        val expectedValue: Any = fixture.fixture()
+        val subjectToSpyOn = MockOfMocks(
+            methodToSpiedOn = { payload ->
+                capturedValue = payload
+                expected
+            }
+        )
+
+        // When
+        configurator.useSpyIf(Any()) { payload: Any -> subjectToSpyOn.methodToSpiedOn(payload) }
+        val actual = configurator.getConfiguration().spyOn!!.invoke(expectedValue)
+
+        // Then
+        actual mustBe expected
+        capturedValue mustBe expectedValue
+    }
+}
+
+private class MockOfMocks(
+    @JsName("fn0")
+    val equals: (() -> Boolean)? = null,
+    val methodToSpiedOn: ((Any) -> Any)? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        return equals?.invoke()
+            ?: throw RuntimeException("Missing SideEffect equals.")
+    }
+
+    override fun hashCode(): Int = TODO()
+
+    fun methodToSpiedOn(parameter: Any): Any {
+        return methodToSpiedOn?.invoke(parameter)
+            ?: throw RuntimeException("Missing SideEffect methodToSpiedOn.")
+    }
+}

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
@@ -57,7 +57,7 @@ class NonIntrusiveConfiguratorSpec {
         val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
-        configurator.relaxUnitFunIf(false)
+        configurator.useUnitFunRelaxerIf(false)
         val actual = configurator.getConfiguration()
 
         // Then
@@ -76,7 +76,7 @@ class NonIntrusiveConfiguratorSpec {
         val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
-        configurator.relaxUnitFunIf(true)
+        configurator.useUnitFunRelaxerIf(true)
         val actual = configurator.getConfiguration()
 
         // Then
@@ -90,8 +90,8 @@ class NonIntrusiveConfiguratorSpec {
         val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
-        configurator.relaxUnitFunIf(true)
-        configurator.relaxUnitFunIf(false)
+        configurator.useUnitFunRelaxerIf(true)
+        configurator.useUnitFunRelaxerIf(false)
         val actual = configurator.getConfiguration()
 
         // Then
@@ -322,6 +322,91 @@ class NonIntrusiveConfiguratorSpec {
         // Then
         actual mustBe expected
         capturedValue mustBe expectedValue
+    }
+
+    @Test
+    @JsName("fn17")
+    fun `Given a Relaxer and UnitFunRelaxer is set, the UnitFunRelaxer wipes the Relaxer`() {
+        // Given
+        val configurator = NonIntrusiveFunConfigurator<Unit, (Any) -> Unit>()
+
+        // When
+        configurator.useUnitFunRelaxerIf(true)
+        configurator.useRelaxerIf(true) { fixture.fixture() }
+
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.unitFunRelaxer isNot null
+        actual.relaxer mustBe null
+    }
+
+    @Test
+    @JsName("fn18")
+    fun `Given a Relaxer and BuildInRelaxer is set, the BuildInRelaxer wipes the Relaxer`() {
+        // Given
+        val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
+
+        // When
+        configurator.useEqualsRelaxer(fixture.fixture())
+        configurator.useRelaxerIf(true) { fixture.fixture() }
+
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.buildInRelaxer isNot null
+        actual.relaxer mustBe null
+    }
+
+    @Test
+    @JsName("fn19")
+    fun `Given a Relaxer and Spy is set, the Spy wipes the Relaxer`() {
+        // Given
+        val configurator = NonIntrusiveFunConfigurator<Any, (Any) -> Any>()
+
+        // When
+        configurator.useRelaxerIf(fixture.fixture()) { fixture.fixture() }
+        configurator.useSpyIf(fixture.fixture<Any>()) { fixture.fixture() }
+
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.spyOn isNot null
+        actual.relaxer mustBe null
+    }
+
+    @Test
+    @JsName("fn20")
+    fun `Given a UnitFunRelaxer and Spy is set, the Spy wipes the UnitFunRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveFunConfigurator<Any, (Any) -> Any>()
+
+        // When
+        configurator.useUnitFunRelaxerIf(true)
+        configurator.useSpyIf(fixture.fixture<Any>()) { fixture.fixture() }
+
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.spyOn isNot null
+        actual.unitFunRelaxer mustBe null
+    }
+
+    @Test
+    @JsName("fn21")
+    fun `Given a BuildInRelaxer and Spy is set, the Spy wipes the BuildInRelaxer`() {
+        // Given
+        val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
+
+        // When
+        configurator.useEqualsRelaxer(fixture.fixture())
+        configurator.useSpyIf(fixture.fixture<Any>()) { fixture.fixture() }
+
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.buildInRelaxer isNot null
+        actual.unitFunRelaxer mustBe null
     }
 }
 

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
@@ -347,7 +347,7 @@ class NonIntrusiveConfiguratorSpec {
 
     @Test
     @JsName("fn18")
-    fun `Given a Relaxer and UnitFunRelaxer is set, the UnitFunRelaxer wipes the Relaxer`() {
+    fun `Given a Relaxer and UnitFunRelaxer is set the UnitFunRelaxer wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Unit, (Any) -> Unit>()
 
@@ -364,7 +364,7 @@ class NonIntrusiveConfiguratorSpec {
 
     @Test
     @JsName("fn19")
-    fun `Given a Relaxer and BuildInRelaxer is set, the BuildInRelaxer wipes the Relaxer`() {
+    fun `Given a Relaxer and BuildInRelaxer is set the BuildInRelaxer wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
 
@@ -381,7 +381,7 @@ class NonIntrusiveConfiguratorSpec {
 
     @Test
     @JsName("fn20")
-    fun `Given a Relaxer and Spy is set, the Spy wipes the Relaxer`() {
+    fun `Given a Relaxer and Spy is set the Spy wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Any, (Any) -> Any>()
 
@@ -398,7 +398,7 @@ class NonIntrusiveConfiguratorSpec {
 
     @Test
     @JsName("fn21")
-    fun `Given a UnitFunRelaxer and Spy is set, the Spy wipes the UnitFunRelaxer`() {
+    fun `Given a UnitFunRelaxer and Spy is set the Spy wipes the UnitFunRelaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Any, (Any) -> Any>()
 
@@ -415,7 +415,7 @@ class NonIntrusiveConfiguratorSpec {
 
     @Test
     @JsName("fn22")
-    fun `Given a BuildInRelaxer and Spy is set, the Spy wipes the BuildInRelaxer`() {
+    fun `Given a BuildInRelaxer and Spy is set the Spy wipes the BuildInRelaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
 

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
@@ -29,7 +29,7 @@ class NonIntrusiveConfiguratorSpec {
     @Test
     @JsName("fn1")
     fun `It fulfils NonIntrusiveConfigurationReceiver`() {
-        NonIntrusiveFunConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveFunConfigurationReceiver::class
+        NonIntrusiveFunConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveConfigurationReceiver::class
     }
 
     @Test
@@ -80,7 +80,8 @@ class NonIntrusiveConfiguratorSpec {
         val actual = configurator.getConfiguration()
 
         // Then
-        actual.unitFunRelaxer sameAs kmockUnitFunRelaxer
+        actual.unitFunRelaxer isNot null
+        actual.unitFunRelaxer!!.relax("") mustBe Unit
     }
 
     @Test
@@ -326,6 +327,26 @@ class NonIntrusiveConfiguratorSpec {
 
     @Test
     @JsName("fn17")
+    fun `Given getConfiguration is called after useSpyIf while its spy is null after it was not it returns a configuration without spyOn`() {
+        // Given
+        val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
+
+        // When
+        configurator.useSpyIf(Any()) { fixture.fixture() }
+        configurator.useSpyIf(null) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusiveFunConfiguration(
+            unitFunRelaxer = null,
+            buildInRelaxer = null,
+            relaxer = null,
+            spyOn = null
+        )
+    }
+
+    @Test
+    @JsName("fn18")
     fun `Given a Relaxer and UnitFunRelaxer is set, the UnitFunRelaxer wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Unit, (Any) -> Unit>()
@@ -342,7 +363,7 @@ class NonIntrusiveConfiguratorSpec {
     }
 
     @Test
-    @JsName("fn18")
+    @JsName("fn19")
     fun `Given a Relaxer and BuildInRelaxer is set, the BuildInRelaxer wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
@@ -359,7 +380,7 @@ class NonIntrusiveConfiguratorSpec {
     }
 
     @Test
-    @JsName("fn19")
+    @JsName("fn20")
     fun `Given a Relaxer and Spy is set, the Spy wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Any, (Any) -> Any>()
@@ -376,7 +397,7 @@ class NonIntrusiveConfiguratorSpec {
     }
 
     @Test
-    @JsName("fn20")
+    @JsName("fn21")
     fun `Given a UnitFunRelaxer and Spy is set, the Spy wipes the UnitFunRelaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Any, (Any) -> Any>()
@@ -393,7 +414,7 @@ class NonIntrusiveConfiguratorSpec {
     }
 
     @Test
-    @JsName("fn21")
+    @JsName("fn22")
     fun `Given a BuildInRelaxer and Spy is set, the Spy wipes the BuildInRelaxer`() {
         // Given
         val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
@@ -408,22 +429,22 @@ class NonIntrusiveConfiguratorSpec {
         actual.buildInRelaxer isNot null
         actual.unitFunRelaxer mustBe null
     }
-}
 
-private class MockOfMocks(
-    @JsName("fn0")
-    val equals: (() -> Boolean)? = null,
-    val methodToSpiedOn: ((Any) -> Any)? = null
-) {
-    override fun equals(other: Any?): Boolean {
-        return equals?.invoke()
-            ?: throw RuntimeException("Missing SideEffect equals.")
-    }
+    private class MockOfMocks(
+        @JsName("fn0")
+        val equals: (() -> Boolean)? = null,
+        val methodToSpiedOn: ((Any) -> Any)? = null
+    ) {
+        override fun equals(other: Any?): Boolean {
+            return equals?.invoke()
+                ?: throw RuntimeException("Missing SideEffect equals.")
+        }
 
-    override fun hashCode(): Int = TODO()
+        override fun hashCode(): Int = TODO()
 
-    fun methodToSpiedOn(parameter: Any): Any {
-        return methodToSpiedOn?.invoke(parameter)
-            ?: throw RuntimeException("Missing SideEffect methodToSpiedOn.")
+        fun methodToSpiedOn(parameter: Any): Any {
+            return methodToSpiedOn?.invoke(parameter)
+                ?: throw RuntimeException("Missing SideEffect methodToSpiedOn.")
+        }
     }
 }

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
@@ -7,7 +7,7 @@
 package tech.antibytes.kmock.proxy
 
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.NonIntrusiveConfiguration
+import tech.antibytes.kmock.KMockContract.NonIntrusiveFunConfiguration
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fulfils
@@ -23,26 +23,26 @@ class NonIntrusiveConfiguratorSpec {
     @Test
     @JsName("fn0")
     fun `It fulfils NonIntrusiveConfigurator`() {
-        NonIntrusiveConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveConfigurator::class
+        NonIntrusiveFunConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveFunConfigurator::class
     }
 
     @Test
     @JsName("fn1")
     fun `It fulfils NonIntrusiveConfigurationReceiver`() {
-        NonIntrusiveConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveConfigurationReceiver::class
+        NonIntrusiveFunConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveFunConfigurationReceiver::class
     }
 
     @Test
     @JsName("fn2")
     fun `Given getConfiguration is called while nothing else was invoked it returns the default configuration`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+        val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
         val actual = configurator.getConfiguration()
 
         // Then
-        actual mustBe NonIntrusiveConfiguration(
+        actual mustBe NonIntrusiveFunConfiguration(
             unitFunRelaxer = null,
             buildInRelaxer = null,
             relaxer = null,
@@ -54,14 +54,14 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn3")
     fun `Given getConfiguration is called after relaxUnitFunIf while its condition is falsum it returns a configuration without the unitFunRelaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+        val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
         configurator.relaxUnitFunIf(false)
         val actual = configurator.getConfiguration()
 
         // Then
-        actual mustBe NonIntrusiveConfiguration(
+        actual mustBe NonIntrusiveFunConfiguration(
             unitFunRelaxer = null,
             buildInRelaxer = null,
             relaxer = null,
@@ -73,7 +73,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn4")
     fun `Given getConfiguration is called after relaxUnitFunIf while its condition is verum it returns a configuration with the unitFunRelaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+        val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
         configurator.relaxUnitFunIf(true)
@@ -87,7 +87,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn5")
     fun `Given getConfiguration is called after relaxUnitFunIf while its condition falsum after a verum it returns a configuration without unitFunRelaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+        val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
         configurator.relaxUnitFunIf(true)
@@ -102,7 +102,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn6")
     fun `Given getConfiguration is called after useToStringRelaxer is called with a subject it returns a configuration with a buildInRelaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<String, () -> String>()
+        val configurator = NonIntrusiveFunConfigurator<String, () -> String>()
 
         // When
         val subject: Any = fixture.fixture()
@@ -119,7 +119,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn7")
     fun `Given getConfiguration is called after useHashCodeRelaxer is called with a subject it returns a configuration with a buildInRelaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Int, () -> Int>()
+        val configurator = NonIntrusiveFunConfigurator<Int, () -> Int>()
 
         // When
         val subject: Any = fixture.fixture()
@@ -136,7 +136,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn8")
     fun `Given getConfiguration is called after useEqualsRelaxer is called with a subject it returns a configuration with a buildInRelaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Boolean, () -> Boolean>()
+        val configurator = NonIntrusiveFunConfigurator<Boolean, () -> Boolean>()
 
         // When
         val subject: Any = fixture.fixture()
@@ -154,14 +154,14 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn9")
     fun `Given getConfiguration is called after useRelaxerIf while its condition is falsum it returns a configuration without the relaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Int, () -> Int>()
+        val configurator = NonIntrusiveFunConfigurator<Int, () -> Int>()
 
         // When
         configurator.useRelaxerIf(false) { fixture.fixture() }
         val actual = configurator.getConfiguration()
 
         // Then
-        actual mustBe NonIntrusiveConfiguration(
+        actual mustBe NonIntrusiveFunConfiguration(
             unitFunRelaxer = null,
             buildInRelaxer = null,
             relaxer = null,
@@ -173,7 +173,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn10")
     fun `Given getConfiguration is called after useRelaxerIf while its condition is verum it returns a configuration without the relaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Int, () -> Int>()
+        val configurator = NonIntrusiveFunConfigurator<Int, () -> Int>()
         val expected: Int = fixture.fixture()
 
         // When
@@ -189,7 +189,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn11")
     fun `Given getConfiguration is called after useRelaxerIf while its condition falsum after a verum it returns a configuration without the relaxer`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Unit, () -> Unit>()
+        val configurator = NonIntrusiveFunConfigurator<Unit, () -> Unit>()
 
         // When
         configurator.useRelaxerIf(true) { fixture.fixture() }
@@ -204,7 +204,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn12")
     fun `Given getConfiguration is called after useSpyOnEqualIf while its spy is null it returns a configuration without spyOn`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+        val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
 
         // When
         configurator.useSpyOnEqualIf(
@@ -215,7 +215,7 @@ class NonIntrusiveConfiguratorSpec {
         val actual = configurator.getConfiguration()
 
         // Then
-        actual mustBe NonIntrusiveConfiguration(
+        actual mustBe NonIntrusiveFunConfiguration(
             unitFunRelaxer = null,
             buildInRelaxer = null,
             relaxer = null,
@@ -227,7 +227,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn13")
     fun `Given getConfiguration is called after useSpyOnEqualIf while its spy is not null it returns a configuration with spyOn which uses the subjectToSpyOn`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+        val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
         val expected: Boolean = fixture.fixture()
         var spyWasCalled = false
         val subjectToSpyOn = MockOfMocks(
@@ -255,7 +255,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn14")
     fun `Given getConfiguration is called after useSpyOnEqualIf while its spy is not null it returns a configuration with spyOn which uses its parent when invoked with another mock of the same Class`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+        val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
         val subjectToSpyOn: Any = fixture.fixture()
         val expected: Boolean = fixture.fixture()
         var parentWasCalled = false
@@ -285,14 +285,14 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn15")
     fun `Given getConfiguration is called after useSpyIf while its spy is null it returns a configuration without spyOn`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Boolean, (Any?) -> Boolean>()
+        val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
 
         // When
         configurator.useSpyIf(null) { fixture.fixture() }
         val actual = configurator.getConfiguration()
 
         // Then
-        actual mustBe NonIntrusiveConfiguration(
+        actual mustBe NonIntrusiveFunConfiguration(
             unitFunRelaxer = null,
             buildInRelaxer = null,
             relaxer = null,
@@ -304,7 +304,7 @@ class NonIntrusiveConfiguratorSpec {
     @JsName("fn16")
     fun `Given getConfiguration is called after useSpyIf while its spy is not null it returns a configuration with spyOn`() {
         // Given
-        val configurator = NonIntrusiveConfigurator<Any, (Any) -> Any>()
+        val configurator = NonIntrusiveFunConfigurator<Any, (Any) -> Any>()
         var capturedValue: Any? = null
         val expected: Any = fixture.fixture()
         val expectedValue: Any = fixture.fixture()

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusiveFunConfiguratorSpec.kt
@@ -13,16 +13,21 @@ import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.isNot
 import tech.antibytes.util.test.mustBe
-import tech.antibytes.util.test.sameAs
 import kotlin.js.JsName
 import kotlin.test.Test
 
-class NonIntrusiveConfiguratorSpec {
+class NonIntrusiveFunConfiguratorSpec {
     private val fixture = kotlinFixture()
 
     @Test
-    @JsName("fn0")
+    @JsName("fn0a")
     fun `It fulfils NonIntrusiveConfigurator`() {
+        NonIntrusiveFunConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveConfigurator::class
+    }
+
+    @Test
+    @JsName("fn0")
+    fun `It fulfils NonIntrusiveFunConfigurator`() {
         NonIntrusiveFunConfigurator<Unit, () -> Unit>() fulfils KMockContract.NonIntrusiveFunConfigurator::class
     }
 
@@ -108,7 +113,7 @@ class NonIntrusiveConfiguratorSpec {
         // When
         val subject: Any = fixture.fixture()
 
-        configurator.useToStringRelaxer(subject)
+        configurator.useToStringRelaxer(subject::toString)
         val actual = configurator.getConfiguration()
 
         // Then
@@ -125,7 +130,7 @@ class NonIntrusiveConfiguratorSpec {
         // When
         val subject: Any = fixture.fixture()
 
-        configurator.useHashCodeRelaxer(subject)
+        configurator.useHashCodeRelaxer(subject::hashCode)
         val actual = configurator.getConfiguration()
 
         // Then
@@ -142,7 +147,7 @@ class NonIntrusiveConfiguratorSpec {
         // When
         val subject: Any = fixture.fixture()
 
-        configurator.useEqualsRelaxer(subject)
+        configurator.useEqualsRelaxer(subject::equals)
         val actual = configurator.getConfiguration()
 
         // Then
@@ -208,9 +213,9 @@ class NonIntrusiveConfiguratorSpec {
         val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
 
         // When
-        configurator.useSpyOnEqualIf(
+        configurator.useSpyOnEqualsIf(
             null,
-            fixture.fixture(),
+            { fixture.fixture() },
             MockOfMocks::class
         )
         val actual = configurator.getConfiguration()
@@ -239,9 +244,9 @@ class NonIntrusiveConfiguratorSpec {
         )
 
         // When
-        configurator.useSpyOnEqualIf(
+        configurator.useSpyOnEqualsIf(
             subjectToSpyOn,
-            fixture.fixture(),
+            { fixture.fixture() },
             MockOfMocks::class
         )
         val actual = configurator.getConfiguration()
@@ -269,9 +274,9 @@ class NonIntrusiveConfiguratorSpec {
         val otherMock = MockOfMocks { !expected }
 
         // When
-        configurator.useSpyOnEqualIf(
+        configurator.useSpyOnEqualsIf(
             subjectToSpyOn,
-            parent,
+            parent::equals,
             MockOfMocks::class
         )
         val actual = configurator.getConfiguration()
@@ -369,7 +374,7 @@ class NonIntrusiveConfiguratorSpec {
         val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
 
         // When
-        configurator.useEqualsRelaxer(fixture.fixture())
+        configurator.useEqualsRelaxer { fixture.fixture() }
         configurator.useRelaxerIf(true) { fixture.fixture() }
 
         val actual = configurator.getConfiguration()
@@ -420,7 +425,7 @@ class NonIntrusiveConfiguratorSpec {
         val configurator = NonIntrusiveFunConfigurator<Boolean, (Any?) -> Boolean>()
 
         // When
-        configurator.useEqualsRelaxer(fixture.fixture())
+        configurator.useEqualsRelaxer { fixture.fixture() }
         configurator.useSpyIf(fixture.fixture<Any>()) { fixture.fixture() }
 
         val actual = configurator.getConfiguration()

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfiguratorSpec.kt
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.proxy
+
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.NonIntrusivePropertyConfiguration
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.fulfils
+import tech.antibytes.util.test.isNot
+import tech.antibytes.util.test.mustBe
+import kotlin.js.JsName
+import kotlin.test.Test
+
+class NonIntrusivePropertyConfiguratorSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    @JsName("fn0")
+    fun `It fulfils NonIntrusivePropertyConfigurator`() {
+        NonIntrusivePropertyConfigurator<Any>() fulfils KMockContract.NonIntrusivePropertyConfigurator::class
+    }
+
+    @Test
+    @JsName("fn1")
+    fun `It fulfils NonIntrusiveConfigurationReceiver`() {
+        NonIntrusivePropertyConfigurator<Any>() fulfils KMockContract.NonIntrusiveConfigurationReceiver::class
+    }
+
+    @Test
+    @JsName("fn2")
+    fun `Given getConfiguration is called while nothing else was invoked it returns the default configuration`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusivePropertyConfiguration(
+            relaxer = null,
+            spyOnGet = null,
+            spyOnSet = null,
+        )
+    }
+
+    @Test
+    @JsName("fn3")
+    fun `Given getConfiguration is called after useRelaxerIf while its condition is falsum it returns a configuration without the relaxer`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useRelaxerIf(false) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusivePropertyConfiguration(
+            relaxer = null,
+            spyOnGet = null,
+            spyOnSet = null,
+        )
+    }
+
+    @Test
+    @JsName("fn4")
+    fun `Given getConfiguration is called after useRelaxerIf while its condition is verum it returns a configuration with the relaxer`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+        val expected: Int = fixture.fixture()
+
+        // When
+        configurator.useRelaxerIf(true) { expected }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.relaxer isNot null
+        actual.relaxer!!.relax(fixture.fixture()) mustBe expected
+    }
+
+    @Test
+    @JsName("fn5")
+    fun `Given getConfiguration is called after useRelaxerIf while its condition falsum after a verum it returns a configuration without the relaxer`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useRelaxerIf(true) { fixture.fixture() }
+        configurator.useRelaxerIf(false) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusivePropertyConfiguration(
+            relaxer = null,
+            spyOnGet = null,
+            spyOnSet = null,
+        )
+    }
+
+    @Test
+    @JsName("fn6")
+    fun `Given getConfiguration is called after useSpyOnGetIf while its spy is null it returns a configuration without spyOnGet`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useSpyOnGetIf(null) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusivePropertyConfiguration(
+            relaxer = null,
+            spyOnGet = null,
+            spyOnSet = null,
+        )
+    }
+
+    @Test
+    @JsName("fn7")
+    fun `Given getConfiguration is called after useSpyOnGetIf while its spy is not null it returns a configuration with spyOnGet`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+        val expected: Int = fixture.fixture()
+        val subjectToSpyOn = MockOfMocks(
+            getterSpiedOn = { expected }
+        )
+
+        // When
+        configurator.useSpyOnGetIf(Any(), subjectToSpyOn::property::get)
+        val actual = configurator.getConfiguration().spyOnGet!!.invoke()
+
+        // Then
+        actual mustBe expected
+    }
+
+    @Test
+    @JsName("fn8")
+    fun `Given getConfiguration is called after useSpyOnGetIf while its spy is null after it was not it returns a configuration without spyOnGet`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useSpyOnGetIf(Any()) { fixture.fixture() }
+        configurator.useSpyOnGetIf(null) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusivePropertyConfiguration(
+            relaxer = null,
+            spyOnGet = null,
+            spyOnSet = null,
+        )
+    }
+
+    @Test
+    @JsName("fn9")
+    fun `Given getConfiguration is called after useSpyOnSetIf while its spy is null it returns a configuration without spyOnSet`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useSpyOnSetIf(null) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusivePropertyConfiguration(
+            relaxer = null,
+            spyOnGet = null,
+            spyOnSet = null,
+        )
+    }
+
+    @Test
+    @JsName("fn10")
+    fun `Given getConfiguration is called after useSpyOnSetIf while its spy is not null it returns a configuration with spyOnSet`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+        val expected: Int = fixture.fixture()
+        var actual: Int? = null
+        val subjectToSpyOn = MockOfMocks(
+            setterSpiedOn = { givenValue ->
+                actual = givenValue
+            }
+        )
+
+        // When
+        configurator.useSpyOnSetIf(Any(), subjectToSpyOn::property::set)
+        configurator.getConfiguration().spyOnSet!!.invoke(expected)
+
+        // Then
+        actual mustBe expected
+    }
+
+    @Test
+    @JsName("fn11")
+    fun `Given getConfiguration is called after useSpyOnSetIf while its spy is null after it was not it returns a configuration without spyOnSet`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useSpyOnSetIf(Any()) { fixture.fixture() }
+        configurator.useSpyOnSetIf(null) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual mustBe NonIntrusivePropertyConfiguration(
+            relaxer = null,
+            spyOnGet = null,
+            spyOnSet = null,
+        )
+    }
+
+    @Test
+    @JsName("fn12")
+    fun `Given a Relaxer and SpyOnGet is set, the SpyOnGet wipes the Relaxer`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useRelaxerIf(true) { fixture.fixture() }
+        configurator.useSpyOnGetIf(Any()) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.relaxer mustBe null
+        actual.spyOnGet isNot null
+    }
+
+    @Test
+    @JsName("fn14")
+    fun `Given a Relaxer and SpyOnSet is set, the SpyOnGet wipes the Relaxer`() {
+        // Given
+        val configurator = NonIntrusivePropertyConfigurator<Int>()
+
+        // When
+        configurator.useRelaxerIf(true) { fixture.fixture() }
+        configurator.useSpyOnSetIf(Any()) { fixture.fixture() }
+        val actual = configurator.getConfiguration()
+
+        // Then
+        actual.relaxer mustBe null
+        actual.spyOnSet isNot null
+    }
+
+    private class MockOfMocks(
+        val getterSpiedOn: (() -> Int)? = null,
+        val setterSpiedOn: ((Int) -> Unit)? = null
+    ) {
+        var property: Int
+            get() = getterSpiedOn?.invoke() ?: throw RuntimeException("Missing SideEffect getterSpiedOn.")
+            set(value) = setterSpiedOn?.invoke(value) ?: throw RuntimeException("Missing SideEffect setterSpiedOn.")
+    }
+}

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfiguratorSpec.kt
@@ -20,6 +20,12 @@ class NonIntrusivePropertyConfiguratorSpec {
     private val fixture = kotlinFixture()
 
     @Test
+    @JsName("fn0a")
+    fun `It fulfils NonIntrusiveConfigurator`() {
+        NonIntrusivePropertyConfigurator<Any>() fulfils KMockContract.NonIntrusiveConfigurator::class
+    }
+
+    @Test
     @JsName("fn0")
     fun `It fulfils NonIntrusivePropertyConfigurator`() {
         NonIntrusivePropertyConfigurator<Any>() fulfils KMockContract.NonIntrusivePropertyConfigurator::class

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfiguratorSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/NonIntrusivePropertyConfiguratorSpec.kt
@@ -216,7 +216,7 @@ class NonIntrusivePropertyConfiguratorSpec {
 
     @Test
     @JsName("fn12")
-    fun `Given a Relaxer and SpyOnGet is set, the SpyOnGet wipes the Relaxer`() {
+    fun `Given a Relaxer and SpyOnGet is set the SpyOnGet wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusivePropertyConfigurator<Int>()
 
@@ -232,7 +232,7 @@ class NonIntrusivePropertyConfiguratorSpec {
 
     @Test
     @JsName("fn14")
-    fun `Given a Relaxer and SpyOnSet is set, the SpyOnGet wipes the Relaxer`() {
+    fun `Given a Relaxer and SpyOnSet is set the SpyOnGet wipes the Relaxer`() {
         // Given
         val configurator = NonIntrusivePropertyConfigurator<Int>()
 

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
@@ -6,7 +6,6 @@
 
 package tech.antibytes.kmock.proxy
 
-import co.touchlab.stately.freeze
 import co.touchlab.stately.isFrozen
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Proxy
@@ -111,7 +110,7 @@ class ProxyFactorySpec {
         // When
         val proxy = ProxyFactory.createSyncFunProxy<Any, (Any, Any) -> Unit>(
             id = fixture.fixture(),
-        ) { relaxUnitFunIf(true) }
+        ) { useUnitFunRelaxerIf(true) }
 
         // Then
         proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture()) mustBe Unit
@@ -196,7 +195,7 @@ class ProxyFactorySpec {
         // When
         val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Unit>(
             id = fixture.fixture(),
-        ) { relaxUnitFunIf(true) }
+        ) { useUnitFunRelaxerIf(true) }
 
         // Then
         proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture()) mustBe Unit

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
@@ -7,10 +7,10 @@
 package tech.antibytes.kmock.proxy
 
 import tech.antibytes.kmock.KMockContract
-import tech.antibytes.kmock.KMockContract.Proxy
-import tech.antibytes.kmock.KMockContract.PropertyProxy
-import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.KMockContract.AsyncFunProxy
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.KMockContract.PropertyProxy
+import tech.antibytes.kmock.KMockContract.Proxy
 import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.util.test.annotations.NativeOnly
 import tech.antibytes.util.test.coroutine.AsyncTestReturnValue

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
@@ -6,13 +6,14 @@
 
 package tech.antibytes.kmock.proxy
 
-import co.touchlab.stately.isFrozen
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Proxy
+import tech.antibytes.kmock.KMockContract.PropertyProxy
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.SyncFunProxy
 import tech.antibytes.util.test.annotations.NativeOnly
+import tech.antibytes.util.test.coroutine.AsyncTestReturnValue
 import tech.antibytes.util.test.coroutine.runBlockingTest
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
@@ -22,6 +23,7 @@ import tech.antibytes.util.test.sameAs
 import kotlin.js.JsName
 import kotlin.test.Test
 
+// NOTE: This is a entry point and the reason for its integration character
 class ProxyFactorySpec {
     private val fixture = kotlinFixture()
 
@@ -46,7 +48,6 @@ class ProxyFactorySpec {
 
     @Test
     @JsName("fn2")
-    @Suppress("USELESS_IS_CHECK")
     fun `Given createSyncFunProxy it creates a SyncFunProxy while using a Collector`() {
         // Given
         var capturedProxy: Proxy<*, *>? = null
@@ -71,10 +72,9 @@ class ProxyFactorySpec {
     @Test
     @JsName("fn3")
     @NativeOnly
-    @Suppress("USELESS_IS_CHECK")
-    fun `Given createSyncFunProxy it creates a SyncFunProxy while setting freeze`() {
+    fun `Given createSyncFunProxy it creates a SyncFunProxy while setting freeze`(): AsyncTestReturnValue {
         // Given
-        val freeze: Boolean = fixture.fixture()
+        val freeze = true
 
         // When
         val proxy = ProxyFactory.createSyncFunProxy<Any, (Any, Any) -> Any>(
@@ -82,13 +82,16 @@ class ProxyFactorySpec {
             freeze = freeze,
         )
 
-        // Then
-        proxy.isFrozen mustBe freeze
+        return runBlockingTest {
+            proxy.returnValue = fixture.fixture()
+
+            // Then
+            proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture()) // just runs
+        }
     }
 
     @Test
     @JsName("fn4")
-    @Suppress("USELESS_IS_CHECK")
     fun `Given createSyncFunProxy it creates a SyncFunProxy while override ignorableForVerification`() {
         // Given
         val ignorable: Boolean = fixture.fixture()
@@ -105,7 +108,6 @@ class ProxyFactorySpec {
 
     @Test
     @JsName("fn5")
-    @Suppress("USELESS_IS_CHECK")
     fun `Given createSyncFunProxy it creates a SyncFunProxy while setting up relaxers`() {
         // When
         val proxy = ProxyFactory.createSyncFunProxy<Any, (Any, Any) -> Unit>(
@@ -131,7 +133,6 @@ class ProxyFactorySpec {
 
     @Test
     @JsName("fn7")
-    @Suppress("USELESS_IS_CHECK")
     fun `Given createAsyncFunProxy it creates a AsyncFunProxy while using a Collector`() = runBlockingTest {
         // Given
         var capturedProxy: Proxy<*, *>? = null
@@ -156,10 +157,9 @@ class ProxyFactorySpec {
     @Test
     @JsName("fn8")
     @NativeOnly
-    @Suppress("USELESS_IS_CHECK")
-    fun `Given createAsyncFunProxy it creates a AsyncFunProxy while setting freeze`() {
+    fun `Given createAsyncFunProxy it creates a AsyncFunProxy while setting freeze`(): AsyncTestReturnValue {
         // Given
-        val freeze: Boolean = fixture.fixture()
+        val freeze = true
 
         // When
         val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Any>(
@@ -167,13 +167,16 @@ class ProxyFactorySpec {
             freeze = freeze,
         )
 
-        // Then
-        proxy.isFrozen mustBe freeze
+        return runBlockingTest {
+            proxy.returnValue = fixture.fixture()
+
+            // Then
+            proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture()) // just runs
+        }
     }
 
     @Test
     @JsName("fn9")
-    @Suppress("USELESS_IS_CHECK")
     fun `Given createAsyncFunProxy it creates a AsyncFunProxy while ignoring ignorableForVerification`() {
         // Given
         val ignorable = true
@@ -190,7 +193,6 @@ class ProxyFactorySpec {
 
     @Test
     @JsName("fn10")
-    @Suppress("USELESS_IS_CHECK")
     fun `Given createAsyncFunProxy it creates a AsyncFunProxy while setting up relaxers`() = runBlockingTest {
         // When
         val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Unit>(
@@ -210,6 +212,65 @@ class ProxyFactorySpec {
         )
 
         // Then
-        (proxy is KMockContract.PropertyProxy<Int>) mustBe true
+        (proxy is PropertyProxy<Int>) mustBe true
+    }
+
+    @Test
+    @JsName("fn12")
+    fun `Given createPropertyProxy it creates a PropertyProxy while using a Collector`() {
+        // Given
+        var capturedProxy: Proxy<*, *>? = null
+        val collector = Collector { proxy, _ ->
+            capturedProxy = proxy
+        }
+
+        // When
+        val proxy: PropertyProxy<Int> = ProxyFactory.createPropertyProxy(
+            id = fixture.fixture(),
+            collector = collector,
+        )
+
+        // Then
+        proxy.get = fixture.fixture()
+        proxy.onGet()
+
+        // Then
+        capturedProxy sameAs proxy
+    }
+
+    @Test
+    @JsName("fn13")
+    @NativeOnly
+    fun `Given createPropertyProxy it creates a PropertyProxy while setting freeze`(): AsyncTestReturnValue {
+        // Given
+        val freeze = true
+
+        // When
+        val proxy: PropertyProxy<Int> = ProxyFactory.createPropertyProxy(
+            id = fixture.fixture(),
+            freeze = freeze,
+        )
+
+        return runBlockingTest {
+            proxy.get = fixture.fixture()
+
+            // Then
+            proxy.onGet() // just runs
+        }
+    }
+
+    @Test
+    @JsName("fn14")
+    fun `Given createPropertyProxy it creates a PropertyProxy while setting up relaxers`() {
+        // Given
+        val expected: Int = fixture.fixture()
+
+        // When
+        val proxy: PropertyProxy<Int> = ProxyFactory.createPropertyProxy(
+            id = fixture.fixture(),
+        ) { useRelaxerIf(true) { expected } }
+
+        // Then
+        proxy.onGet() mustBe expected
     }
 }

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/ProxyFactorySpec.kt
@@ -6,13 +6,20 @@
 
 package tech.antibytes.kmock.proxy
 
+import co.touchlab.stately.freeze
+import co.touchlab.stately.isFrozen
 import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Proxy
+import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.KMockContract.AsyncFunProxy
 import tech.antibytes.kmock.KMockContract.SyncFunProxy
+import tech.antibytes.util.test.annotations.NativeOnly
+import tech.antibytes.util.test.coroutine.runBlockingTest
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
+import tech.antibytes.util.test.sameAs
 import kotlin.js.JsName
 import kotlin.test.Test
 
@@ -41,6 +48,78 @@ class ProxyFactorySpec {
     @Test
     @JsName("fn2")
     @Suppress("USELESS_IS_CHECK")
+    fun `Given createSyncFunProxy it creates a SyncFunProxy while using a Collector`() {
+        // Given
+        var capturedProxy: Proxy<*, *>? = null
+        val collector = Collector { proxy, _ ->
+            capturedProxy = proxy
+        }
+
+        // When
+        val proxy = ProxyFactory.createSyncFunProxy<Any, (Any, Any) -> Any>(
+            id = fixture.fixture(),
+            collector = collector,
+        )
+
+        proxy.returnValue = fixture.fixture()
+
+        proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture())
+
+        // Then
+        capturedProxy sameAs proxy
+    }
+
+    @Test
+    @JsName("fn3")
+    @NativeOnly
+    @Suppress("USELESS_IS_CHECK")
+    fun `Given createSyncFunProxy it creates a SyncFunProxy while setting freeze`() {
+        // Given
+        val freeze: Boolean = fixture.fixture()
+
+        // When
+        val proxy = ProxyFactory.createSyncFunProxy<Any, (Any, Any) -> Any>(
+            id = fixture.fixture(),
+            freeze = freeze,
+        )
+
+        // Then
+        proxy.isFrozen mustBe freeze
+    }
+
+    @Test
+    @JsName("fn4")
+    @Suppress("USELESS_IS_CHECK")
+    fun `Given createSyncFunProxy it creates a SyncFunProxy while override ignorableForVerification`() {
+        // Given
+        val ignorable: Boolean = fixture.fixture()
+
+        // When
+        val proxy = ProxyFactory.createSyncFunProxy<Any, (Any, Any) -> Any>(
+            id = fixture.fixture(),
+            ignorableForVerification = ignorable,
+        )
+
+        // Then
+        proxy.ignorableForVerification mustBe ignorable
+    }
+
+    @Test
+    @JsName("fn5")
+    @Suppress("USELESS_IS_CHECK")
+    fun `Given createSyncFunProxy it creates a SyncFunProxy while setting up relaxers`() {
+        // When
+        val proxy = ProxyFactory.createSyncFunProxy<Any, (Any, Any) -> Unit>(
+            id = fixture.fixture(),
+        ) { relaxUnitFunIf(true) }
+
+        // Then
+        proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture()) mustBe Unit
+    }
+
+    @Test
+    @JsName("fn6")
+    @Suppress("USELESS_IS_CHECK")
     fun `Given createAsyncFunProxy it creates a AsyncFunProxy`() {
         // When
         val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Any>(
@@ -52,10 +131,82 @@ class ProxyFactorySpec {
     }
 
     @Test
-    @JsName("fn3")
+    @JsName("fn7")
+    @Suppress("USELESS_IS_CHECK")
+    fun `Given createAsyncFunProxy it creates a AsyncFunProxy while using a Collector`() = runBlockingTest {
+        // Given
+        var capturedProxy: Proxy<*, *>? = null
+        val collector = Collector { proxy, _ ->
+            capturedProxy = proxy
+        }
+
+        // When
+        val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Any>(
+            id = fixture.fixture(),
+            collector = collector,
+        )
+
+        proxy.returnValue = fixture.fixture()
+
+        proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture())
+
+        // Then
+        capturedProxy sameAs proxy
+    }
+
+    @Test
+    @JsName("fn8")
+    @NativeOnly
+    @Suppress("USELESS_IS_CHECK")
+    fun `Given createAsyncFunProxy it creates a AsyncFunProxy while setting freeze`() {
+        // Given
+        val freeze: Boolean = fixture.fixture()
+
+        // When
+        val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Any>(
+            id = fixture.fixture(),
+            freeze = freeze,
+        )
+
+        // Then
+        proxy.isFrozen mustBe freeze
+    }
+
+    @Test
+    @JsName("fn9")
+    @Suppress("USELESS_IS_CHECK")
+    fun `Given createAsyncFunProxy it creates a AsyncFunProxy while ignoring ignorableForVerification`() {
+        // Given
+        val ignorable = true
+
+        // When
+        val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Any>(
+            id = fixture.fixture(),
+            ignorableForVerification = ignorable,
+        )
+
+        // Then
+        proxy.ignorableForVerification mustBe false
+    }
+
+    @Test
+    @JsName("fn10")
+    @Suppress("USELESS_IS_CHECK")
+    fun `Given createAsyncFunProxy it creates a AsyncFunProxy while setting up relaxers`() = runBlockingTest {
+        // When
+        val proxy = ProxyFactory.createAsyncFunProxy<Any, suspend (Any, Any) -> Unit>(
+            id = fixture.fixture(),
+        ) { relaxUnitFunIf(true) }
+
+        // Then
+        proxy.invoke<Any, Any>(fixture.fixture(), fixture.fixture()) mustBe Unit
+    }
+
+    @Test
+    @JsName("fn11")
     fun `Given createPropertyProxy it creates a PropertyProxy`() {
         // When
-        val proxy: KMockContract.Proxy<Int, KMockContract.GetOrSet> = ProxyFactory.createPropertyProxy(
+        val proxy: Proxy<Int, KMockContract.GetOrSet> = ProxyFactory.createPropertyProxy(
             id = fixture.fixture()
         )
 

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/RelaxationGuardSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/RelaxationGuardSpec.kt
@@ -6,7 +6,6 @@
 
 package tech.antibytes.kmock.proxy
 
-import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Relaxer
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/RelaxationGuardSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/RelaxationGuardSpec.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.proxy
+
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Relaxer
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.fulfils
+import tech.antibytes.util.test.isNot
+import tech.antibytes.util.test.mustBe
+import kotlin.js.JsName
+import kotlin.test.Test
+
+class RelaxationGuardSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    @JsName("fn0")
+    fun `Given a negative condtion and guardRelaxer is called with a function it returns null`() {
+        // When
+        val actual = false.guardRelaxer { fixture.fixture<Any>() }
+
+        // Then
+        actual mustBe null
+    }
+
+    @Test
+    @JsName("fn1")
+    fun `Given a positive condtion and guardRelaxer is called with a function it returns a Relaxer with the given function`() {
+        // Given
+        val expected: Any = fixture.fixture()
+
+        // When
+        val actual = true.guardRelaxer { expected }
+
+        // Then
+        actual!! fulfils Relaxer::class
+        actual.relax("") mustBe expected
+    }
+
+    @Test
+    @JsName("fn2")
+    fun `Given a null and guardSpy is called with a function it returns null`() {
+        // When
+        val actual = (null as Any?).guardSpy { fixture.fixture<Any>() }
+
+        // Then
+        actual mustBe null
+    }
+
+    @Test
+    @JsName("fn3")
+    fun `Given Anything and guardSpy is called with a function it returns the given SideEffect`() {
+        // Given
+        val expected: Any = fixture.fixture()
+
+        // When
+        val actual = Any().guardSpy { expected }
+
+        // Then
+        actual isNot null
+        actual!!.invoke() mustBe expected
+    }
+}

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxerSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxerSpec.kt
@@ -13,13 +13,7 @@ import kotlin.test.Test
 class UnitFunRelaxerSpec {
     @Test
     @JsName("fn0")
-    fun `Given relaxVoidFunction is called it returns Unit if the refered type is Unit`() {
-        relaxVoidFunction<Unit>() mustBe Unit
-    }
-
-    @Test
-    @JsName("fn1")
-    fun `Given relaxVoidFunction is called it returns Null if the refered type is not Unit`() {
-        relaxVoidFunction<Int>() mustBe null
+    fun `Given kmockUnitFunRelaxer is called it returns Unit if the refered type is Unit`() {
+        kmockUnitFunRelaxer.relax("xx") mustBe Unit
     }
 }

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxerSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/proxy/UnitFunRelaxerSpec.kt
@@ -14,6 +14,6 @@ class UnitFunRelaxerSpec {
     @Test
     @JsName("fn0")
     fun `Given kmockUnitFunRelaxer is called it returns Unit if the refered type is Unit`() {
-        kmockUnitFunRelaxer.relax("xx") mustBe Unit
+        kmockUnitFunRelaxer("xx") mustBe Unit
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #88 

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
All relaxation logic is from now on solved by the runtime part of KMock

### What is the overall concept of the implementation?
<!-- Provide a description of the implementation -->
This PR introduces 2 new components - NonIntrusiveFunConfigurator and NonIntrusivePropertyConfigurator. Both are invoked by the ProxyFactory and take care of any necessary relaxation logic, which are resolve independent from the processor.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
