### PR TITLE
Fix Source Distribution

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -69,6 +69,8 @@ toc::[]
 
 * Method names with nullable or multi-bounded types defined as generic parameter
 * Scoped extension are now correctly resolved
+* Annotation was not picked up when more then one Annotation was used
+* Factories for Common were not created when no Template was specified
 
 === Security
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -14,7 +14,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
 
 /*
- * Notices -> No deep checking in order to no drain performance
+ * Notice -> No deep checking in order to not drain performance
  */
 internal class KMockProcessor(
     private val isKmp: Boolean,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -55,10 +55,6 @@ internal class KMockProcessor(
             relaxer
         )
 
-        entryPointGenerator.generateCommon(
-            aggregated.extractedTemplates
-        )
-
         return aggregated
     }
 
@@ -86,8 +82,9 @@ internal class KMockProcessor(
         return mergeSources(commonAggregated, aggregated, filteredInterfaces)
     }
 
-    private fun stubPlatformSources(
+    private fun stubPlatformAndEntryPointSources(
         resolver: Resolver,
+        commonAggregated: Aggregated,
         sharedAggregated: Aggregated,
         relaxer: Relaxer?
     ): List<KSAnnotated> {
@@ -110,25 +107,43 @@ internal class KMockProcessor(
             relaxer
         )
 
+        entryPointGenerator.generateCommon(
+            templateSources = commonAggregated.extractedTemplates,
+            totalTemplates = totalAggregated.extractedTemplates
+        )
+
         codeGenerator.closeFiles()
         return totalAggregated.illFormed
+    }
+
+    private fun extractMetaSources(
+        resolver: Resolver,
+        relaxer: Relaxer?
+    ): Pair<Aggregated, Aggregated> {
+        return if (isKmp) {
+            val commonAggregated = stubCommonSources(resolver, relaxer)
+            val sharedAggregated = stubSharedSources(resolver, commonAggregated, relaxer)
+
+            Pair(commonAggregated, sharedAggregated)
+        } else {
+            Pair(
+                Aggregated(emptyList(), emptyList(), emptyList()),
+                Aggregated(emptyList(), emptyList(), emptyList())
+            )
+        }
     }
 
     @OptIn(KotlinPoetKspPreview::class)
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val relaxer = aggregator.extractRelaxer(resolver)
 
-        val sharedAggregated = if (isKmp) {
-            val commonAggregated = stubCommonSources(resolver, relaxer)
-            stubSharedSources(resolver, commonAggregated, relaxer)
-        } else {
-            Aggregated(emptyList(), emptyList(), emptyList())
-        }
+        val (commonAggregated, sharedAggregated) = extractMetaSources(resolver, relaxer)
 
-        return stubPlatformSources(
-            resolver,
-            sharedAggregated,
-            relaxer
+        return stubPlatformAndEntryPointSources(
+            resolver = resolver,
+            commonAggregated = commonAggregated,
+            sharedAggregated = sharedAggregated,
+            relaxer = relaxer
         )
     }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -348,6 +348,7 @@ internal interface ProcessorContract {
     interface MockFactoryEntryPointGenerator {
         fun generateCommon(
             templateSources: List<TemplateSource>,
+            totalTemplates: List<TemplateSource>,
         )
 
         fun generateShared(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
@@ -124,9 +124,10 @@ internal class KMockFactoryEntryPointGenerator(
     }
 
     override fun generateCommon(
-        templateSources: List<TemplateSource>
+        templateSources: List<TemplateSource>,
+        totalTemplates: List<TemplateSource>,
     ) {
-        if (isKmp && templateSources.isNotEmpty()) { // TODO: Solve multi Rounds in a better way
+        if (isKmp && totalTemplates.isNotEmpty()) { // TODO: Solve multi Rounds in a better way
             val file = FileSpec.builder(
                 rootPackage,
                 FACTORY_FILE_NAME

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/NoopFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/NoopFactoryGenerator.kt
@@ -20,7 +20,8 @@ internal object NoopFactoryGenerator : MockFactoryGenerator, MockFactoryEntryPoi
     ) = Unit
 
     override fun generateCommon(
-        templateSources: List<TemplateSource>
+        templateSources: List<TemplateSource>,
+        totalTemplates: List<TemplateSource>,
     ) = Unit
 
     override fun generateShared(

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
@@ -867,4 +867,54 @@ class KMockFactoriesSpec {
         actualActual!!.readText().normalizeSource() mustBe expectedActual.normalizeSource()
         actualExpect!!.readText().normalizeSource() mustBe expectedExpect.normalizeSource()
     }
+
+    @Test
+    fun `Given a annotated Source with only a Platform is processed, it writes a mock factory entryPoint`() {
+        // Given
+        val source = SourceFile.kotlin(
+            "Platform.kt",
+            loadResource("/template/nocommon/Platform.kt")
+        )
+        val expected = loadResource("/expected/nocommon/CommonExpect.kt")
+
+        // When
+        val compilerResult = compile(
+            provider,
+            isKmp = true,
+            emptyMap(),
+            source
+        )
+        val actual = resolveGenerated("kotlin/common/commonTest/kotlin/$rootPackage/MockFactory.kt")
+
+        // Then
+        compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK
+        actual isNot null
+
+        actual!!.readText().normalizeSource() mustBe expected.normalizeSource()
+    }
+
+    @Test
+    fun `Given a annotated Source only for Shared is processed, it writes a mock factory entryPoint`() {
+        // Given
+        val source = SourceFile.kotlin(
+            "Shared.kt",
+            loadResource("/template/nocommon/Shared.kt")
+        )
+        val expected = loadResource("/expected/nocommon/CommonExpect.kt")
+
+        // When
+        val compilerResult = compile(
+            provider,
+            isKmp = true,
+            emptyMap(),
+            source
+        )
+        val actual = resolveGenerated("kotlin/common/commonTest/kotlin/$rootPackage/MockFactory.kt")
+
+        // Then
+        compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK
+        actual isNot null
+
+        actual!!.readText().normalizeSource() mustBe expected.normalizeSource()
+    }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
@@ -1174,4 +1174,40 @@ class KMockMocksSpec {
         ) mustBe true
         actual.readText().normalizeSource() mustBe expected.normalizeSource()
     }
+
+    @Test
+    fun `Given a Source with multiple Annotations is processed, it writes a mock`() {
+        // Given
+        val source = SourceFile.kotlin(
+            "Sample.kt",
+            loadResource("/template/mixedannotation/Sample.kt")
+        )
+        val expectedPlatform = loadResource("/expected/mixedannotation/Platform.kt")
+        val expectedShared = loadResource("/expected/mixedannotation/Shared.kt")
+        val expectedCommon = loadResource("/expected/mixedannotation/Common.kt")
+
+        // When
+        val compilerResult = compile(
+            provider,
+            source,
+            isKmp = true,
+        )
+        val actualPlatform = resolveGenerated("PlatformMock.kt")
+        val actualShared = resolveGenerated("SharedMock.kt")
+        val actualCommon = resolveGenerated("CommonMock.kt")
+
+        // Then
+        compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK
+
+        actualShared!!.absolutePath.toString().endsWith(
+            "shared/sharedTest/kotlin/mock/template/mixedannotation/SharedMock.kt"
+        ) mustBe true
+        actualCommon!!.absolutePath.toString().endsWith(
+            "common/commonTest/kotlin/mock/template/mixedannotation/CommonMock.kt"
+        ) mustBe true
+
+        actualPlatform!!.readText().normalizeSource() mustBe expectedPlatform.normalizeSource()
+        actualShared.readText().normalizeSource() mustBe expectedShared.normalizeSource()
+        actualCommon.readText().normalizeSource() mustBe expectedCommon.normalizeSource()
+    }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorCommonSpec.kt
@@ -23,7 +23,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
+import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
@@ -55,7 +57,7 @@ class KMockAggregatorCommonSpec {
     @Test
     fun `Given extractCommonInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
         // Given
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
 
         val annotation1: KSAnnotation = mockk()
@@ -66,7 +68,7 @@ class KMockAggregatorCommonSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         every {
@@ -81,7 +83,7 @@ class KMockAggregatorCommonSpec {
             annotation2.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns fixture.fixture()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         // When
         val (illegal, _, _) = KMockAggregator(
@@ -94,7 +96,7 @@ class KMockAggregatorCommonSpec {
         ).extractCommonInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source)
+        illegal mustBe listOf(symbol)
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
@@ -103,7 +105,7 @@ class KMockAggregatorCommonSpec {
     @Test
     fun `Given extractCommonInterfaces is called it filters all ill Annotations`() {
         // Given
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
 
         val annotation: KSAnnotation = mockk()
@@ -112,7 +114,7 @@ class KMockAggregatorCommonSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         every {
@@ -125,7 +127,7 @@ class KMockAggregatorCommonSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockCommon::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         // When
         val (illegal, _, _) = KMockAggregator(
@@ -138,7 +140,7 @@ class KMockAggregatorCommonSpec {
         ).extractCommonInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source)
+        illegal mustBe listOf(symbol)
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
@@ -148,7 +150,7 @@ class KMockAggregatorCommonSpec {
     fun `Given extractCommonInterfaces is called it filters all non class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -158,7 +160,7 @@ class KMockAggregatorCommonSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -175,7 +177,7 @@ class KMockAggregatorCommonSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockCommon::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -183,7 +185,7 @@ class KMockAggregatorCommonSpec {
         every { arguments[0].value } returns values
         every { type.declaration } returns declaration
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { logger.error(any()) } just Runs
 
@@ -208,7 +210,7 @@ class KMockAggregatorCommonSpec {
     fun `Given extractCommonInterfaces is called it filters all implementation class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -228,7 +230,7 @@ class KMockAggregatorCommonSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -248,7 +250,7 @@ class KMockAggregatorCommonSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockCommon::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -260,7 +262,7 @@ class KMockAggregatorCommonSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -288,7 +290,7 @@ class KMockAggregatorCommonSpec {
     fun `Given extractCommonInterfaces is called it returns all found interfaces`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -298,7 +300,7 @@ class KMockAggregatorCommonSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -325,7 +327,7 @@ class KMockAggregatorCommonSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockCommon::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -337,7 +339,7 @@ class KMockAggregatorCommonSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -369,7 +371,7 @@ class KMockAggregatorCommonSpec {
     fun `Given extractCommonInterfaces is called it returns the corresponding source files`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -379,7 +381,7 @@ class KMockAggregatorCommonSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -399,7 +401,7 @@ class KMockAggregatorCommonSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockCommon::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -411,7 +413,93 @@ class KMockAggregatorCommonSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
+
+        every { declaration.qualifiedName!!.asString() } returns className
+        every { declaration.packageName.asString() } returns packageName
+
+        every { logger.error(any()) } just Runs
+
+        // When
+        val (_, _, sourceFiles) = KMockAggregator(
+            logger,
+            mockk(),
+            mockk(),
+            mockk(relaxed = true),
+            emptyMap(),
+            emptyMap(),
+        ).extractCommonInterfaces(resolver)
+
+        // Then
+        sourceFiles mustBe listOf(file)
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+        }
+    }
+
+    @Test
+    fun `Given extractCommonInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
+        // Given
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val notRelatedSymbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val notRelatedAnnotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+        }
+
+        val notRelatedSource: Sequence<KSAnnotation> = sequence {
+            yield(notRelatedAnnotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(notRelatedSymbol)
+            yield(notRelatedSymbol)
+            yield(symbol)
+        }
+
+        val type: KSType = mockk(relaxed = true)
+        val declaration: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type)
+
+        val className: String = fixture.fixture(named("stringAlpha"))
+        val packageName: String = fixture.fixture(named("stringAlpha"))
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every {
+            notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returnsMany listOf(
+            MockShared::class.qualifiedName!!,
+            Mock::class.qualifiedName!!
+        )
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns MockCommon::class.qualifiedName!!
+
+        every { symbol.annotations } returns sourceAnnotations
+        every { notRelatedSymbol.annotations } returns notRelatedSource
+
+        every { annotation.arguments } returns arguments
+        every { arguments.size } returns 1
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns values
+        every { type.declaration } returns declaration
+        every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -439,7 +527,7 @@ class KMockAggregatorCommonSpec {
     fun `Given extractCommonInterfaces is called it returns while mapping aliases`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val sourceSetValidator: ProcessorContract.SourceSetValidator = mockk()
@@ -450,7 +538,7 @@ class KMockAggregatorCommonSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -480,7 +568,7 @@ class KMockAggregatorCommonSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockCommon::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -494,7 +582,7 @@ class KMockAggregatorCommonSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorPlatformSpec.kt
@@ -24,6 +24,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.Mock
+import tech.antibytes.kmock.MockCommon
+import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
@@ -55,7 +57,7 @@ class KMockAggregatorPlatformSpec {
     @Test
     fun `Given extractPlatformInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
         // Given
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
 
         val annotation1: KSAnnotation = mockk()
@@ -66,7 +68,7 @@ class KMockAggregatorPlatformSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         every {
@@ -81,7 +83,7 @@ class KMockAggregatorPlatformSpec {
             annotation2.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns fixture.fixture()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         // When
         val (illegal, _, _) = KMockAggregator(
@@ -94,7 +96,7 @@ class KMockAggregatorPlatformSpec {
         ).extractPlatformInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source)
+        illegal mustBe listOf(symbol)
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
@@ -103,7 +105,7 @@ class KMockAggregatorPlatformSpec {
     @Test
     fun `Given extractPlatformInterfaces is called it filters all ill Annotations`() {
         // Given
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
 
         val annotation: KSAnnotation = mockk()
@@ -112,7 +114,7 @@ class KMockAggregatorPlatformSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         every {
@@ -125,7 +127,7 @@ class KMockAggregatorPlatformSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns Mock::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         // When
         val (illegal, _, _) = KMockAggregator(
@@ -138,7 +140,7 @@ class KMockAggregatorPlatformSpec {
         ).extractPlatformInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source)
+        illegal mustBe listOf(symbol)
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
@@ -148,7 +150,7 @@ class KMockAggregatorPlatformSpec {
     fun `Given extractPlatformInterfaces is called it filters all non class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -158,7 +160,7 @@ class KMockAggregatorPlatformSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -175,7 +177,7 @@ class KMockAggregatorPlatformSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns Mock::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -183,7 +185,7 @@ class KMockAggregatorPlatformSpec {
         every { arguments[0].value } returns values
         every { type.declaration } returns declaration
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { logger.error(any()) } just Runs
 
@@ -208,7 +210,7 @@ class KMockAggregatorPlatformSpec {
     fun `Given extractPlatformInterfaces is called it filters all implementation class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -228,7 +230,7 @@ class KMockAggregatorPlatformSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -248,7 +250,7 @@ class KMockAggregatorPlatformSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns Mock::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -260,7 +262,7 @@ class KMockAggregatorPlatformSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -288,7 +290,7 @@ class KMockAggregatorPlatformSpec {
     fun `Given extractPlatformInterfaces is called it returns all found interfaces`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -298,7 +300,7 @@ class KMockAggregatorPlatformSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -325,7 +327,7 @@ class KMockAggregatorPlatformSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns Mock::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -337,7 +339,7 @@ class KMockAggregatorPlatformSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -370,7 +372,7 @@ class KMockAggregatorPlatformSpec {
     fun `Given extractPlatformInterfaces is called it returns the corresponding source files`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
 
@@ -380,7 +382,7 @@ class KMockAggregatorPlatformSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -400,7 +402,7 @@ class KMockAggregatorPlatformSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns Mock::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.size } returns 1
@@ -412,7 +414,95 @@ class KMockAggregatorPlatformSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
+
+        every { declaration.qualifiedName!!.asString() } returns className
+        every { declaration.packageName.asString() } returns packageName
+
+        every { logger.error(any()) } just Runs
+
+        // When
+        val (_, _, sourceFiles) = KMockAggregator(
+            logger,
+            mockk(),
+            mockk(),
+            mockk(relaxed = true),
+            emptyMap(),
+            emptyMap(),
+        ).extractPlatformInterfaces(resolver)
+
+        // Then
+        sourceFiles mustBe listOf(file)
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+        }
+    }
+
+    @Test
+    fun `Given extractPlatformInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
+        // Given
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val notRelatedSymbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val notRelatedAnnotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+        }
+
+        val notRelatedSource: Sequence<KSAnnotation> = sequence {
+            yield(notRelatedAnnotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(notRelatedSymbol)
+            yield(notRelatedSymbol)
+            yield(symbol)
+        }
+
+        val type: KSType = mockk(relaxed = true)
+        val declaration: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type)
+
+        val className: String = fixture.fixture(named("stringAlpha"))
+        val packageName: String = fixture.fixture(named("stringAlpha"))
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every {
+            notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returnsMany listOf(
+            MockShared::class.qualifiedName!!,
+            MockCommon::class.qualifiedName!!
+        )
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns Mock::class.qualifiedName!!
+
+        every { symbol.annotations } returns sourceAnnotations
+        every { notRelatedSymbol.annotations } returns notRelatedSource
+
+        every { annotation.arguments } returns arguments
+        every { arguments.isEmpty() } returns false
+
+        every { arguments.size } returns 1
+        every { arguments[0].value } returns values
+
+        every { type.declaration } returns declaration
+        every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -440,10 +530,9 @@ class KMockAggregatorPlatformSpec {
     fun `Given extractPlatformInterfaces is called it returns while mapping aliases`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
-        val sourceSetValidator: ProcessorContract.SourceSetValidator = mockk()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -451,7 +540,7 @@ class KMockAggregatorPlatformSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -481,7 +570,7 @@ class KMockAggregatorPlatformSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns Mock::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -495,14 +584,12 @@ class KMockAggregatorPlatformSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
 
         every { logger.error(any()) } just Runs
-
-        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
@@ -510,7 +597,7 @@ class KMockAggregatorPlatformSpec {
         val (_, interfaces, _) = KMockAggregator(
             logger,
             mockk(),
-            sourceSetValidator,
+            mockk(),
             genericResolver,
             emptyMap(),
             mapping,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorSharedSpec.kt
@@ -23,6 +23,8 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.Mock
+import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
@@ -60,7 +62,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation or CustomAnnotation was found`() {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 3)
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
 
         val annotation1: KSAnnotation = mockk()
@@ -71,7 +73,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         every {
@@ -86,7 +88,7 @@ class KMockAggregatorSharedSpec {
             annotation2.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns fixture.fixture()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         // When
         val (illegal, _, _) = KMockAggregator(
@@ -99,7 +101,7 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source, source, source, source)
+        illegal mustBe listOf(symbol, symbol, symbol, symbol)
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
         }
@@ -114,7 +116,7 @@ class KMockAggregatorSharedSpec {
     @Test
     fun `Given extractSharedInterfaces is called it filters illegal shared sources`() {
         // Given
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val logger: KSPLogger = mockk()
         val resolver: Resolver = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -125,7 +127,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val arguments: List<KSValueArgument> = listOf(
@@ -137,7 +139,7 @@ class KMockAggregatorSharedSpec {
             resolver.getSymbolsWithAnnotation(any(), any())
         } returns annotated
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
@@ -159,7 +161,7 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source)
+        illegal mustBe listOf(symbol)
 
         verify(exactly = 1) {
             sourceSetValidator.isValidateSourceSet(annotation)
@@ -173,7 +175,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it filters illegal custom shared sources`() {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 3)
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val logger: KSPLogger = mockk()
         val resolver: Resolver = mockk()
         val annotationFilter: AnnotationFilter = mockk()
@@ -185,7 +187,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val arguments: List<KSValueArgument> = listOf(
@@ -197,7 +199,7 @@ class KMockAggregatorSharedSpec {
             resolver.getSymbolsWithAnnotation(any(), any())
         } returns annotated
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
@@ -219,7 +221,7 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source, source, source, source)
+        illegal mustBe listOf(symbol, symbol, symbol, symbol)
 
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation)
@@ -240,7 +242,7 @@ class KMockAggregatorSharedSpec {
     @Test
     fun `Given extractSharedInterfaces is called it filters all ill Shared Annotations`() {
         // Given
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
 
@@ -250,7 +252,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         every {
@@ -265,7 +267,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockShared::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         // When
         val (illegal, _, _) = KMockAggregator(
@@ -278,7 +280,7 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source)
+        illegal mustBe listOf(symbol)
         verify(exactly = 1) {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
@@ -291,7 +293,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it filters all ill custom Shared Annotations`() {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 3)
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val annotationFilter: AnnotationFilter = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -302,7 +304,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         every {
@@ -317,7 +319,7 @@ class KMockAggregatorSharedSpec {
 
         every { annotationFilter.isApplicableAnnotation(any()) } returns true
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         // When
         val (illegal, _, _) = KMockAggregator(
@@ -330,7 +332,7 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        illegal mustBe listOf(source, source, source, source)
+        illegal mustBe listOf(symbol, symbol, symbol, symbol)
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
@@ -351,7 +353,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it filters all non class types and reports an error for Shared Sources`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -362,7 +364,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -381,7 +383,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockShared::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -390,7 +392,7 @@ class KMockAggregatorSharedSpec {
         every { arguments.size } returns 2
         every { type.declaration } returns declaration
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { logger.error(any()) } just Runs
 
@@ -421,7 +423,7 @@ class KMockAggregatorSharedSpec {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val annotationFilter: AnnotationFilter = mockk()
@@ -433,7 +435,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -452,16 +454,18 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns customAnnotations.keys.random()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
+
         every { arguments.isEmpty() } returns false
         every { arguments[0].value } returns allowedSourceSets.first()
         every { arguments[1].value } returns values
         every { arguments.size } returns 2
+
         every { type.declaration } returns declaration
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { logger.error(any()) } just Runs
 
@@ -499,7 +503,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it filters all implementation class types and reports an error for Shared Sources`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -520,7 +524,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -541,7 +545,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockShared::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -554,7 +558,7 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -588,7 +592,7 @@ class KMockAggregatorSharedSpec {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val annotationFilter: AnnotationFilter = mockk()
@@ -610,7 +614,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -631,7 +635,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns customAnnotations.keys.random()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -644,7 +648,7 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -685,7 +689,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it returns all found interfaces for SharedSources`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -697,7 +701,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -724,7 +728,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockShared::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -737,7 +741,7 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -778,7 +782,7 @@ class KMockAggregatorSharedSpec {
             fixture.fixture<String>() to marker
         )
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val annotationFilter: AnnotationFilter = mockk()
@@ -790,7 +794,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -817,7 +821,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns customAnnotations.keys.random()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -830,7 +834,7 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -1126,7 +1130,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it returns the corresponding source files for Shared Sources`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -1137,7 +1141,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -1160,7 +1164,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockShared::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -1173,7 +1177,7 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -1207,7 +1211,7 @@ class KMockAggregatorSharedSpec {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 1)
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val annotationFilter: AnnotationFilter = mockk()
@@ -1219,7 +1223,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -1242,7 +1246,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns customAnnotations.keys.random()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -1255,7 +1259,202 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
+
+        every { declaration.qualifiedName!!.asString() } returns className
+        every { declaration.packageName.asString() } returns packageName
+
+        every { logger.error(any()) } just Runs
+
+        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+
+        // When
+        val (_, _, sourceFiles) = KMockAggregator(
+            logger,
+            annotationFilter,
+            sourceSetValidator,
+            mockk(relaxed = true),
+            customAnnotations,
+            emptyMap(),
+        ).extractSharedInterfaces(resolver)
+
+        // Then
+        sourceFiles mustBe listOf(file, file)
+        verify(exactly = 2) {
+            annotationFilter.isApplicableAnnotation(annotation)
+        }
+        verify(exactly = 0) {
+            sourceSetValidator.isValidateSourceSet(annotation)
+        }
+
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+        }
+        customAnnotations.forEach { (annotation, _) ->
+            verify(exactly = 1) {
+                resolver.getSymbolsWithAnnotation(annotation, false)
+            }
+        }
+    }
+
+    @Test
+    fun `Given getSymbolsWithAnnotation is called it returns the corresponding source files, while filter non related annotations`() {
+        // Given
+        val sourceSetValidator: SourceSetValidator = mockk()
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val notRelatedSymbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val notRelatedAnnotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+        }
+
+        val notRelatedSource: Sequence<KSAnnotation> = sequence {
+            yield(notRelatedAnnotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(notRelatedSymbol)
+            yield(notRelatedSymbol)
+            yield(symbol)
+        }
+
+        val type: KSType = mockk(relaxed = true)
+        val declaration: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type)
+
+        val className: String = fixture.fixture(named("stringAlpha"))
+        val packageName: String = fixture.fixture(named("stringAlpha"))
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every {
+            notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returnsMany listOf(
+            Mock::class.qualifiedName!!,
+            MockCommon::class.qualifiedName!!
+        )
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns MockShared::class.qualifiedName!!
+
+        every { symbol.annotations } returns sourceAnnotations
+        every { notRelatedSymbol.annotations } returns notRelatedSource
+
+        every { annotation.arguments } returns arguments
+        every { arguments.size } returns 1
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns values
+        every { type.declaration } returns declaration
+        every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
+
+        every { declaration.qualifiedName!!.asString() } returns className
+        every { declaration.packageName.asString() } returns packageName
+
+        every { logger.error(any()) } just Runs
+
+        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
+
+        // When
+        val (_, _, sourceFiles) = KMockAggregator(
+            logger,
+            mockk(),
+            sourceSetValidator,
+            mockk(relaxed = true),
+            emptyMap(),
+            emptyMap(),
+        ).extractSharedInterfaces(resolver)
+
+        // Then
+        sourceFiles mustBe listOf(file)
+        verify(exactly = 1) {
+            sourceSetValidator.isValidateSourceSet(annotation)
+        }
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+        }
+    }
+
+    @Test
+    fun `Given getSymbolsWithAnnotation is called it returns the corresponding source files, while filter non related annotations for custom annotations`() {
+        // Given
+        val customAnnotations: Map<String, String> = fixture.mapFixture(size = 1)
+        val annotationFilter: AnnotationFilter = mockk()
+        val sourceSetValidator: SourceSetValidator = mockk()
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val notRelatedSymbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val notRelatedAnnotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+        }
+
+        val notRelatedSource: Sequence<KSAnnotation> = sequence {
+            yield(notRelatedAnnotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(notRelatedSymbol)
+            yield(notRelatedSymbol)
+            yield(symbol)
+        }
+
+        val type: KSType = mockk(relaxed = true)
+        val declaration: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type)
+
+        val className: String = fixture.fixture(named("stringAlpha"))
+        val packageName: String = fixture.fixture(named("stringAlpha"))
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every {
+            notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returnsMany listOf(
+            Mock::class.qualifiedName!!,
+            MockCommon::class.qualifiedName!!
+        )
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns customAnnotations.keys.random()
+
+        every { symbol.annotations } returns sourceAnnotations
+        every { notRelatedSymbol.annotations } returns notRelatedSource
+
+        every { annotation.arguments } returns arguments
+        every { arguments.size } returns 1
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns values
+        every { type.declaration } returns declaration
+        every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -1297,7 +1496,7 @@ class KMockAggregatorSharedSpec {
     fun `Given extractSharedInterfaces is called it returns while mapping aliases`() {
         // Given
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -1308,7 +1507,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -1341,7 +1540,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns MockShared::class.qualifiedName!!
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -1356,7 +1555,7 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
@@ -1391,7 +1590,7 @@ class KMockAggregatorSharedSpec {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 1)
         val logger: KSPLogger = mockk()
-        val source: KSAnnotated = mockk()
+        val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
         val annotationFilter: AnnotationFilter = mockk()
@@ -1403,7 +1602,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
-            yield(source)
+            yield(symbol)
         }
 
         val type: KSType = mockk(relaxed = true)
@@ -1436,7 +1635,7 @@ class KMockAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns customAnnotations.keys.random()
 
-        every { source.annotations } returns sourceAnnotations
+        every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
@@ -1451,7 +1650,7 @@ class KMockAggregatorSharedSpec {
         every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
-        every { source.parent } returns file
+        every { symbol.parent } returns file
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
@@ -70,7 +70,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
         every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
-        every { entryPointGenerator.generateCommon(any()) } just Runs
+        every { entryPointGenerator.generateCommon(any(), any()) } just Runs
         every { entryPointGenerator.generateShared(any()) } just Runs
 
         // When
@@ -139,7 +139,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
         every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
-        every { entryPointGenerator.generateCommon(any()) } just Runs
+        every { entryPointGenerator.generateCommon(any(), any()) } just Runs
         every { entryPointGenerator.generateShared(any()) } just Runs
 
         // When
@@ -188,7 +188,14 @@ class KMockProcessorSpec {
         }
 
         verify(exactly = 1) {
-            entryPointGenerator.generateCommon(interfacesCommon)
+            entryPointGenerator.generateCommon(
+                interfacesCommon,
+                listOf(
+                    interfacesCommon.first(),
+                    interfacesFiltered.first(),
+                    interfacesFiltered.first(),
+                )
+            )
         }
 
         verify(exactly = 1) { entryPointGenerator.generateShared(interfacesFiltered) }
@@ -234,7 +241,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
         every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
-        every { entryPointGenerator.generateCommon(any()) } just Runs
+        every { entryPointGenerator.generateCommon(any(), any()) } just Runs
 
         // When
         KMockProcessor(
@@ -276,7 +283,7 @@ class KMockProcessorSpec {
         }
 
         verify(exactly = 0) {
-            entryPointGenerator.generateCommon(interfacesCommon)
+            entryPointGenerator.generateCommon(interfacesCommon, interfacesFiltered)
         }
 
         verify(exactly = 1) { codeGenerator.closeFiles() }

--- a/kmock-processor/src/test/resources/factory/expected/nocommon/CommonExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/nocommon/CommonExpect.kt
@@ -1,0 +1,16 @@
+@file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+
+package generatorTest
+
+import kotlin.Boolean
+import kotlin.Suppress
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+
+internal expect inline fun <reified Mock> kmock(
+    verifier: KMockContract.Collector = NoopCollector,
+    relaxed: Boolean = false,
+    relaxUnitFun: Boolean = false,
+    freeze: Boolean = true,
+): Mock

--- a/kmock-processor/src/test/resources/factory/template/nocommon/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/template/nocommon/Platform.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package factory.template.nocommon
+
+import tech.antibytes.kmock.Mock
+
+@Mock(Platform::class)
+interface Platform {
+    val foo: String
+    val bar: Int
+        get() = foo.length
+
+    var buzz: Any
+}

--- a/kmock-processor/src/test/resources/factory/template/nocommon/Shared.kt
+++ b/kmock-processor/src/test/resources/factory/template/nocommon/Shared.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package factory.template.nocommon
+
+import tech.antibytes.kmock.MockShared
+
+@MockShared("sharedTest", Shared::class)
+interface Shared {
+    val foo: String
+    val bar: Int
+        get() = foo.length
+
+    var buzz: Any
+}

--- a/kmock-processor/src/test/resources/mock/expected/mixedannotation/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/mixedannotation/Common.kt
@@ -1,0 +1,32 @@
+package mock.template.mixedannotation
+
+import kotlin.Boolean
+import kotlin.Suppress
+import kotlin.Unit
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+import tech.antibytes.kmock.proxy.ProxyFactory
+
+internal class CommonMock(
+    verifier: KMockContract.Collector = NoopCollector,
+    @Suppress("UNUSED_PARAMETER")
+    spyOn: Common? = null,
+    freeze: Boolean = true,
+    @Suppress("unused")
+    private val relaxUnitFun: Boolean = false,
+    @Suppress("unused")
+    private val relaxed: Boolean = false,
+) : Common {
+    public val _doSomething: KMockContract.SyncFunProxy<Unit, () -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.mixedannotation.CommonMock#_doSomething",
+            collector = verifier, freeze = freeze)
+
+    public override fun doSomething(): Unit = _doSomething.invoke() {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public fun _clearMock(): Unit {
+        _doSomething.clear()
+    }
+}

--- a/kmock-processor/src/test/resources/mock/expected/mixedannotation/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/mixedannotation/Platform.kt
@@ -1,0 +1,32 @@
+package mock.template.mixedannotation
+
+import kotlin.Boolean
+import kotlin.Suppress
+import kotlin.Unit
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+import tech.antibytes.kmock.proxy.ProxyFactory
+
+internal class PlatformMock(
+    verifier: KMockContract.Collector = NoopCollector,
+    @Suppress("UNUSED_PARAMETER")
+    spyOn: Platform? = null,
+    freeze: Boolean = true,
+    @Suppress("unused")
+    private val relaxUnitFun: Boolean = false,
+    @Suppress("unused")
+    private val relaxed: Boolean = false,
+) : Platform {
+    public val _doSomething: KMockContract.SyncFunProxy<Unit, () -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.mixedannotation.PlatformMock#_doSomething",
+            collector = verifier, freeze = freeze)
+
+    public override fun doSomething(): Unit = _doSomething.invoke() {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public fun _clearMock(): Unit {
+        _doSomething.clear()
+    }
+}

--- a/kmock-processor/src/test/resources/mock/expected/mixedannotation/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/mixedannotation/Shared.kt
@@ -1,0 +1,32 @@
+package mock.template.mixedannotation
+
+import kotlin.Boolean
+import kotlin.Suppress
+import kotlin.Unit
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+import tech.antibytes.kmock.proxy.ProxyFactory
+
+internal class SharedMock(
+    verifier: KMockContract.Collector = NoopCollector,
+    @Suppress("UNUSED_PARAMETER")
+    spyOn: Shared? = null,
+    freeze: Boolean = true,
+    @Suppress("unused")
+    private val relaxUnitFun: Boolean = false,
+    @Suppress("unused")
+    private val relaxed: Boolean = false,
+) : Shared {
+    public val _doSomething: KMockContract.SyncFunProxy<Unit, () -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.mixedannotation.SharedMock#_doSomething",
+            collector = verifier, freeze = freeze)
+
+    public override fun doSomething(): Unit = _doSomething.invoke() {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public fun _clearMock(): Unit {
+        _doSomething.clear()
+    }
+}

--- a/kmock-processor/src/test/resources/mock/template/mixedannotation/Sample.kt
+++ b/kmock-processor/src/test/resources/mock/template/mixedannotation/Sample.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package mock.template.mixedannotation
+
+import tech.antibytes.kmock.Mock
+import tech.antibytes.kmock.MockShared
+import tech.antibytes.kmock.MockCommon
+
+@MockCommon(Common::class)
+@MockShared(
+    "sharedTest",
+    Shared::class
+)
+@Mock(Platform::class)
+interface Platform {
+    fun doSomething()
+}
+
+interface Shared {
+    fun doSomething()
+}
+
+interface Common {
+    fun doSomething()
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #124 

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This fixes the issue of more then one Annotation for test set and the not working creation of the factories for Common.

### What is the overall concept of the implementation?
<!-- Provide a description of the implementation -->
1) The root cause was KSP since it merges all Annotated in each sequence per annotation, therefore the Aggregator did not picked up the Annotation correctly. Now the specific Annotation is propagated per aggregation method down to filter the given sequence instead of just take the first Annotation which is related to KMock.

2) Simply the entryPoint creation has changed it location to `process` to enforce the creation of the factories for Common.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
