### PR TITLE
Add instrumented AndroidTest support for KMP

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,6 +42,7 @@ toc::[]
 * `assertOrder` in order to make the names more consistent and preserves the old behaviour of `verifyStrictOrder`
 * `assertProxy` as alternative to `verify`
 * iosSimulatorArm64 support
+* support for instrumented Android tests (aka androidAndroidTest) on KMP
 
 === Changed
 

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -33,7 +33,10 @@ ksp {
 }
 
 kotlin {
-    android()
+    android {
+        publishAllLibraryVariants()
+        publishLibraryVariantsGroupedByFlavor = true
+    }
 
     js(IR) {
         nodejs()
@@ -91,7 +94,12 @@ kotlin {
                 implementation(Dependency.multiplatform.kotlin.android)
             }
         }
-        val androidAndroidTestRelease by getting
+        val androidAndroidTestRelease by getting {
+            kotlin.srcDir("build/generated/ksp/android/androidReleaseAndroidTest")
+        }
+        val androidAndroidTestDebug by getting {
+            kotlin.srcDir("build/generated/ksp/android/androidDebugAndroidTest")
+        }
         val androidTestFixtures by getting
         val androidTestFixturesDebug by getting
         val androidTestFixturesRelease by getting
@@ -99,15 +107,25 @@ kotlin {
             kotlin.srcDir("build/generated/ksp/android/androidTest")
 
             dependsOn(concurrentTest)
-            dependsOn(androidAndroidTestRelease)
             dependsOn(androidTestFixtures)
             dependsOn(androidTestFixturesDebug)
             dependsOn(androidTestFixturesRelease)
+            dependsOn(androidAndroidTestRelease)
 
             dependencies {
                 implementation(Dependency.multiplatform.test.jvm)
                 implementation(Dependency.multiplatform.test.junit)
                 implementation(Dependency.android.test.robolectric)
+            }
+        }
+
+        val androidAndroidTest by getting {
+            dependsOn(concurrentTest)
+
+            dependencies {
+                implementation(Dependency.multiplatform.test.jvm)
+                implementation(Dependency.android.test.junit)
+                implementation(Dependency.android.test.junit5)
             }
         }
 
@@ -192,10 +210,41 @@ kotlin {
 }
 
 dependencies {
+    androidTestImplementation("org.junit.jupiter:junit-jupiter")
+    add("kspAndroidAndroidTest", project(":kmock-processor"))
     add("kspJvmTest", project(":kmock-processor"))
     add("kspAndroidTest", project(":kmock-processor"))
     add("kspJsTest", project(":kmock-processor"))
     add("kspLinuxX64Test", project(":kmock-processor"))
     add("kspIosX64Test", project(":kmock-processor"))
     add("kspIosSimulatorArm64Test", project(":kmock-processor"))
+}
+
+android {
+    defaultConfig {
+        minSdk = 30
+    }
+
+    sourceSets {
+        val androidTest = getByName("androidTest")
+        androidTest.java.setSrcDirs(setOf("src/androidAndroidTest/kotlin"))
+        androidTest.res.setSrcDirs(setOf("src/androidAndroidTest/res"))
+    }
+
+    packagingOptions {
+        resources.excludes.addAll(
+            setOf(
+                "META-INF/DEPENDENCIES",
+                "META-INF/LICENSE",
+                "META-INF/LICENSE.md",
+                "META-INF/LICENSE.txt",
+                "META-INF/license.txt",
+                "META-INF/LICENSE-notice.md",
+                "META-INF/NOTICE",
+                "META-INF/NOTICE.txt",
+                "META-INF/notice.txt",
+                "META-INF/ASL2.0"
+            )
+        )
+    }
 }

--- a/examples/src/androidAndroidTest/kotlin/tech/antibytes/kmock/example/AndroidSampleControllerAutoStubSpec.kt
+++ b/examples/src/androidAndroidTest/kotlin/tech/antibytes/kmock/example/AndroidSampleControllerAutoStubSpec.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.example
+
+import co.touchlab.stately.concurrency.AtomicReference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.Mock
+import tech.antibytes.kmock.example.contract.AndroidThing
+import tech.antibytes.kmock.example.contract.AndroidThingMock
+import tech.antibytes.kmock.example.contract.ExampleContract
+import tech.antibytes.kmock.example.contract.ExampleContract.SampleDomainObject
+import tech.antibytes.kmock.example.contract.ExampleContract.SampleLocalRepository
+import tech.antibytes.kmock.example.contract.ExampleContract.SampleRemoteRepository
+import tech.antibytes.kmock.example.contract.SampleDomainObjectMock
+import tech.antibytes.kmock.example.contract.SampleLocalRepositoryMock
+import tech.antibytes.kmock.example.contract.SampleRemoteRepositoryMock
+import tech.antibytes.kmock.verification.Asserter
+import tech.antibytes.kmock.verification.assertOrder
+import tech.antibytes.kmock.verification.verify
+import tech.antibytes.kmock.verification.verifyOrder
+import tech.antibytes.util.test.coroutine.clearBlockingTest
+import tech.antibytes.util.test.coroutine.defaultTestContext
+import tech.antibytes.util.test.coroutine.runBlockingTestWithTimeout
+import tech.antibytes.util.test.coroutine.runBlockingTestWithTimeoutInScope
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.fixture.listFixture
+import tech.antibytes.util.test.fulfils
+import tech.antibytes.util.test.mustBe
+
+@Mock(
+    SampleRemoteRepository::class,
+    SampleLocalRepository::class,
+    SampleDomainObject::class,
+    ExampleContract.DecoderFactory::class,
+    AndroidThing::class
+)
+@Disabled
+class AndroidSampleControllerAutoStubSpec {
+    private val fixture = kotlinFixture()
+    private val verifier = Asserter()
+    private val local = SampleLocalRepositoryMock(verifier)
+    private val remote = SampleRemoteRepositoryMock(verifier)
+    private val domainObject = SampleDomainObjectMock(verifier)
+    private val androidThing = AndroidThingMock()
+
+    @BeforeEach
+    fun setUp() {
+        verifier.clear()
+        local._clearMock()
+        remote._clearMock()
+        domainObject._clearMock()
+        clearBlockingTest()
+    }
+
+    @Test
+    fun `It fulfils SampleController`() {
+        SampleController(local, remote) fulfils ExampleContract.SampleController::class
+    }
+
+    @Test
+    fun `Given fetchAndStore it fetches and stores DomainObjects`() {
+        // Given
+        val url = fixture.fixture<String>()
+        val id = fixture.listFixture<String>(size = 2)
+        val number = fixture.fixture<Int>()
+
+        domainObject._id.getMany = id
+        domainObject._value.get = number
+
+        remote._fetch.returnValue = domainObject
+        local._store.returnValue = domainObject
+
+        // When
+        val controller = SampleController(local, remote)
+        return runBlockingTestWithTimeout {
+            val actual = controller.fetchAndStore(url)
+
+            // Then
+            actual mustBe domainObject
+
+            verify(exactly = 1) { remote._fetch.hasBeenStrictlyCalledWith(url) }
+            verify(exactly = 1) { local._store.hasBeenStrictlyCalledWith(id[1], number) }
+
+            verifier.assertOrder {
+                remote._fetch.hasBeenStrictlyCalledWith(url)
+                domainObject._id.wasGotten()
+                domainObject._id.wasSet()
+                domainObject._id.wasGotten()
+                domainObject._value.wasGotten()
+                local._store.hasBeenCalledWith(id[1])
+            }
+
+            verifier.verifyOrder {
+                remote._fetch.hasBeenCalledWith(url)
+                domainObject._id.wasSetTo("42")
+                local._store.hasBeenCalledWith(id[1])
+            }
+        }
+    }
+
+    @Test
+    fun `Given find it fetches a DomainObjects`() {
+        // Given
+        val idOrg = fixture.fixture<String>()
+        val id = fixture.fixture<String>()
+        val number = fixture.fixture<Int>()
+
+        domainObject._id.get = id
+        domainObject._value.get = number
+
+        remote._find.returnValue = domainObject
+        local._contains.sideEffect = { true }
+        local._fetch.returnValue = domainObject
+
+        // When
+        val controller = SampleController(local, remote)
+        val doRef = AtomicReference(domainObject)
+        val contextRef = AtomicReference(defaultTestContext)
+
+        return runBlockingTestWithTimeoutInScope(defaultTestContext) {
+            // When
+            controller.find(idOrg)
+                .onEach { actual -> actual mustBe doRef.get() }
+                .launchIn(CoroutineScope(contextRef.get()))
+
+            delay(20)
+
+            verify(exactly = 1) { local._contains.hasBeenStrictlyCalledWith(idOrg) }
+            verify(exactly = 2) { local._fetch.hasBeenStrictlyCalledWith(id) }
+            verify(exactly = 2) { remote._find.hasBeenStrictlyCalledWith(idOrg) }
+
+            verifier.assertOrder {
+                local._contains.hasBeenStrictlyCalledWith(idOrg)
+                remote._find.hasBeenStrictlyCalledWith(idOrg)
+                domainObject._id.wasGotten()
+                local._fetch.hasBeenStrictlyCalledWith(id)
+                domainObject._id.wasGotten()
+                local._fetch.hasBeenStrictlyCalledWith(id)
+                remote._find.hasBeenStrictlyCalledWith(idOrg)
+                domainObject._id.wasSet()
+            }
+
+            verifier.verifyOrder {
+                local._contains.hasBeenCalledWithout("abc")
+                remote._find.hasBeenStrictlyCalledWith(idOrg)
+                remote._find.hasBeenStrictlyCalledWith(idOrg)
+            }
+        }
+    }
+}

--- a/examples/src/androidMain/kotlin/tech/antibytes/kmock/example/contract/AndroidThing.kt
+++ b/examples/src/androidMain/kotlin/tech/antibytes/kmock/example/contract/AndroidThing.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.example.contract
+
+interface AndroidThing {
+    fun doSomeAndroidThings()
+}

--- a/gradlePlugin/kmock-dependency/src/main/kotlin/tech/antibytes/gradle/kmock/dependency/Version.kt
+++ b/gradlePlugin/kmock-dependency/src/main/kotlin/tech/antibytes/gradle/kmock/dependency/Version.kt
@@ -20,7 +20,7 @@ object Version {
         /**
          * [AnitBytes GradlePlugins](https://github.com/bitPogo/gradle-plugins)
          */
-        const val antibytes = "1b95abe"
+        const val antibytes = "e5793eb"
 
         /**
          * [Spotless](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless)
@@ -36,7 +36,7 @@ object Version {
     val antibytes = Antibytes
 
     object Antibytes {
-        const val test = "dd59a45"
+        const val test = "5238ed6"
     }
 
     val google = Google

--- a/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/source/KmpSourceSetsConfiguratorSpec.kt
+++ b/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/source/KmpSourceSetsConfiguratorSpec.kt
@@ -175,9 +175,24 @@ class KmpSourceSetsConfiguratorSpec {
         val source2Dependencies: KotlinSourceSet = mockk()
         val source2DependenciesName: String = fixture.fixture()
 
+        val source3: KotlinSourceSet = mockk()
+        val source3Dependencies: KotlinSourceSet = mockk()
+        val source3DependenciesName: String = fixture.fixture()
+
+        val source4: KotlinSourceSet = mockk()
+        val source4Dependencies: KotlinSourceSet = mockk()
+        val source4DependenciesName: String = fixture.fixture()
+
+        val source5: KotlinSourceSet = mockk()
+        val source5Dependencies: KotlinSourceSet = mockk()
+        val source5DependenciesName: String = fixture.fixture()
+
         val sourceSets = mutableListOf(
             source1,
-            source2
+            source2,
+            source3,
+            source4,
+            source5,
         )
 
         every { project.dependencies } returns dependencies
@@ -205,6 +220,21 @@ class KmpSourceSetsConfiguratorSpec {
         every { source2.dependsOn } returns setOf(source2Dependencies)
         every { source2Dependencies.name } returns source2DependenciesName
 
+        every { source3.name } returns "androidAndroidTest"
+        every { source3.kotlin.srcDir(any()) } returns mockk()
+        every { source3.dependsOn } returns setOf(source3Dependencies)
+        every { source3Dependencies.name } returns source3DependenciesName
+
+        every { source4.name } returns "androidAndroidTestDebug"
+        every { source4.kotlin.srcDir(any()) } returns mockk()
+        every { source4.dependsOn } returns setOf(source4Dependencies)
+        every { source4Dependencies.name } returns source4DependenciesName
+
+        every { source5.name } returns "androidAndroidTestRelease"
+        every { source5.kotlin.srcDir(any()) } returns mockk()
+        every { source5.dependsOn } returns setOf(source5Dependencies)
+        every { source5Dependencies.name } returns source5DependenciesName
+
         every { extensions.getByType(KspExtension::class.java) } returns kspExtension
         every { kspExtension.arg(any(), any()) } just Runs
 
@@ -227,11 +257,30 @@ class KmpSourceSetsConfiguratorSpec {
         }
 
         verify(exactly = 1) {
+            dependencies.add(
+                "kspAndroidAndroidTest",
+                "tech.antibytes.kmock:kmock-processor:${MainConfig.version}"
+            )
+        }
+
+        verify(exactly = 1) {
             source1.kotlin.srcDir("$path/generated/ksp/jvm/jvmTest")
         }
 
         verify(exactly = 1) {
             source2.kotlin.srcDir("$path/generated/ksp/android/androidTest")
+        }
+
+        verify(exactly = 0) {
+            source3.kotlin.srcDir(any())
+        }
+
+        verify(exactly = 1) {
+            source4.kotlin.srcDir("$path/generated/ksp/android/androidDebugAndroidTest")
+        }
+
+        verify(exactly = 1) {
+            source5.kotlin.srcDir("$path/generated/ksp/android/androidReleaseAndroidTest")
         }
 
         verify(exactly = 0) { kspExtension.arg(any(), any()) }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #129

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This enables the support for instrumented AndroidTests (aka AndroidAndroid) for the KMP side of the project.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
