### PR TITLE
Add multi interface support for common (kmock)

### DIFF
--- a/examples/src/commonTest/kotlin/tech/antibytes/kmock/example/SampleControllerAutoSpyFactorySpec.kt
+++ b/examples/src/commonTest/kotlin/tech/antibytes/kmock/example/SampleControllerAutoSpyFactorySpec.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import tech.antibytes.kmock.MockCommon
+import tech.antibytes.kmock.MultiMockCommon
 import tech.antibytes.kmock.example.contract.ExampleContract
 import tech.antibytes.kmock.example.contract.ExampleContract.SampleDomainObject
 import tech.antibytes.kmock.example.contract.ExampleContract.SampleLocalRepository
@@ -45,6 +46,11 @@ import kotlin.test.assertTrue
 @MockCommon(
     SampleRemoteRepository::class,
     SampleLocalRepository::class,
+    SampleDomainObject::class,
+    ExampleContract.DecoderFactory::class
+)
+@MultiMockCommon(
+    "Merged",
     SampleDomainObject::class,
     ExampleContract.DecoderFactory::class
 )

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockAggregator.kt
@@ -77,8 +77,8 @@ internal class KMockAggregator(
                 val templateName = interfaze.qualifiedName!!.asString()
                 templateCollector[templateName + sourceIndicator] = TemplateSource(
                     indicator = sourceIndicator,
+                    templateName = aliases[templateName] ?: interfaze.simpleName.asString(),
                     template = interfaze,
-                    alias = aliases[templateName],
                     generics = resolveGenerics(interfaze)
                 )
             }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockAggregator.kt
@@ -108,8 +108,8 @@ internal class KMockAggregator(
     @Suppress("UNCHECKED_CAST")
     private fun extractInterfaces(
         annotated: Sequence<KSAnnotated>,
-        condition: (String, KSAnnotation) -> Boolean
-    ): Aggregated {
+        condition: (String, KSAnnotation) -> Boolean,
+    ): Aggregated<TemplateSource> {
         val illAnnotated = mutableListOf<KSAnnotated>()
         val typeContainer = mutableMapOf<String, MutableList<KSType>>()
         val templateCollector: MutableMap<String, TemplateSource> = mutableMapOf()
@@ -148,7 +148,7 @@ internal class KMockAggregator(
 
     override fun extractCommonInterfaces(
         resolver: Resolver
-    ): Aggregated {
+    ): Aggregated<TemplateSource>  {
         val annotated = fetchCommonAnnotated(resolver)
 
         return extractInterfaces(annotated) { annotationName, _ ->
@@ -179,7 +179,7 @@ internal class KMockAggregator(
 
     override fun extractSharedInterfaces(
         resolver: Resolver
-    ): Aggregated {
+    ): Aggregated<TemplateSource>  {
         val annotated = fetchSharedAnnotated(resolver)
 
         return extractInterfaces(annotated, ::isSharedAnnotation)
@@ -194,7 +194,7 @@ internal class KMockAggregator(
 
     override fun extractPlatformInterfaces(
         resolver: Resolver
-    ): Aggregated {
+    ): Aggregated<TemplateSource>  {
         val annotated = fetchPlatformAnnotated(resolver)
 
         return extractInterfaces(annotated) { annotationName, _ ->

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockAggregator.kt
@@ -78,6 +78,7 @@ internal class KMockAggregator(
                 templateCollector[templateName + sourceIndicator] = TemplateSource(
                     indicator = sourceIndicator,
                     templateName = aliases[templateName] ?: interfaze.simpleName.asString(),
+                    packageName = interfaze.packageName.asString(),
                     template = interfaze,
                     generics = resolveGenerics(interfaze)
                 )

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -121,10 +121,12 @@ internal class KMockProcessor(
             relaxer = relaxer,
         )
 
-        interfaceGenerator.bind(
-            templateSources = multiCommonSources.extractedTemplates,
-            dependencies = multiCommonSources.dependencies
-        )
+        if (multiCommonSources.extractedTemplates.isNotEmpty()) {
+            interfaceGenerator.bind(
+                templateSources = multiCommonSources.extractedTemplates,
+                dependencies = multiCommonSources.dependencies
+            )
+        }
 
         return resolveCommonAggregated(
             singleCommonSources = singleCommonSources,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -12,6 +12,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.squareup.kotlinpoet.ksp.KotlinPoetKspPreview
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 
 /*
  * Notice -> No deep checking in order to not drain performance
@@ -28,7 +29,7 @@ internal class KMockProcessor(
     private fun mergeSources(
         rootSource: Aggregated,
         dependentSource: Aggregated,
-        filteredTemplates: List<ProcessorContract.TemplateSource>
+        filteredTemplates: List<TemplateSource>
     ): Aggregated {
         return Aggregated(
             illFormed = rootSource.illFormed.toMutableList().also {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -60,9 +60,9 @@ internal class KMockProcessor(
         val aggregated = sourceAggregator.extractCommonInterfaces(resolver)
 
         mockGenerator.writeCommonMocks(
-            aggregated.extractedTemplates,
-            aggregated.dependencies,
-            relaxer
+            templateSources = aggregated.extractedTemplates,
+            dependencies = aggregated.dependencies,
+            relaxer = relaxer
         )
 
         return aggregated
@@ -79,14 +79,12 @@ internal class KMockProcessor(
             commonAggregated.extractedTemplates
         )
 
-        entryPointGenerator.generateShared(
-            filteredInterfaces,
-        )
+        entryPointGenerator.generateShared(filteredInterfaces)
 
         mockGenerator.writeSharedMocks(
-            filteredInterfaces,
-            aggregated.dependencies,
-            relaxer
+            templateSources = filteredInterfaces,
+            dependencies = aggregated.dependencies,
+            relaxer = relaxer
         )
 
         return mergeSources(commonAggregated, aggregated, filteredInterfaces)
@@ -100,8 +98,8 @@ internal class KMockProcessor(
     ): List<KSAnnotated> {
         val aggregated = sourceAggregator.extractPlatformInterfaces(resolver)
         val filteredInterfaces = filter.filter(
-            aggregated.extractedTemplates,
-            sharedAggregated.extractedTemplates
+            templateSources = aggregated.extractedTemplates,
+            filteredBy = sharedAggregated.extractedTemplates
         )
         val totalAggregated = mergeSources(sharedAggregated, aggregated, filteredInterfaces)
 
@@ -136,10 +134,7 @@ internal class KMockProcessor(
 
             Pair(commonAggregated, sharedAggregated)
         } else {
-            Pair(
-                Aggregated(emptyList(), emptyList(), emptyList()),
-                Aggregated(emptyList(), emptyList(), emptyList())
-            )
+            Pair(NON_KMP_AGGREGATED_SINGLE, NON_KMP_AGGREGATED_SINGLE)
         }
     }
 
@@ -155,5 +150,9 @@ internal class KMockProcessor(
             sharedAggregated = sharedAggregated,
             relaxer = relaxer
         )
+    }
+
+    private companion object {
+        val NON_KMP_AGGREGATED_SINGLE = Aggregated<TemplateSource>(emptyList(), emptyList(), emptyList())
     }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -107,6 +107,13 @@ internal class KMockProcessor(
         }
     }
 
+    private fun interfaceBinderIsApplicable(
+        templateSources: List<TemplateMultiSource>
+    ): Boolean {
+        return templateSources.isNotEmpty() &&
+            commonMultiAggregated.extractedTemplates.isEmpty() // TODO - Test Concern see: https://github.com/tschuchortdev/kotlin-compile-testing/issues/263
+    }
+
     private fun stubCommonSources(
         resolver: Resolver,
         relaxer: Relaxer?
@@ -121,7 +128,7 @@ internal class KMockProcessor(
             relaxer = relaxer,
         )
 
-        if (multiCommonSources.extractedTemplates.isNotEmpty()) {
+        if (interfaceBinderIsApplicable(multiCommonSources.extractedTemplates)) {
             interfaceGenerator.bind(
                 templateSources = multiCommonSources.extractedTemplates,
                 dependencies = multiCommonSources.dependencies

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -14,8 +14,9 @@ import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryEntryPointGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.Options
+import tech.antibytes.kmock.processor.aggregation.KMockMultiSourceAggregator
 import tech.antibytes.kmock.processor.aggregation.KMockRelaxationAggregator
-import tech.antibytes.kmock.processor.aggregation.KMockSourceAggregator
+import tech.antibytes.kmock.processor.aggregation.KMockSingleSourceAggregator
 import tech.antibytes.kmock.processor.factory.KMockFactoryEntryPointGenerator
 import tech.antibytes.kmock.processor.factory.KMockFactoryGenerator
 import tech.antibytes.kmock.processor.factory.KMockFactoryGeneratorUtil
@@ -30,6 +31,8 @@ import tech.antibytes.kmock.processor.mock.KMockPropertyGenerator
 import tech.antibytes.kmock.processor.mock.KMockRelaxerGenerator
 import tech.antibytes.kmock.processor.mock.KMockSpyGenerator
 import tech.antibytes.kmock.processor.mock.KmockProxyNameSelector
+import tech.antibytes.kmock.processor.multi.KMockMultiInterfaceBinder
+import tech.antibytes.kmock.processor.multi.KMockParentFinder
 import tech.antibytes.kmock.processor.utils.AnnotationFilter
 import tech.antibytes.kmock.processor.utils.SourceFilter
 import tech.antibytes.kmock.processor.utils.SourceSetValidator
@@ -138,6 +141,10 @@ class KMockProcessorProvider : SymbolProcessorProvider {
         return KMockProcessor(
             isKmp = options.isKmp,
             codeGenerator = codeGenerator,
+            interfazeGenerator = KMockMultiInterfaceBinder(
+                logger = logger,
+                codeGenerator = codeGenerator
+            ),
             mockGenerator = KMockGenerator(
                 logger = logger,
                 spyOn = options.spyOn,
@@ -145,13 +152,22 @@ class KMockProcessorProvider : SymbolProcessorProvider {
                 codeGenerator = codeGenerator,
                 genericsResolver = KMockGenerics,
                 nameCollector = nameSelector,
+                parentFinder = KMockParentFinder,
                 propertyGenerator = propertyGenerator,
                 methodGenerator = methodGenerator,
                 buildInGenerator = buildInGenerator,
             ),
             factoryGenerator = factoryGenerator,
             entryPointGenerator = entryPointGenerator,
-            sourceAggregator = KMockSourceAggregator.getInstance(
+            multiSourceAggregator = KMockMultiSourceAggregator.getInstance(
+                logger = logger,
+                annotationFilter = annotationFilter,
+                sourceSetValidator = sourceSetValidator,
+                generics = KMockGenerics,
+                customAnnotations = options.customAnnotations,
+                aliases = options.aliases,
+            ),
+            singleSourceAggregator = KMockSingleSourceAggregator.getInstance(
                 logger = logger,
                 annotationFilter = annotationFilter,
                 sourceSetValidator = sourceSetValidator,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -139,9 +139,10 @@ class KMockProcessorProvider : SymbolProcessorProvider {
         )
 
         return KMockProcessor(
+            logger = logger,
             isKmp = options.isKmp,
             codeGenerator = codeGenerator,
-            interfazeGenerator = KMockMultiInterfaceBinder(
+            interfaceGenerator = KMockMultiInterfaceBinder(
                 logger = logger,
                 codeGenerator = codeGenerator
             ),

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -144,6 +144,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
             codeGenerator = codeGenerator,
             interfaceGenerator = KMockMultiInterfaceBinder(
                 logger = logger,
+                rootPackage = options.rootPackage,
                 codeGenerator = codeGenerator
             ),
             mockGenerator = KMockGenerator(
@@ -162,6 +163,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
             entryPointGenerator = entryPointGenerator,
             multiSourceAggregator = KMockMultiSourceAggregator.getInstance(
                 logger = logger,
+                rootPackage = options.rootPackage,
                 annotationFilter = annotationFilter,
                 sourceSetValidator = sourceSetValidator,
                 generics = KMockGenerics,
@@ -170,6 +172,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
             ),
             singleSourceAggregator = KMockSingleSourceAggregator.getInstance(
                 logger = logger,
+                rootPackage = options.rootPackage,
                 annotationFilter = annotationFilter,
                 sourceSetValidator = sourceSetValidator,
                 generics = KMockGenerics,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -14,6 +14,8 @@ import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryEntryPointGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.Options
+import tech.antibytes.kmock.processor.aggregation.KMockRelaxationAggregator
+import tech.antibytes.kmock.processor.aggregation.KMockSourceAggregator
 import tech.antibytes.kmock.processor.factory.KMockFactoryEntryPointGenerator
 import tech.antibytes.kmock.processor.factory.KMockFactoryGenerator
 import tech.antibytes.kmock.processor.factory.KMockFactoryGeneratorUtil
@@ -149,7 +151,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
             ),
             factoryGenerator = factoryGenerator,
             entryPointGenerator = entryPointGenerator,
-            aggregator = KMockAggregator.getInstance(
+            sourceAggregator = KMockSourceAggregator.getInstance(
                 logger = logger,
                 annotationFilter = annotationFilter,
                 sourceSetValidator = sourceSetValidator,
@@ -157,6 +159,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
                 customAnnotations = options.customAnnotations,
                 aliases = options.aliases,
             ),
+            relaxationAggregator = KMockRelaxationAggregator(logger),
             filter = SourceFilter(options.precedences, logger)
         )
     }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -28,8 +28,11 @@ import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.Mock
+import tech.antibytes.kmock.MultiMock
 import tech.antibytes.kmock.MockCommon
+import tech.antibytes.kmock.MultiMockCommon
 import tech.antibytes.kmock.MockShared
+import tech.antibytes.kmock.MultiMockShared
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
 import tech.antibytes.kmock.Relaxer as RelaxationAnnotation
@@ -101,7 +104,11 @@ internal interface ProcessorContract {
             annotations: Map<String, String>
         ): Map<String, String>
 
-        fun isApplicableAnnotation(
+        fun isApplicableSingleSourceAnnotation(
+            annotation: KSAnnotation
+        ): Boolean
+
+        fun isApplicableMultiSourceAnnotation(
             annotation: KSAnnotation
         ): Boolean
     }
@@ -411,8 +418,11 @@ internal interface ProcessorContract {
         const val SHARED_MOCK_FACTORY = "getMockInstance"
         const val FACTORY_FILE_NAME = "MockFactory"
         val ANNOTATION_PLATFORM_NAME: String = Mock::class.java.canonicalName
+        val ANNOTATION_PLATFORM_MULTI_NAME: String = MultiMock::class.java.canonicalName
         val ANNOTATION_COMMON_NAME: String = MockCommon::class.java.canonicalName
+        val ANNOTATION_COMMON_MULTI_NAME: String = MultiMockCommon::class.java.canonicalName
         val ANNOTATION_SHARED_NAME: String = MockShared::class.java.canonicalName
+        val ANNOTATION_SHARED_MULTI_NAME: String = MultiMockShared::class.java.canonicalName
         val RELAXATION_NAME: String = RelaxationAnnotation::class.java.canonicalName
 
         val COLLECTOR_NAME = ClassName(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -79,14 +79,14 @@ internal interface ProcessorContract {
     }
 
     interface SourceFilter {
-        fun filter(
-            templateSources: List<TemplateSource>,
-            filteredBy: List<TemplateSource>
-        ): List<TemplateSource>
+        fun <T : Source> filter(
+            templateSources: List<T>,
+            filteredBy: List<T>
+        ): List<T>
 
-        fun filterSharedSources(
-            templateSources: List<TemplateSource>
-        ): List<TemplateSource>
+        fun <T : Source> filterSharedSources(
+            templateSources: List<T>
+        ): List<T>
     }
 
     interface AggregatorFactory {
@@ -107,12 +107,19 @@ internal interface ProcessorContract {
         fun extractRelaxer(resolver: Resolver): Relaxer?
     }
 
+    sealed interface Source {
+        val indicator: String
+        val templateName: String
+        val packageName: String
+    }
+
     data class TemplateSource(
-        val indicator: String,
-        val templateName: String,
+        override val indicator: String,
+        override val templateName: String,
+        override val packageName: String,
         val template: KSClassDeclaration,
         val generics: Map<String, List<KSTypeReference>>?
-    )
+    ) : Source
 
     data class Aggregated(
         val illFormed: List<KSAnnotated>,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -37,7 +37,7 @@ import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
 import tech.antibytes.kmock.Relaxer as RelaxationAnnotation
 
-interface ProcessorContract {
+internal interface ProcessorContract {
     data class Relaxer(
         val packageName: String,
         val functionName: String
@@ -392,6 +392,7 @@ interface ProcessorContract {
 
         fun buildSharedMockFactory(
             templateSources: List<TemplateSource>,
+            templateMultiSources: List<TemplateMultiSource>,
             relaxer: Relaxer?
         ): FunSpec
     }
@@ -412,6 +413,7 @@ interface ProcessorContract {
     interface MockFactoryGenerator {
         fun writeFactories(
             templateSources: List<TemplateSource>,
+            templateMultiSources: List<TemplateMultiSource>,
             dependencies: List<KSFile>,
             relaxer: Relaxer?,
         )

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -37,7 +37,7 @@ import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
 import tech.antibytes.kmock.Relaxer as RelaxationAnnotation
 
-internal interface ProcessorContract {
+interface ProcessorContract {
     data class Relaxer(
         val packageName: String,
         val functionName: String
@@ -130,7 +130,7 @@ internal interface ProcessorContract {
         fun extractRelaxer(resolver: Resolver): Relaxer?
     }
 
-    interface SourceAggregator : Aggregator {
+    interface SingleSourceAggregator : Aggregator {
         fun extractCommonInterfaces(resolver: Resolver): Aggregated<TemplateSource>
         fun extractSharedInterfaces(resolver: Resolver): Aggregated<TemplateSource>
         fun extractPlatformInterfaces(resolver: Resolver): Aggregated<TemplateSource>
@@ -336,8 +336,23 @@ internal interface ProcessorContract {
 
         fun writeCommonMocks(
             templateSources: List<TemplateSource>,
+            templateMultiSources: Aggregated<TemplateMultiSource>,
             dependencies: List<KSFile>,
             relaxer: Relaxer?
+        )
+    }
+
+    fun interface ParentFinder {
+        fun find(
+            templateSource: TemplateSource,
+            templateMultiSources: Aggregated<TemplateMultiSource>,
+        ): List<KSClassDeclaration>
+    }
+
+    interface MultiInterfaceBinder {
+        fun bind(
+            templateSources: List<TemplateMultiSource>,
+            dependencies: List<KSFile>,
         )
     }
 
@@ -449,6 +464,9 @@ internal interface ProcessorContract {
             "UNUSED_PARAMETER",
             "UNUSED_EXPRESSION"
         ).build()
+
+        const val MULTI_MOCK = "MultiMock"
+        val multiMock = TypeVariableName(MULTI_MOCK)
 
         const val COMMON_INDICATOR = "commonTest"
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -101,9 +101,9 @@ internal interface ProcessorContract {
     }
 
     interface Aggregator {
-        fun extractCommonInterfaces(resolver: Resolver): Aggregated
-        fun extractSharedInterfaces(resolver: Resolver): Aggregated
-        fun extractPlatformInterfaces(resolver: Resolver): Aggregated
+        fun extractCommonInterfaces(resolver: Resolver): Aggregated<TemplateSource>
+        fun extractSharedInterfaces(resolver: Resolver): Aggregated<TemplateSource>
+        fun extractPlatformInterfaces(resolver: Resolver): Aggregated<TemplateSource>
         fun extractRelaxer(resolver: Resolver): Relaxer?
     }
 
@@ -121,9 +121,17 @@ internal interface ProcessorContract {
         val generics: Map<String, List<KSTypeReference>>?
     ) : Source
 
-    data class Aggregated(
+    data class TemplateMultiSource(
+        override val indicator: String,
+        override val templateName: String,
+        override val packageName: String,
+        val template: List<KSClassDeclaration>,
+        val generics: List<Map<String, List<KSTypeReference>>?>
+    ) : Source
+
+    data class Aggregated<out T : Source>(
         val illFormed: List<KSAnnotated>,
-        val extractedTemplates: List<TemplateSource>,
+        val extractedTemplates: List<T>,
         val dependencies: List<KSFile>
     )
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -145,6 +145,7 @@ interface ProcessorContract {
     interface AggregatorFactory<T : Aggregator> {
         fun getInstance(
             logger: KSPLogger,
+            rootPackage: String,
             sourceSetValidator: SourceSetValidator,
             annotationFilter: AnnotationFilter,
             generics: GenericResolver,
@@ -432,6 +433,7 @@ interface ProcessorContract {
         const val KSPY_FACTORY_TYPE_NAME = "SpyOn"
         const val SHARED_MOCK_FACTORY = "getMockInstance"
         const val FACTORY_FILE_NAME = "MockFactory"
+        const val INTERMEDIATE_INTERFACES_FILE_NAME = "KMockMultiInterfaceArtifacts"
         val ANNOTATION_PLATFORM_NAME: String = Mock::class.java.canonicalName
         val ANNOTATION_PLATFORM_MULTI_NAME: String = MultiMock::class.java.canonicalName
         val ANNOTATION_COMMON_NAME: String = MockCommon::class.java.canonicalName

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -28,10 +28,10 @@ import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.Mock
-import tech.antibytes.kmock.MultiMock
 import tech.antibytes.kmock.MockCommon
-import tech.antibytes.kmock.MultiMockCommon
 import tech.antibytes.kmock.MockShared
+import tech.antibytes.kmock.MultiMock
+import tech.antibytes.kmock.MultiMockCommon
 import tech.antibytes.kmock.MultiMockShared
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -109,8 +109,8 @@ internal interface ProcessorContract {
 
     data class TemplateSource(
         val indicator: String,
+        val templateName: String,
         val template: KSClassDeclaration,
-        val alias: String?,
         val generics: Map<String, List<KSTypeReference>>?
     )
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/BaseSourceAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/BaseSourceAggregator.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.aggregation
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
+import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
+
+internal abstract class BaseSourceAggregator(
+    private val logger: KSPLogger,
+    private val customAnnotations: Map<String, String>,
+    private val generics: GenericResolver,
+) {
+    protected fun resolveAnnotationName(
+        annotation: KSAnnotation
+    ): String = annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+
+    protected fun findKMockAnnotation(
+        annotations: Sequence<KSAnnotation>,
+        condition: (String, KSAnnotation) -> Boolean
+    ): KSAnnotation? {
+        val annotation = annotations.firstOrNull { annotation ->
+            condition(resolveAnnotationName(annotation), annotation)
+        }
+
+        return annotation
+    }
+
+    protected fun resolveGenerics(template: KSDeclaration): Map<String, List<KSTypeReference>>? {
+        val typeResolver = template.typeParameters.toTypeParameterResolver()
+        return generics.extractGenerics(
+            template,
+            typeResolver,
+        )
+    }
+
+    protected fun fetchCustomShared(
+        resolver: Resolver
+    ): Array<Sequence<KSAnnotated>> {
+        return customAnnotations.keys.map { annotation ->
+            resolver.getSymbolsWithAnnotation(
+                annotation,
+                false
+            )
+        }.toTypedArray()
+    }
+
+    protected fun safeCastInterface(interfaze: KSDeclaration): KSClassDeclaration {
+        return when {
+            interfaze !is KSClassDeclaration -> {
+                logger.error("Cannot stub non interfaces.")
+                throw IllegalArgumentException("Cannot stub non interfaces.")
+            }
+            interfaze.classKind != ClassKind.INTERFACE -> {
+                logger.error("Cannot stub non interface ${interfaze.toClassName()}.")
+                throw IllegalArgumentException("Cannot stub non interface ${interfaze.toClassName()}.")
+            }
+            else -> interfaze
+        }
+    }
+}

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregator.kt
@@ -29,6 +29,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 
 internal class KMockMultiSourceAggregator(
     private val logger: KSPLogger,
+    private val rootPackage: String,
     private val annotationFilter: AnnotationFilter,
     private val sourceSetValidator: SourceSetValidator,
     private val generics: GenericResolver,
@@ -56,27 +57,21 @@ internal class KMockMultiSourceAggregator(
         sourceIndicator: String,
         templateCollector: MutableMap<String, TemplateMultiSource>
     ) {
-        var packageName: String? = null
         val interfazes: MutableList<KSClassDeclaration> = mutableListOf()
         val generics: MutableList<Map<String, List<KSTypeReference>>?> = mutableListOf()
 
         interfaces.forEach { declaration ->
             val interfaze = safeCastInterface(declaration)
-            packageName = resolvePackageName(
-                currentName = packageName,
-                nameCandidate = interfaze.packageName.asString()
-            )
-
             generics.add(resolveGenerics(interfaze))
             interfazes.add(interfaze)
         }
 
-        val qualifiedName = "$packageName.$interfaceName"
+        val qualifiedName = "$rootPackage.$interfaceName"
 
         templateCollector[qualifiedName + sourceIndicator] = TemplateMultiSource(
             indicator = sourceIndicator,
             templateName = interfaceName,
-            packageName = packageName!!,
+            packageName = rootPackage,
             templates = interfazes,
             generics = generics
         )
@@ -215,6 +210,7 @@ internal class KMockMultiSourceAggregator(
     companion object : ProcessorContract.AggregatorFactory<MultiSourceAggregator> {
         override fun getInstance(
             logger: KSPLogger,
+            rootPackage: String,
             sourceSetValidator: SourceSetValidator,
             annotationFilter: AnnotationFilter,
             generics: GenericResolver,
@@ -227,6 +223,7 @@ internal class KMockMultiSourceAggregator(
 
             return KMockMultiSourceAggregator(
                 logger = logger,
+                rootPackage = rootPackage,
                 annotationFilter = annotationFilter,
                 sourceSetValidator = sourceSetValidator,
                 generics = generics,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockRelaxationAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockRelaxationAggregator.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.aggregation
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueParameter
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.RelaxationAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
+
+internal class KMockRelaxationAggregator(
+    private val logger: KSPLogger
+) : RelaxationAggregator {
+    private fun hasValidParameter(parameter: List<KSValueParameter>): Boolean {
+        return parameter.size == 1 &&
+            parameter.first().type.resolve().toString() == "String"
+    }
+
+    private fun hasValidTypeParameter(
+        typeParameter: List<KSTypeParameter>,
+        returnType: KSTypeReference?
+    ): Boolean {
+        return typeParameter.size == 1 &&
+            typeParameter.first().bounds.toList().isEmpty() &&
+            typeParameter.first().toString() == returnType.toString()
+    }
+
+    private fun validateRelaxer(symbol: KSFunctionDeclaration) {
+        val isValid = hasValidParameter(symbol.parameters) &&
+            hasValidTypeParameter(symbol.typeParameters, symbol.returnType)
+
+        if (!isValid) {
+            logger.error("Invalid Relaxer!")
+        }
+    }
+
+    private fun fetchRelaxerAnnotated(resolver: Resolver): Sequence<KSAnnotated> {
+        return resolver.getSymbolsWithAnnotation(
+            ProcessorContract.RELAXATION_NAME,
+            false
+        )
+    }
+
+    override fun extractRelaxer(resolver: Resolver): Relaxer? {
+        val annotatedSymbol = fetchRelaxerAnnotated(resolver).firstOrNull()
+
+        return if (annotatedSymbol is KSFunctionDeclaration) {
+            validateRelaxer(annotatedSymbol)
+            Relaxer(
+                annotatedSymbol.packageName.asString(),
+                annotatedSymbol.simpleName.asString()
+            )
+        } else {
+            null
+        }
+    }
+}

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSingleSourceAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSingleSourceAggregator.kt
@@ -166,6 +166,7 @@ internal class KMockSingleSourceAggregator(
     companion object : AggregatorFactory<SingleSourceAggregator> {
         override fun getInstance(
             logger: KSPLogger,
+            rootPackage: String,
             sourceSetValidator: SourceSetValidator,
             annotationFilter: AnnotationFilter,
             generics: GenericResolver,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSingleSourceAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSingleSourceAggregator.kt
@@ -21,18 +21,18 @@ import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_COM
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_PLATFORM_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_SHARED_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SingleSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 
-internal class KMockSourceAggregator(
+internal class KMockSingleSourceAggregator(
     private val logger: KSPLogger,
     private val annotationFilter: AnnotationFilter,
     private val sourceSetValidator: SourceSetValidator,
     generics: GenericResolver,
     private val customAnnotations: Map<String, String>,
     private val aliases: Map<String, String>
-) : SourceAggregator, BaseSourceAggregator(logger, customAnnotations, generics) {
+) : SingleSourceAggregator, BaseSourceAggregator(logger, customAnnotations, generics) {
     private fun resolveInterface(
         declaration: KSDeclaration,
         sourceIndicator: String,
@@ -159,7 +159,7 @@ internal class KMockSourceAggregator(
         }
     }
 
-    companion object : AggregatorFactory<SourceAggregator> {
+    companion object : AggregatorFactory<SingleSourceAggregator> {
         override fun getInstance(
             logger: KSPLogger,
             sourceSetValidator: SourceSetValidator,
@@ -167,12 +167,12 @@ internal class KMockSourceAggregator(
             generics: GenericResolver,
             customAnnotations: Map<String, String>,
             aliases: Map<String, String>,
-        ): SourceAggregator {
+        ): SingleSourceAggregator {
             val additionalAnnotations = annotationFilter.filterAnnotation(
                 customAnnotations
             )
 
-            return KMockSourceAggregator(
+            return KMockSingleSourceAggregator(
                 logger = logger,
                 annotationFilter = annotationFilter,
                 sourceSetValidator = sourceSetValidator,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSingleSourceAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSingleSourceAggregator.kt
@@ -24,6 +24,8 @@ import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.SingleSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.utils.deriveSimpleName
+import tech.antibytes.kmock.processor.utils.ensureNotNullClassName
 
 internal class KMockSingleSourceAggregator(
     private val logger: KSPLogger,
@@ -39,11 +41,13 @@ internal class KMockSingleSourceAggregator(
         templateCollector: MutableMap<String, TemplateSource>
     ) {
         val interfaze = safeCastInterface(declaration)
-        val templateName = interfaze.qualifiedName!!.asString()
-        templateCollector[templateName + sourceIndicator] = TemplateSource(
+        val qualifiedName = ensureNotNullClassName(interfaze.qualifiedName?.asString())
+        val packageName = interfaze.packageName.asString()
+
+        templateCollector[qualifiedName + sourceIndicator] = TemplateSource(
             indicator = sourceIndicator,
-            templateName = aliases[templateName] ?: interfaze.simpleName.asString(),
-            packageName = interfaze.packageName.asString(),
+            templateName = aliases[qualifiedName] ?: interfaze.deriveSimpleName(packageName),
+            packageName = packageName,
             template = interfaze,
             generics = resolveGenerics(interfaze)
         )

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregator.kt
@@ -169,7 +169,7 @@ internal class KMockSourceAggregator(
     }
 
     private fun isSharedAnnotation(annotationName: String, annotation: KSAnnotation): Boolean {
-        return (annotationName in customAnnotations.keys && annotationFilter.isApplicableAnnotation(annotation)) ||
+        return (annotationName in customAnnotations.keys && annotationFilter.isApplicableSingleSourceAnnotation(annotation)) ||
             (ANNOTATION_SHARED_NAME == annotationName && sourceSetValidator.isValidateSourceSet(annotation))
     }
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
@@ -11,7 +11,6 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.ksp.writeTo
-import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.COMMON_INDICATOR
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.FACTORY_FILE_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.KMOCK_CONTRACT
@@ -19,6 +18,10 @@ import tech.antibytes.kmock.processor.ProcessorContract.Companion.KMOCK_FACTORY_
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.KSPY_FACTORY_TYPE_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.NOOP_COLLECTOR_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.UNUSED
+import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
+import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryEntryPointGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 
 internal class KMockFactoryEntryPointGenerator(
@@ -26,10 +29,10 @@ internal class KMockFactoryEntryPointGenerator(
     private val rootPackage: String,
     private val spiesOnly: Boolean,
     spyOn: Set<String>,
-    private val utils: ProcessorContract.MockFactoryGeneratorUtil,
-    private val genericResolver: ProcessorContract.GenericResolver,
-    private val codeGenerator: ProcessorContract.KmpCodeGenerator,
-) : ProcessorContract.MockFactoryEntryPointGenerator {
+    private val utils: MockFactoryGeneratorUtil,
+    private val genericResolver: GenericResolver,
+    private val codeGenerator: KmpCodeGenerator,
+) : MockFactoryEntryPointGenerator {
     private val hasSpies = spyOn.isNotEmpty() || spiesOnly
 
     private fun buildMockFactory(): FunSpec {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
@@ -103,6 +103,7 @@ internal class KMockFactoryGenerator(
         relaxer: Relaxer?
     ) {
         if (templateSources.isNotEmpty()) { // TODO: Solve multi Rounds in a better way
+
             writeFactoryImplementation(
                 templateSources = templateSources,
                 dependencies = dependencies,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
@@ -11,15 +11,16 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSFile
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ksp.writeTo
-import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.FACTORY_FILE_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.KMOCK_CONTRACT
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.NOOP_COLLECTOR_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.UNUSED
+import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithGenerics
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithoutGenerics
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 
 internal class KMockFactoryGenerator(
@@ -32,11 +33,12 @@ internal class KMockFactoryGenerator(
     private val genericGenerator: MockFactoryWithGenerics,
     private val utils: MockFactoryGeneratorUtil,
     private val codeGenerator: CodeGenerator,
-) : ProcessorContract.MockFactoryGenerator {
+) : MockFactoryGenerator {
     private val hasSpies = spyOn.isNotEmpty() || spiesOnly
 
     private fun writeFactoryImplementation(
         templateSources: List<TemplateSource>,
+        templateMultiSources: List<TemplateMultiSource>,
         dependencies: List<KSFile>,
         relaxer: Relaxer?
     ) {
@@ -61,6 +63,7 @@ internal class KMockFactoryGenerator(
         file.addFunction(
             nonGenericGenerator.buildSharedMockFactory(
                 templateSources = regular,
+                templateMultiSources = templateMultiSources,
                 relaxer = relaxer
             )
         )
@@ -99,13 +102,14 @@ internal class KMockFactoryGenerator(
 
     override fun writeFactories(
         templateSources: List<TemplateSource>,
+        templateMultiSources: List<TemplateMultiSource>,
         dependencies: List<KSFile>,
         relaxer: Relaxer?
     ) {
-        if (templateSources.isNotEmpty()) { // TODO: Solve multi Rounds in a better way
-
+        if (templateSources.isNotEmpty() || templateMultiSources.isNotEmpty()) { // TODO: Solve multi Rounds in a better way
             writeFactoryImplementation(
                 templateSources = templateSources,
+                templateMultiSources = templateMultiSources,
                 dependencies = dependencies,
                 relaxer = relaxer
             )

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGeneratorUtil.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGeneratorUtil.kt
@@ -200,18 +200,7 @@ internal class KMockFactoryGeneratorUtil(
     override fun splitInterfacesIntoRegularAndGenerics(
         templateSources: List<TemplateSource>
     ): Pair<List<TemplateSource>, List<TemplateSource>> {
-        val regular: MutableList<TemplateSource> = mutableListOf()
-        val generics: MutableList<TemplateSource> = mutableListOf()
-
-        templateSources.forEach { source ->
-            if (source.generics == null) {
-                regular.add(source)
-            } else {
-                generics.add(source)
-            }
-        }
-
-        return Pair(regular, generics)
+        return templateSources.partition { source -> source.generics == null }
     }
 
     override fun resolveGenerics(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
@@ -18,6 +18,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithGenerics
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.utils.ensureNotNullClassName
 
 internal class KMockFactoryWithGenerics(
     private val isKmp: Boolean,
@@ -36,7 +37,6 @@ internal class KMockFactoryWithGenerics(
     private fun fillMockFactory(
         type: TypeVariableName,
         generics: List<TypeVariableName>,
-        isKmp: Boolean,
     ): FunSpec.Builder {
         val modifier = resolveModifier()
 
@@ -52,7 +52,6 @@ internal class KMockFactoryWithGenerics(
         mockType: TypeVariableName,
         spyType: TypeVariableName,
         generics: List<TypeVariableName>,
-        isKmp: Boolean,
     ): FunSpec.Builder {
         val modifier = resolveModifier()
 
@@ -76,7 +75,6 @@ internal class KMockFactoryWithGenerics(
         return fillMockFactory(
             generics = generics,
             type = type,
-            isKmp = isKmp,
         ).build()
     }
 
@@ -94,7 +92,6 @@ internal class KMockFactoryWithGenerics(
             mockType = mockType,
             spyType = spyType,
             generics = generics,
-            isKmp = isKmp,
         ).build()
     }
 
@@ -163,9 +160,9 @@ internal class KMockFactoryWithGenerics(
         templateSource: TemplateSource,
         relaxer: Relaxer?
     ) {
-        val packageName = templateSource.template.packageName.asString()
-        val qualifiedName = templateSource.template.qualifiedName!!.asString()
-        val interfaceName = "$packageName.${templateSource.templateName}"
+        val packageName = templateSource.packageName
+        val qualifiedName = ensureNotNullClassName(templateSource.template.qualifiedName?.asString())
+        val interfaceName = "$packageName.${templateSource.templateName.substringAfterLast('.')}"
 
         addMock(
             mockFactory = mockFactory,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
@@ -16,6 +16,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithoutGenerics
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.utils.ensureNotNullClassName
 
 internal class KMockFactoryWithoutGenerics(
     private val isKmp: Boolean,
@@ -81,9 +82,9 @@ internal class KMockFactoryWithoutGenerics(
         templateSource: TemplateSource,
         relaxer: Relaxer?
     ) {
-        val packageName = templateSource.template.packageName.asString()
-        val qualifiedName = templateSource.template.qualifiedName!!.asString()
-        val interfaceName = "$packageName.${templateSource.templateName}"
+        val packageName = templateSource.packageName
+        val qualifiedName = ensureNotNullClassName(templateSource.template.qualifiedName?.asString())
+        val interfaceName = "$packageName.${templateSource.templateName.substringAfterLast('.')}"
 
         addMock(
             mockFactory = mockFactory,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
@@ -22,17 +22,6 @@ internal class KMockFactoryWithoutGenerics(
     private val allowInterfaces: Boolean,
     private val utils: MockFactoryGeneratorUtil,
 ) : MockFactoryWithoutGenerics {
-    private fun createAliasName(
-        alias: String?,
-        packageName: String
-    ): String? {
-        return if (alias != null) {
-            "$packageName.$alias"
-        } else {
-            null
-        }
-    }
-
     private fun buildMockSelectorFlow(
         mockFactory: FunSpec.Builder,
         addItems: FunSpec.Builder.() -> Unit,
@@ -67,7 +56,6 @@ internal class KMockFactoryWithoutGenerics(
         mockFactory: FunSpec.Builder,
         qualifiedName: String,
         interfaceName: String,
-        aliasInterfaceName: String?,
         relaxer: Relaxer?
     ) {
         val (interfaceInvocationTemplate, mockInvocationTemplate) = determineMockTemplate(relaxer)
@@ -75,15 +63,15 @@ internal class KMockFactoryWithoutGenerics(
             mockFactory.addStatement(
                 interfaceInvocationTemplate,
                 qualifiedName,
-                aliasInterfaceName ?: interfaceName,
+                interfaceName,
                 qualifiedName,
             )
         }
 
         mockFactory.addStatement(
             mockInvocationTemplate,
-            aliasInterfaceName ?: interfaceName,
-            aliasInterfaceName ?: interfaceName,
+            interfaceName,
+            interfaceName,
             qualifiedName,
         )
     }
@@ -95,13 +83,11 @@ internal class KMockFactoryWithoutGenerics(
     ) {
         val packageName = templateSource.template.packageName.asString()
         val qualifiedName = templateSource.template.qualifiedName!!.asString()
-        val aliasInterfaceName = createAliasName(templateSource.alias, packageName)
-        val interfaceName = "$packageName.${templateSource.template.simpleName.asString()}"
+        val interfaceName = "$packageName.${templateSource.templateName}"
 
         addMock(
             mockFactory = mockFactory,
             qualifiedName = qualifiedName,
-            aliasInterfaceName = aliasInterfaceName,
             interfaceName = interfaceName,
             relaxer = relaxer,
         )

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/NoopFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/NoopFactoryGenerator.kt
@@ -10,11 +10,13 @@ import com.google.devtools.ksp.symbol.KSFile
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryEntryPointGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 
 internal object NoopFactoryGenerator : MockFactoryGenerator, MockFactoryEntryPointGenerator {
     override fun writeFactories(
         templateSources: List<TemplateSource>,
+        templateMultiSources: List<TemplateMultiSource>,
         dependencies: List<KSFile>,
         relaxer: Relaxer?
     ) = Unit

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/NoopFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/NoopFactoryGenerator.kt
@@ -21,7 +21,7 @@ internal object NoopFactoryGenerator : MockFactoryGenerator, MockFactoryEntryPoi
 
     override fun generateCommon(
         templateSources: List<TemplateSource>,
-        totalTemplates: List<TemplateSource>,
+        totalTemplates: List<TemplateSource>
     ) = Unit
 
     override fun generateShared(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockGenerator.kt
@@ -215,12 +215,11 @@ internal class KMockGenerator(
 
     private fun writeMock(
         template: KSClassDeclaration,
-        alias: String?,
+        templateName: String,
         generics: Map<String, List<KSTypeReference>>?,
         dependencies: List<KSFile>,
         relaxer: Relaxer?
     ) {
-        val templateName = alias ?: template.simpleName.asString()
         val mockName = "${templateName}Mock"
         val file = FileSpec.builder(
             template.packageName.asString(),
@@ -262,7 +261,7 @@ internal class KMockGenerator(
 
             writeMock(
                 template = template.template,
-                alias = template.alias,
+                templateName = template.templateName,
                 generics = template.generics,
                 dependencies = dependencies,
                 relaxer = relaxer
@@ -280,7 +279,7 @@ internal class KMockGenerator(
 
             writeMock(
                 template = template.template,
-                alias = template.alias,
+                templateName = template.templateName,
                 generics = template.generics,
                 dependencies = dependencies,
                 relaxer = relaxer
@@ -296,7 +295,7 @@ internal class KMockGenerator(
         templateSources.forEach { template ->
             writeMock(
                 template = template.template,
-                alias = template.alias,
+                templateName = template.templateName,
                 generics = template.generics,
                 dependencies = dependencies,
                 relaxer = relaxer

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KmockProxyNameSelector.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KmockProxyNameSelector.kt
@@ -14,7 +14,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.MethodTypeInfo
 import tech.antibytes.kmock.processor.ProcessorContract.ProxyInfo
 import tech.antibytes.kmock.processor.ProcessorContract.ProxyNameCollector
 import tech.antibytes.kmock.processor.ProcessorContract.ProxyNameSelector
-import tech.antibytes.kmock.processor.titleCase
+import tech.antibytes.kmock.processor.utils.titleCase
 import java.util.SortedSet
 
 internal class KmockProxyNameSelector(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
@@ -14,10 +14,10 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
-import tech.antibytes.kmock.processor.ProcessorContract.MultiInterfaceBinder
-import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
 import tech.antibytes.kmock.MockCommon
+import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.MultiInterfaceBinder
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 
 internal class KMockMultiInterfaceBinder(
     private val logger: KSPLogger,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
@@ -11,6 +11,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
@@ -31,11 +32,12 @@ internal class KMockMultiInterfaceBinder(
     ): TypeSpec {
         val interfaze = TypeSpec.interfaceBuilder(interfaceName)
         interfaze.addSuperinterfaces(
-            templates.map { parent -> parent.asStarProjectedType().toTypeName().also { println(it) } }
+            templates.map { parent -> parent.asStarProjectedType().toTypeName() }
         )
         interfaze.addAnnotation(
             AnnotationSpec.builder(MockCommon::class).addMember("$interfaceName::class").build()
         )
+        interfaze.addModifiers(KModifier.PRIVATE)
 
         return interfaze.build()
     }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.multi
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.writeTo
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+import tech.antibytes.kmock.processor.ProcessorContract.MultiInterfaceBinder
+import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
+import tech.antibytes.kmock.MockCommon
+
+internal class KMockMultiInterfaceBinder(
+    private val logger: KSPLogger,
+    private val codeGenerator: KmpCodeGenerator,
+) : MultiInterfaceBinder {
+    private fun createInterface(
+        interfaceName: String,
+        templates: List<KSClassDeclaration>
+    ): TypeSpec {
+        val interfaze = TypeSpec.interfaceBuilder(interfaceName)
+        interfaze.addSuperinterfaces(
+            templates.map { parent -> parent.asStarProjectedType().toTypeName() }
+        )
+        interfaze.addAnnotation(
+            AnnotationSpec.builder(MockCommon::class).addMember("$interfaceName::class").build()
+        )
+
+        return interfaze.build()
+    }
+
+    private fun writeInterface(
+        interfaceName: String,
+        packageName: String,
+        templates: List<KSClassDeclaration>,
+        dependencies: KSFile,
+    ) {
+        val file = FileSpec.builder(
+            packageName,
+            interfaceName
+        )
+
+        val implementation = createInterface(
+            interfaceName = interfaceName,
+            templates = templates
+        )
+
+        file.addType(implementation)
+        file.build().writeTo(
+            codeGenerator = codeGenerator,
+            aggregating = true,
+            originatingKSFiles = listOf(dependencies)
+        )
+    }
+
+    override fun bind(
+        templateSources: List<TemplateMultiSource>,
+        dependencies: List<KSFile>
+    ) {
+        templateSources.mapIndexed { idx, source ->
+            writeInterface(
+                interfaceName = source.templateName,
+                packageName = source.packageName,
+                templates = source.templates,
+                dependencies = dependencies[idx]
+            )
+        }
+    }
+}

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
@@ -60,7 +60,6 @@ internal class KMockMultiInterfaceBinder(
             file.addType(implementation)
         }
 
-
         file.build().writeTo(
             codeGenerator = codeGenerator,
             aggregating = true,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
@@ -7,19 +7,16 @@
 package tech.antibytes.kmock.processor.multi
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFile
-import tech.antibytes.kmock.processor.ProcessorContract
-import tech.antibytes.kmock.processor.ProcessorContract.ParentFinder
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
+import tech.antibytes.kmock.processor.ProcessorContract.ParentFinder
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 
 internal object KMockParentFinder : ParentFinder {
     override fun find(
         templateSource: TemplateSource,
         templateMultiSources: Aggregated<TemplateMultiSource>,
-        dependency: KSFile
-    ): Pair<List<KSClassDeclaration>, KSFile> {
+    ): List<KSClassDeclaration> {
         val parentsIdx = templateMultiSources.extractedTemplates.indexOfFirst { parent ->
             templateSource.packageName == parent.packageName &&
                 templateSource.indicator == parent.indicator &&
@@ -27,12 +24,9 @@ internal object KMockParentFinder : ParentFinder {
         }
 
         return if (parentsIdx == -1) {
-            Pair(emptyList(), dependency)
+            emptyList()
         } else {
-            Pair(
-                templateMultiSources.extractedTemplates[parentsIdx].templates,
-                templateMultiSources.dependencies[parentsIdx]
-            )
+            templateMultiSources.extractedTemplates[parentsIdx].templates
         }
     }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.multi
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.ParentFinder
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+
+internal object KMockParentFinder : ParentFinder {
+    override fun find(
+        templateSource: TemplateSource,
+        templateMultiSources: Aggregated<TemplateMultiSource>,
+        dependency: KSFile
+    ): Pair<List<KSClassDeclaration>, KSFile> {
+        val parentsIdx = templateMultiSources.extractedTemplates.indexOfFirst { parent ->
+            templateSource.packageName == parent.packageName &&
+                templateSource.indicator == parent.indicator &&
+                templateSource.templateName == parent.templateName
+        }
+
+        return if (parentsIdx == -1) {
+            Pair(emptyList(), dependency)
+        } else {
+            Pair(
+                templateMultiSources.extractedTemplates[parentsIdx].templates,
+                templateMultiSources.dependencies[parentsIdx]
+            )
+        }
+    }
+}

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilter.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilter.kt
@@ -51,12 +51,19 @@ internal class AnnotationFilter(
         }
     }
 
-    override fun isApplicableAnnotation(
+    override fun isApplicableSingleSourceAnnotation(
         annotation: KSAnnotation
     ): Boolean {
         return annotation.arguments.size == 1 &&
-            annotation.arguments.first().value is List<*> &&
-            ((annotation.arguments.first().value as List<*>).size == 0 || (annotation.arguments.first().value as List<*>).random() is KSType)
+            annotation.arguments[0].value is List<*> &&
+            ((annotation.arguments[0].value as List<*>).size == 0 || (annotation.arguments[0].value as List<*>).random() is KSType)
+    }
+
+    override fun isApplicableMultiSourceAnnotation(annotation: KSAnnotation): Boolean {
+        return annotation.arguments.size == 2 &&
+            annotation.arguments[0].value is String &&
+            annotation.arguments[1].value is List<*> &&
+            ((annotation.arguments[1].value as List<*>).size == 0 || (annotation.arguments[1].value as List<*>).random() is KSType)
     }
 
     private companion object {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilter.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilter.kt
@@ -10,8 +10,11 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSType
 import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_COMMON_MULTI_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_COMMON_NAME
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_PLATFORM_MULTI_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_PLATFORM_NAME
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_SHARED_MULTI_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_SHARED_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.RELAXATION_NAME
 
@@ -69,8 +72,11 @@ internal class AnnotationFilter(
     private companion object {
         val RESERVED = sortedSetOf(
             ANNOTATION_PLATFORM_NAME,
+            ANNOTATION_PLATFORM_MULTI_NAME,
             ANNOTATION_SHARED_NAME,
+            ANNOTATION_SHARED_MULTI_NAME,
             ANNOTATION_COMMON_NAME,
+            ANNOTATION_COMMON_MULTI_NAME,
             RELAXATION_NAME,
         )
     }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/KSClassDeclaration.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/KSClassDeclaration.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.utils
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+internal fun KSClassDeclaration.deriveSimpleName(packageName: String): String {
+    val qualifiedName = ensureNotNullClassName(this.qualifiedName?.asString())
+
+    return if (!qualifiedName.startsWith(packageName) || qualifiedName == packageName) {
+        throw IllegalStateException("Malformed class name!")
+    } else {
+        qualifiedName.substringAfter("$packageName.")
+    }
+}

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SourceFilter.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SourceFilter.kt
@@ -8,22 +8,22 @@ package tech.antibytes.kmock.processor.utils
 
 import com.google.devtools.ksp.processing.KSPLogger
 import tech.antibytes.kmock.processor.ProcessorContract
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.ProcessorContract.Source
 
 internal class SourceFilter(
     private val precedences: Map<String, Int>,
     private val logger: KSPLogger
 ) : ProcessorContract.SourceFilter {
-    override fun filter(
-        templateSources: List<TemplateSource>,
-        filteredBy: List<TemplateSource>
-    ): List<TemplateSource> {
+    override fun <T : Source> filter(
+        templateSources: List<T>,
+        filteredBy: List<T>
+    ): List<T> {
         val filter = filteredBy.map { source ->
-            source.template.qualifiedName!!.asString()
+            "${source.packageName}.${source.templateName}"
         }
 
         return templateSources.filter { source ->
-            !filter.contains(source.template.qualifiedName!!.asString())
+            !filter.contains("${source.packageName}.${source.templateName}")
         }
     }
 
@@ -34,14 +34,14 @@ internal class SourceFilter(
         }
     }
 
-    override fun filterSharedSources(
-        templateSources: List<TemplateSource>
-    ): List<TemplateSource> {
-        val filtered: MutableList<TemplateSource> = mutableListOf()
+    override fun <T : Source> filterSharedSources(
+        templateSources: List<T>
+    ): List<T> {
+        val filtered: MutableList<T> = mutableListOf()
         val filteredNamed: MutableList<String> = mutableListOf()
 
         templateSources.forEach { source ->
-            val qualifiedName = source.template.qualifiedName!!.asString()
+            val qualifiedName = "${source.packageName}.${source.templateName}"
             val currentFieldIdx = filteredNamed.indexOf(qualifiedName)
 
             if (currentFieldIdx == -1) {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SourceSetValidator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SourceSetValidator.kt
@@ -24,7 +24,10 @@ internal class SourceSetValidator(
 
     override fun isValidateSourceSet(sourceSet: Any?): Boolean {
         return when (extractSourceSet(sourceSet)) {
-            !is String -> false
+            !is String -> {
+                logger.warn("Unexpected annotation payload!")
+                false
+            }
             !in knownSharedSourceSets -> {
                 logger.warn("$sourceSet is not a applicable sourceSet!")
                 false

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/StringExtension.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/StringExtension.kt
@@ -4,7 +4,7 @@
  * Use of this source code is governed by Apache v2.0
  */
 
-package tech.antibytes.kmock.processor
+package tech.antibytes.kmock.processor.utils
 
 import java.util.Locale
 
@@ -16,4 +16,8 @@ internal fun String.titleCase(): String {
             it.toString()
         }
     }
+}
+
+internal fun ensureNotNullClassName(name: String?): String {
+    return name ?: throw IllegalStateException("Expected non null class name!")
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
@@ -73,6 +73,7 @@ class KMockFactoriesSpec {
 
     private fun String.normalizeSource(): String = this
         .replace(Regex("[ \t\r\n]+\n"), "\n")
+        .replace(Regex("\n[ \t\r]+"), "\n")
         .replace(Regex("[\t\r]"), " ")
         .replace(Regex("[ ]+"), " ")
         .trim()

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
@@ -75,6 +75,7 @@ class KMockMocksSpec {
 
     private fun String.normalizeSource(): String = this
         .replace(Regex("[ \t\r\n]+\n"), "\n")
+        .replace(Regex("\n[ \t\r]+"), "\n")
         .replace(Regex("[\t\r]"), " ")
         .replace(Regex("[ ]+"), " ")
         .trim()

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -6,10 +6,13 @@
 
 package tech.antibytes.kmock.integration
 
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspArgs
+import com.tschuchort.compiletesting.kspIncremental
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -26,11 +29,28 @@ import java.io.File
 class KMockMultiInterfaceMocksSpec {
     @TempDir
     lateinit var buildDir: File
-    private val provider = KMockProcessorProvider()
     private val root = "/multi"
 
     private fun loadResource(path: String): String {
         return KMockMultiInterfaceMocksSpec::class.java.getResource(root + path).readText()
+    }
+
+    // Workaround for https://github.com/tschuchortdev/kotlin-compile-testing/issues/263
+    class SymbolProcessorProviderSpy : SymbolProcessorProvider {
+        lateinit var lastProcessor: SymbolProcessor
+
+        override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+            val processor = KMockProcessorProvider().create(environment)
+            lastProcessor = processor
+
+            return processor
+        }
+    }
+
+    class ShallowSymbolProcessorProvider(
+        private val processor: SymbolProcessor
+    ) : SymbolProcessorProvider {
+        override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = processor
     }
 
     private fun compile(
@@ -58,6 +78,7 @@ class KMockMultiInterfaceMocksSpec {
             workingDir = buildDir
             inheritClassPath = true
             verbose = false
+            kspIncremental = true
             kspArgs = args
         }.compile()
     }
@@ -65,7 +86,6 @@ class KMockMultiInterfaceMocksSpec {
     private fun findGeneratedSource(filter: (File) -> Boolean): List<File> {
         return buildDir.walkBottomUp()
             .toList()
-            .onEach { println(it) }
             .filter(filter)
     }
 
@@ -76,13 +96,16 @@ class KMockMultiInterfaceMocksSpec {
 
     private fun String.normalizeSource(): String = this
         .replace(Regex("[ \t\r\n]+\n"), "\n")
+        .replace(Regex("\n[ \t\r]+"), "\n")
         .replace(Regex("[\t\r]"), " ")
         .replace(Regex("[ ]+"), " ")
         .trim()
 
     @Test
     fun `Given a annotated Source with multiple Interface it writes a mock`() {
+        // Round1
         // Given
+        val spyProvider = SymbolProcessorProviderSpy()
         val rootInterface = SourceFile.kotlin(
             "Regular1.kt",
             loadResource("/template/common/Regular1.kt")
@@ -98,20 +121,46 @@ class KMockMultiInterfaceMocksSpec {
         val expectedInterface = loadResource("/expected/common/RegularInterface.kt")
 
         // When
-        val compilerResult = compile(
-            provider,
+        val compilerResultRound1 = compile(
+            spyProvider,
             isKmp = true,
             sourceFiles = arrayOf(rootInterface, nestedInterface, scopedInterface)
         )
         val actualIntermediateInterfaces = resolveGenerated("KMockMultiInterfaceArtifacts.kt")
 
         // Then
-        compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK
+        compilerResultRound1.exitCode mustBe KotlinCompilation.ExitCode.OK
         actualIntermediateInterfaces isNot null
 
         actualIntermediateInterfaces!!.absolutePath.toString().endsWith(
             "ksp/sources/kotlin/multi/KMockMultiInterfaceArtifacts.kt"
         ) mustBe true
         actualIntermediateInterfaces.readText().normalizeSource() mustBe expectedInterface.normalizeSource()
+
+        // Round2
+        // Given
+        val provider = ShallowSymbolProcessorProvider(spyProvider.lastProcessor)
+        val multiInterfaceInterface = SourceFile.kotlin(
+            "KMockMultiInterfaceArtifacts.kt",
+            actualIntermediateInterfaces.readText()
+        )
+        val expectedMock = loadResource("/expected/common/RegularMock.kt")
+
+        // When
+        val compilerResultRound2 = compile(
+            provider,
+            isKmp = true,
+            sourceFiles = arrayOf(multiInterfaceInterface, rootInterface, nestedInterface, scopedInterface)
+        )
+        val actualMock = resolveGenerated("CommonMultiMock.kt")
+
+        // Then
+        compilerResultRound2.exitCode mustBe KotlinCompilation.ExitCode.OK
+        actualMock isNot null
+
+        actualMock!!.absolutePath.toString().endsWith(
+            "ksp/sources/kotlin/common/commonTest/kotlin/multi/CommonMultiMock.kt"
+        ) mustBe true
+        actualMock.readText().normalizeSource() mustBe expectedMock.normalizeSource()
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.integration
+
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspArgs
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import tech.antibytes.kmock.processor.KMockProcessorProvider
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.KMOCK_PREFIX
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.KMP_FLAG
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.KSP_DIR
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.PRECEDENCE
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.ROOT_PACKAGE
+import tech.antibytes.util.test.isNot
+import tech.antibytes.util.test.mustBe
+import java.io.File
+
+class KMockMultiInterfaceMocksSpec {
+    @TempDir
+    lateinit var buildDir: File
+    private val provider = KMockProcessorProvider()
+    private val root = "/multi"
+
+    private fun loadResource(path: String): String {
+        return KMockMultiInterfaceMocksSpec::class.java.getResource(root + path).readText()
+    }
+
+    private fun compile(
+        processorProvider: SymbolProcessorProvider,
+        isKmp: Boolean,
+        kspArguments: Map<String, String> = emptyMap(),
+        vararg sourceFiles: SourceFile,
+    ): KotlinCompilation.Result {
+        val args = mutableMapOf(
+            KSP_DIR to "${buildDir.absolutePath.trimEnd('/')}/ksp/sources/kotlin",
+            ROOT_PACKAGE to "multi",
+            KMP_FLAG to isKmp.toString(),
+        ).also {
+            it.putAll(kspArguments)
+        }.also {
+            it["${KMOCK_PREFIX}oldNamePrefix_0"] = "kotlin.collections"
+            it["${KMOCK_PREFIX}oldNamePrefix_1"] = "kotlin"
+            it["${PRECEDENCE}sharedTest"] = "0"
+            it["${PRECEDENCE}otherTest"] = "1"
+        }
+
+        return KotlinCompilation().apply {
+            sources = sourceFiles.toList()
+            symbolProcessorProviders = listOf(processorProvider)
+            workingDir = buildDir
+            inheritClassPath = true
+            verbose = false
+            kspArgs = args
+        }.compile()
+    }
+
+    private fun findGeneratedSource(filter: (File) -> Boolean): List<File> {
+        return buildDir.walkBottomUp()
+            .toList()
+            .onEach { println(it) }
+            .filter(filter)
+    }
+
+    private fun resolveGenerated(expected: String): File? {
+        return findGeneratedSource { file -> file.absolutePath.endsWith(expected) }
+            .getOrNull(0)
+    }
+
+    private fun String.normalizeSource(): String = this
+        .replace(Regex("[ \t\r\n]+\n"), "\n")
+        .replace(Regex("[\t\r]"), " ")
+        .replace(Regex("[ ]+"), " ")
+        .trim()
+
+    @Test
+    fun `Given a annotated Source with multiple Interface it writes a mock`() {
+        // Given
+        val rootInterface = SourceFile.kotlin(
+            "Regular1.kt",
+            loadResource("/template/common/Regular1.kt")
+        )
+        val nestedInterface = SourceFile.kotlin(
+            "Regular3.kt",
+            loadResource("/template/common/nested/Regular3.kt")
+        )
+        val scopedInterface = SourceFile.kotlin(
+            "Regular2.kt",
+            loadResource("/template/common/Regular2.kt")
+        )
+        val expectedInterface = loadResource("/expected/common/RegularInterface.kt")
+
+        // When
+        val compilerResult = compile(
+            provider,
+            isKmp = true,
+            sourceFiles = arrayOf(rootInterface, nestedInterface, scopedInterface)
+        )
+        val actualIntermediateInterfaces = resolveGenerated("KMockMultiInterfaceArtifacts.kt")
+
+        // Then
+        compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK
+        actualIntermediateInterfaces isNot null
+
+        actualIntermediateInterfaces!!.absolutePath.toString().endsWith(
+            "ksp/sources/kotlin/multi/KMockMultiInterfaceArtifacts.kt"
+        ) mustBe true
+        actualIntermediateInterfaces.readText().normalizeSource() mustBe expectedInterface.normalizeSource()
+    }
+}

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -119,23 +119,33 @@ class KMockMultiInterfaceMocksSpec {
             loadResource("/template/common/Regular2.kt")
         )
         val expectedInterface = loadResource("/expected/common/RegularInterface.kt")
+        val expectedActualFactory = loadResource("/expected/common/RegularActualFactory.kt")
 
         // When
         val compilerResultRound1 = compile(
             spyProvider,
             isKmp = true,
+            kspArguments = mapOf(
+                "${KMOCK_PREFIX}allowInterfaces" to "true"
+            ),
             sourceFiles = arrayOf(rootInterface, nestedInterface, scopedInterface)
         )
         val actualIntermediateInterfaces = resolveGenerated("KMockMultiInterfaceArtifacts.kt")
+        val actualActualMockFactory = resolveGenerated("MockFactory.kt")
 
         // Then
         compilerResultRound1.exitCode mustBe KotlinCompilation.ExitCode.OK
         actualIntermediateInterfaces isNot null
+        actualActualMockFactory isNot null
 
         actualIntermediateInterfaces!!.absolutePath.toString().endsWith(
             "ksp/sources/kotlin/multi/KMockMultiInterfaceArtifacts.kt"
         ) mustBe true
+        actualActualMockFactory!!.absolutePath.toString().endsWith(
+            "ksp/sources/kotlin/multi/MockFactory.kt"
+        ) mustBe true
         actualIntermediateInterfaces.readText().normalizeSource() mustBe expectedInterface.normalizeSource()
+        actualActualMockFactory.readText().normalizeSource() mustBe expectedActualFactory.normalizeSource()
 
         // Round2
         // Given

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorCommonSpec.kt
@@ -369,6 +369,7 @@ class KMockAggregatorCommonSpec {
             TemplateSource(
                 indicator = "",
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )
@@ -625,6 +626,7 @@ class KMockAggregatorCommonSpec {
             TemplateSource(
                 indicator = "",
                 templateName = alias,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorCommonSpec.kt
@@ -27,6 +27,8 @@ import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.qualifier.named
@@ -240,6 +242,7 @@ class KMockAggregatorCommonSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -266,6 +269,7 @@ class KMockAggregatorCommonSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -310,6 +314,7 @@ class KMockAggregatorCommonSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -343,6 +348,7 @@ class KMockAggregatorCommonSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -359,7 +365,14 @@ class KMockAggregatorCommonSpec {
         ).extractCommonInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(ProcessorContract.TemplateSource("", declaration, null, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = "",
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 1) {
@@ -391,6 +404,7 @@ class KMockAggregatorCommonSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -503,6 +517,7 @@ class KMockAggregatorCommonSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -530,7 +545,7 @@ class KMockAggregatorCommonSpec {
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
-        val sourceSetValidator: ProcessorContract.SourceSetValidator = mockk()
+        val sourceSetValidator: SourceSetValidator = mockk()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -548,6 +563,7 @@ class KMockAggregatorCommonSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val alias: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -586,6 +602,7 @@ class KMockAggregatorCommonSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -604,7 +621,14 @@ class KMockAggregatorCommonSpec {
         ).extractCommonInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(ProcessorContract.TemplateSource("", declaration, alias, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = "",
+                templateName = alias,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 1) {

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorPlatformSpec.kt
@@ -368,6 +368,7 @@ class KMockAggregatorPlatformSpec {
             TemplateSource(
                 indicator = "",
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )
@@ -625,6 +626,7 @@ class KMockAggregatorPlatformSpec {
             TemplateSource(
                 indicator = "",
                 templateName = alias,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorPlatformSpec.kt
@@ -27,6 +27,7 @@ import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.qualifier.named
@@ -240,6 +241,7 @@ class KMockAggregatorPlatformSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -266,6 +268,7 @@ class KMockAggregatorPlatformSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -310,6 +313,7 @@ class KMockAggregatorPlatformSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -343,6 +347,7 @@ class KMockAggregatorPlatformSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -359,7 +364,14 @@ class KMockAggregatorPlatformSpec {
         ).extractPlatformInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(ProcessorContract.TemplateSource("", declaration, null, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = "",
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
 
@@ -392,6 +404,7 @@ class KMockAggregatorPlatformSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -471,6 +484,7 @@ class KMockAggregatorPlatformSpec {
 
         val className: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -506,6 +520,7 @@ class KMockAggregatorPlatformSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -550,8 +565,9 @@ class KMockAggregatorPlatformSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val alias: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
         val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
@@ -588,6 +604,7 @@ class KMockAggregatorPlatformSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -604,7 +621,14 @@ class KMockAggregatorPlatformSpec {
         ).extractPlatformInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(ProcessorContract.TemplateSource("", declaration, alias, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = "",
+                templateName = alias,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorSharedSpec.kt
@@ -534,6 +534,7 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(fixture.fixture())
 
@@ -562,6 +563,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
@@ -624,6 +626,7 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(fixture.fixture())
 
@@ -652,6 +655,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { annotationFilter.isApplicableAnnotation(any()) } returns true
 
@@ -711,6 +715,7 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -745,6 +750,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -763,7 +769,14 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(TemplateSource(marker, declaration, null, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = marker,
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 1) {
@@ -804,6 +817,7 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -838,6 +852,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -856,7 +871,14 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(TemplateSource(marker, declaration, null, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = marker,
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
 
@@ -918,6 +940,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -958,6 +981,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -977,8 +1001,18 @@ class KMockAggregatorSharedSpec {
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(marker0, declaration, null, generics),
-            TemplateSource(marker1, declaration, null, generics)
+            TemplateSource(
+                indicator = marker0,
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            ),
+            TemplateSource(
+                indicator = marker1,
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            )
         )
 
         verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
@@ -1039,6 +1073,7 @@ class KMockAggregatorSharedSpec {
         }
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -1079,6 +1114,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -1098,8 +1134,18 @@ class KMockAggregatorSharedSpec {
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(marker0, declaration, null, generics),
-            TemplateSource(marker1, declaration, null, generics)
+            TemplateSource(
+                indicator = marker0,
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            ),
+            TemplateSource(
+                indicator = marker1,
+                templateName = simpleName,
+                template = declaration,
+                generics = generics
+            )
         )
 
         verify(exactly = 6) { genericResolver.extractGenerics(declaration, any()) }
@@ -1151,6 +1197,7 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(
             fixture.fixture()
@@ -1181,6 +1228,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -1233,6 +1281,7 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(
             fixture.fixture()
@@ -1458,6 +1507,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -1517,8 +1567,9 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val alias: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(
             fixture.fixture()
         )
@@ -1559,6 +1610,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -1577,7 +1629,14 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(TemplateSource(allowedSourceSets.first(), declaration, alias, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = allowedSourceSets.first(),
+                templateName = alias,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 1) {
@@ -1612,8 +1671,9 @@ class KMockAggregatorSharedSpec {
         val values: List<KSType> = listOf(type)
 
         val className: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val alias: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(
             fixture.fixture()
         )
@@ -1633,7 +1693,7 @@ class KMockAggregatorSharedSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns customAnnotations.keys.random()
+        } returns customAnnotations.keys.first()
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -1654,6 +1714,7 @@ class KMockAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns className
         every { declaration.packageName.asString() } returns packageName
+        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -1672,7 +1733,14 @@ class KMockAggregatorSharedSpec {
         ).extractSharedInterfaces(resolver)
 
         // Then
-        interfaces mustBe listOf(TemplateSource(allowedSourceSets.first(), declaration, alias, generics))
+        interfaces mustBe listOf(
+            TemplateSource(
+                indicator = allowedSourceSets.first(),
+                templateName = alias,
+                template = declaration,
+                generics = generics
+            )
+        )
 
         verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 2) {

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockAggregatorSharedSpec.kt
@@ -773,6 +773,7 @@ class KMockAggregatorSharedSpec {
             TemplateSource(
                 indicator = marker,
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )
@@ -875,6 +876,7 @@ class KMockAggregatorSharedSpec {
             TemplateSource(
                 indicator = marker,
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )
@@ -1004,12 +1006,14 @@ class KMockAggregatorSharedSpec {
             TemplateSource(
                 indicator = marker0,
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             ),
             TemplateSource(
                 indicator = marker1,
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )
@@ -1137,12 +1141,14 @@ class KMockAggregatorSharedSpec {
             TemplateSource(
                 indicator = marker0,
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             ),
             TemplateSource(
                 indicator = marker1,
                 templateName = simpleName,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )
@@ -1633,6 +1639,7 @@ class KMockAggregatorSharedSpec {
             TemplateSource(
                 indicator = allowedSourceSets.first(),
                 templateName = alias,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )
@@ -1737,6 +1744,7 @@ class KMockAggregatorSharedSpec {
             TemplateSource(
                 indicator = allowedSourceSets.first(),
                 templateName = alias,
+                packageName = packageName,
                 template = declaration,
                 generics = generics
             )

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
@@ -91,7 +91,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writeSharedMocks(any(), any(), any()) } just Runs
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
-        every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
+        every { factoryGenerator.writeFactories(any(), any(), any(), any()) } just Runs
         every { entryPointGenerator.generateCommon(any(), any()) } just Runs
         every { entryPointGenerator.generateShared(any()) } just Runs
 
@@ -164,7 +164,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writeSharedMocks(any(), any(), any()) } just Runs
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
-        every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
+        every { factoryGenerator.writeFactories(any(), any(), any(), any()) } just Runs
         every { entryPointGenerator.generateCommon(any(), any()) } just Runs
         every { entryPointGenerator.generateShared(any()) } just Runs
 
@@ -252,7 +252,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writeSharedMocks(any(), any(), any()) } just Runs
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
-        every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
+        every { factoryGenerator.writeFactories(any(), any(), any(), any()) } just Runs
         every { entryPointGenerator.generateCommon(any(), any()) } just Runs
         every { entryPointGenerator.generateShared(any()) } just Runs
 
@@ -304,6 +304,7 @@ class KMockProcessorSpec {
                     interfacesFiltered,
                     interfacesFiltered,
                 ).flatten(),
+                emptyList(),
                 dependencies.toMutableList().also {
                     it.addAll(dependencies)
                     it.addAll(dependencies)
@@ -389,7 +390,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writeSharedMocks(any(), any(), any()) } just Runs
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
-        every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
+        every { factoryGenerator.writeFactories(any(), any(), any(), any()) } just Runs
         every { entryPointGenerator.generateCommon(any(), any()) } just Runs
         every { entryPointGenerator.generateShared(any()) } just Runs
 
@@ -464,12 +465,11 @@ class KMockProcessorSpec {
             factoryGenerator.writeFactories(
                 listOf(
                     interfacesCommonRound1,
-                    interfacesCommonRound2,
                     interfacesFiltered,
                     interfacesFiltered,
                 ).flatten(),
+                multiInterfacesCommon,
                 dependencies.toMutableList().also {
-                    it.addAll(dependencies)
                     it.addAll(dependencies)
                     it.addAll(dependencies)
                 },
@@ -479,10 +479,9 @@ class KMockProcessorSpec {
 
         verify(exactly = 1) {
             entryPointGenerator.generateCommon(
-                listOf(interfacesCommonRound1, interfacesCommonRound2).flatten(),
+                listOf(interfacesCommonRound1).flatten(),
                 listOf(
                     interfacesCommonRound1,
-                    interfacesCommonRound2,
                     interfacesFiltered,
                     interfacesFiltered,
                 ).flatten()
@@ -532,7 +531,7 @@ class KMockProcessorSpec {
         every { mockGenerator.writeSharedMocks(any(), any(), any()) } just Runs
         every { mockGenerator.writePlatformMocks(any(), any(), any()) } just Runs
 
-        every { factoryGenerator.writeFactories(any(), any(), any()) } just Runs
+        every { factoryGenerator.writeFactories(any(), any(), any(), any()) } just Runs
         every { entryPointGenerator.generateCommon(any(), any()) } just Runs
 
         // When
@@ -573,6 +572,7 @@ class KMockProcessorSpec {
                 listOf(
                     interfacesFiltered.first(),
                 ),
+                emptyList(),
                 dependencies,
                 relaxer
             )

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
@@ -433,6 +433,10 @@ class KMockProcessorSpec {
             interfaceBinder.bind(multiInterfacesCommon, dependencies)
         }
 
+        verify(exactly = 1) {
+            interfaceBinder.bind(any(), any())
+        }
+
         verify(exactly = 1) { filter.filter(interfacesFiltered, interfacesCommonRound1) }
         verify(exactly = 1) {
             filter.filter(
@@ -503,7 +507,7 @@ class KMockProcessorSpec {
         val entryPointGenerator: MockFactoryEntryPointGenerator = mockk()
 
         val filter: ProcessorContract.SourceFilter = mockk()
-        val relaxer: Relaxer = Relaxer(fixture.fixture(), fixture.fixture())
+        val relaxer = Relaxer(fixture.fixture(), fixture.fixture())
 
         val illegal: List<KSAnnotated> = listOf(mockk())
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
@@ -16,6 +16,12 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
+import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryEntryPointGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.MockGenerator
+import tech.antibytes.kmock.processor.ProcessorContract.Source
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fulfils
@@ -41,11 +47,11 @@ class KMockProcessorSpec {
     fun `Given process is called it returns all aggregated and merges illegal sources`() {
         // Given
         val resolver: Resolver = mockk()
-        val aggregator: ProcessorContract.Aggregator = mockk()
+        val aggregator: Aggregator = mockk()
 
-        val mockGenerator: ProcessorContract.MockGenerator = mockk()
-        val factoryGenerator: ProcessorContract.MockFactoryGenerator = mockk()
-        val entryPointGenerator: ProcessorContract.MockFactoryEntryPointGenerator = mockk()
+        val mockGenerator: MockGenerator = mockk()
+        val factoryGenerator: MockFactoryGenerator = mockk()
+        val entryPointGenerator: MockFactoryEntryPointGenerator = mockk()
 
         val illegalCommon: List<KSAnnotated> = listOf(mockk())
         val illegalShared: List<KSAnnotated> = listOf(mockk())
@@ -53,15 +59,15 @@ class KMockProcessorSpec {
 
         every {
             aggregator.extractCommonInterfaces(any())
-        } returns ProcessorContract.Aggregated(illegalCommon, listOf(mockk()), listOf(mockk()))
+        } returns Aggregated(illegalCommon, listOf(mockk()), listOf(mockk()))
 
         every {
             aggregator.extractSharedInterfaces(any())
-        } returns ProcessorContract.Aggregated(illegalShared, listOf(mockk()), listOf(mockk()))
+        } returns Aggregated(illegalShared, listOf(mockk()), listOf(mockk()))
 
         every {
             aggregator.extractPlatformInterfaces(any())
-        } returns ProcessorContract.Aggregated(illegalPlatform, listOf(mockk()), listOf(mockk()))
+        } returns Aggregated(illegalPlatform, listOf(mockk()), listOf(mockk()))
 
         every { aggregator.extractRelaxer(any()) } returns mockk()
 
@@ -96,12 +102,12 @@ class KMockProcessorSpec {
     fun `Given process is called it delegates captured Stubs to the StubGenerator`() {
         // Given
         val resolver: Resolver = mockk()
-        val aggregator: ProcessorContract.Aggregator = mockk()
+        val aggregator: Aggregator = mockk()
 
         val codeGenerator: ProcessorContract.KmpCodeGenerator = mockk()
-        val mockGenerator: ProcessorContract.MockGenerator = mockk()
-        val factoryGenerator: ProcessorContract.MockFactoryGenerator = mockk()
-        val entryPointGenerator: ProcessorContract.MockFactoryEntryPointGenerator = mockk()
+        val mockGenerator: MockGenerator = mockk()
+        val factoryGenerator: MockFactoryGenerator = mockk()
+        val entryPointGenerator: MockFactoryEntryPointGenerator = mockk()
 
         val filter: ProcessorContract.SourceFilter = mockk()
         val relaxer: ProcessorContract.Relaxer = ProcessorContract.Relaxer(fixture.fixture(), fixture.fixture())
@@ -117,18 +123,18 @@ class KMockProcessorSpec {
 
         every {
             aggregator.extractCommonInterfaces(any())
-        } returns ProcessorContract.Aggregated(illegal, interfacesCommon, dependencies)
+        } returns Aggregated(illegal, interfacesCommon, dependencies)
 
         every {
             aggregator.extractSharedInterfaces(any())
-        } returns ProcessorContract.Aggregated(illegal, interfacesShared, dependencies)
+        } returns Aggregated(illegal, interfacesShared, dependencies)
 
         every {
             aggregator.extractPlatformInterfaces(any())
-        } returns ProcessorContract.Aggregated(illegal, interfacesPlatform, dependencies)
+        } returns Aggregated(illegal, interfacesPlatform, dependencies)
 
-        every { filter.filter(any(), any()) } returns interfacesFiltered
-        every { filter.filterSharedSources(any()) } returns interfacesFiltered
+        every { filter.filter<Source>(any(), any()) } returns interfacesFiltered
+        every { filter.filterSharedSources<Source>(any()) } returns interfacesFiltered
 
         every { aggregator.extractRelaxer(any()) } returns relaxer
 
@@ -207,12 +213,12 @@ class KMockProcessorSpec {
     fun `Given process is called it delegates it delegates only Platform sources`() {
         // Given
         val resolver: Resolver = mockk()
-        val aggregator: ProcessorContract.Aggregator = mockk()
+        val aggregator: Aggregator = mockk()
 
         val codeGenerator: ProcessorContract.KmpCodeGenerator = mockk()
-        val mockGenerator: ProcessorContract.MockGenerator = mockk()
-        val factoryGenerator: ProcessorContract.MockFactoryGenerator = mockk()
-        val entryPointGenerator: ProcessorContract.MockFactoryEntryPointGenerator = mockk()
+        val mockGenerator: MockGenerator = mockk()
+        val factoryGenerator: MockFactoryGenerator = mockk()
+        val entryPointGenerator: MockFactoryEntryPointGenerator = mockk()
 
         val filter: ProcessorContract.SourceFilter = mockk()
         val relaxer: ProcessorContract.Relaxer = ProcessorContract.Relaxer(fixture.fixture(), fixture.fixture())
@@ -227,10 +233,10 @@ class KMockProcessorSpec {
 
         every {
             aggregator.extractPlatformInterfaces(any())
-        } returns ProcessorContract.Aggregated(illegal, interfacesPlatform, dependencies)
+        } returns Aggregated(illegal, interfacesPlatform, dependencies)
 
-        every { filter.filter(any(), any()) } returns interfacesFiltered
-        every { filter.filterSharedSources(any()) } returns interfacesFiltered
+        every { filter.filter<Source>(any(), any()) } returns interfacesFiltered
+        every { filter.filterSharedSources<Source>(any()) } returns interfacesFiltered
 
         every { aggregator.extractRelaxer(any()) } returns relaxer
 
@@ -259,8 +265,8 @@ class KMockProcessorSpec {
 
         verify(exactly = 0) { mockGenerator.writeCommonMocks(any(), any(), any()) }
 
-        verify(exactly = 1) { filter.filter(any(), any()) }
-        verify(exactly = 0) { filter.filterSharedSources(any()) }
+        verify(exactly = 1) { filter.filter<Source>(any(), any()) }
+        verify(exactly = 0) { filter.filterSharedSources<Source>(any()) }
 
         verify(exactly = 0) { mockGenerator.writeSharedMocks(any(), any(), any()) }
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorCommonSpec.kt
@@ -51,6 +51,7 @@ class KMockMultiSourceAggregatorCommonSpec {
     fun `It fulfils Aggregator`() {
         KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -62,6 +63,7 @@ class KMockMultiSourceAggregatorCommonSpec {
     fun `It fulfils MultiSourceAggregator`() {
         KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -103,6 +105,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -146,6 +149,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -209,6 +213,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 mockk(),
                 mockk(),
                 mockk(),
@@ -295,6 +300,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 mockk(),
                 mockk(),
                 mockk(),
@@ -317,6 +323,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -374,6 +381,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             genericResolver,
@@ -385,7 +393,7 @@ class KMockMultiSourceAggregatorCommonSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -398,12 +406,13 @@ class KMockMultiSourceAggregatorCommonSpec {
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it returns all found interfaces, while filtering douplets`() {
+    fun `Given extractCommonInterfaces is called it returns all found interfaces while filtering doublets`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -463,6 +472,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             genericResolver,
@@ -474,7 +484,7 @@ class KMockMultiSourceAggregatorCommonSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -487,12 +497,13 @@ class KMockMultiSourceAggregatorCommonSpec {
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it returns all found interfaces while using the shortest package name`() {
+    fun `Given extractCommonInterfaces is called it returns all found interfaces while using the RootPackage`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -572,6 +583,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             genericResolver,
@@ -583,7 +595,7 @@ class KMockMultiSourceAggregatorCommonSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName3,
+                packageName = rootPackage,
                 templates = listOf(declaration1, declaration2, declaration3),
                 generics = listOf(generics, generics, generics)
             )
@@ -652,6 +664,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         // When
         val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(relaxed = true),
@@ -673,6 +686,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         val notRelatedSymbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val notRelatedAnnotation: KSAnnotation = mockk()
@@ -736,6 +750,7 @@ class KMockMultiSourceAggregatorCommonSpec {
         // When
         val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             mockk(relaxed = true),
@@ -748,7 +763,7 @@ class KMockMultiSourceAggregatorCommonSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(emptyMap())
             )

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorCommonSpec.kt
@@ -24,14 +24,13 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.Mock
-import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
+import tech.antibytes.kmock.MultiMockCommon
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
-import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.ProcessorContract.MultiSourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.qualifier.named
@@ -39,7 +38,7 @@ import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 import kotlin.test.assertFailsWith
 
-class KMockSourceAggregatorPlatformSpec {
+class KMockMultiSourceAggregatorCommonSpec {
     private val fixture = kotlinFixture { configuration ->
         configuration.addGenerator(
             String::class,
@@ -50,30 +49,28 @@ class KMockSourceAggregatorPlatformSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockSourceAggregator(
+        KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
-            emptyMap(),
             emptyMap(),
         ) fulfils Aggregator::class
     }
 
     @Test
-    fun `It fulfils SourceAggregator`() {
-        KMockSourceAggregator(
+    fun `It fulfils MultiSourceAggregator`() {
+        KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
-            emptyMap(),
-        ) fulfils SourceAggregator::class
+        ) fulfils MultiSourceAggregator::class
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
+    fun `Given extractCommonInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
         // Given
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
@@ -104,24 +101,23 @@ class KMockSourceAggregatorPlatformSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
-            emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it filters all ill Annotations`() {
+    fun `Given extractCommonInterfaces is called it filters all ill Annotations`() {
         // Given
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
@@ -143,29 +139,28 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
-            emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it filters all non class types and reports an error`() {
+    fun `Given extractCommonInterfaces is called it filters all non class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -186,6 +181,7 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -193,14 +189,16 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { file.parent } returns null
         every { symbol.parent } returns file
@@ -209,26 +207,25 @@ class KMockSourceAggregatorPlatformSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
                 mockk(),
                 emptyMap(),
-                emptyMap(),
-            ).extractPlatformInterfaces(resolver)
+            ).extractCommonInterfaces(resolver)
         }
 
         // Then
         error.message mustBe "Cannot stub non interfaces."
         verify(exactly = 1) { logger.error("Cannot stub non interfaces.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it filters all implementation class types and reports an error`() {
+    fun `Given extractCommonInterfaces is called it filters all implementation class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -259,10 +256,11 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -270,21 +268,23 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns selection[selector]
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
         every { declaration.simpleName.asString() } returns simpleName
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
@@ -293,26 +293,25 @@ class KMockSourceAggregatorPlatformSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
                 mockk(),
                 emptyMap(),
-                emptyMap(),
-            ).extractPlatformInterfaces(resolver)
+            ).extractCommonInterfaces(resolver)
         }
 
         // Then
         error.message mustBe "Cannot stub non interface $packageName.$qualifiedName."
         verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$qualifiedName.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns all found interfaces`() {
+    fun `Given extractCommonInterfaces is called it returns all found interfaces`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -333,9 +332,7 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
-
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -351,58 +348,57 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
 
         every { logger.error(any()) } just Runs
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             genericResolver,
             emptyMap(),
-            emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = "",
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             )
         )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns all found interfaces while filtering douplets`() {
+    fun `Given extractCommonInterfaces is called it returns all found interfaces, while filtering douplets`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -412,9 +408,11 @@ class KMockSourceAggregatorPlatformSpec {
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
             yield(annotation)
+            yield(annotation)
         }
 
         val annotated: Sequence<KSAnnotated> = sequence {
+            yield(symbol)
             yield(symbol)
         }
 
@@ -422,10 +420,8 @@ class KMockSourceAggregatorPlatformSpec {
         val declaration: KSClassDeclaration = mockk(relaxed = true)
         val arguments: List<KSValueArgument> = mockk()
 
-        val values: List<KSType> = listOf(type, type)
-
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
+        val values: List<KSType> = listOf(type)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -441,58 +437,168 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
 
         every { logger.error(any()) } just Runs
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             genericResolver,
             emptyMap(),
-            emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = "",
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             )
         )
 
         verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns the corresponding source files`() {
+    fun `Given extractCommonInterfaces is called it returns all found interfaces while using the shortest package name`() {
+        // Given
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(symbol)
+        }
+
+        val type1: KSType = mockk(relaxed = true)
+        val type2: KSType = mockk(relaxed = true)
+        val type3: KSType = mockk(relaxed = true)
+        val declaration1: KSClassDeclaration = mockk(relaxed = true)
+        val declaration2: KSClassDeclaration = mockk(relaxed = true)
+        val declaration3: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type1, type2, type3)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
+
+        val className1: String = fixture.fixture(named("stringAlpha"))
+        val packageName1 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className2: String = fixture.fixture(named("stringAlpha"))
+        val packageName2 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className3: String = fixture.fixture(named("stringAlpha"))
+        val packageName3 = fixture.fixture<String>(named("stringAlpha"))
+
+        val genericResolver: ProcessorContract.GenericResolver = mockk()
+        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
+            emptyMap()
+        } else {
+            null
+        }
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every { symbol.annotations } returns sourceAnnotations
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns MultiMockCommon::class.qualifiedName!!
+
+        every { annotation.arguments } returns arguments
+        every { arguments.size } returns 2
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
+
+        every { type1.declaration } returns declaration1
+        every { declaration1.classKind } returns ClassKind.INTERFACE
+        every { declaration1.parentDeclaration } returns null
+        every { declaration1.qualifiedName!!.asString() } returns className1
+        every { declaration1.packageName.asString() } returns packageName1
+
+        every { type2.declaration } returns declaration2
+        every { declaration2.classKind } returns ClassKind.INTERFACE
+        every { declaration2.parentDeclaration } returns null
+        every { declaration2.qualifiedName!!.asString() } returns className2
+        every { declaration2.packageName.asString() } returns packageName2
+
+        every { type3.declaration } returns declaration3
+        every { declaration3.classKind } returns ClassKind.INTERFACE
+        every { declaration3.parentDeclaration } returns null
+        every { declaration3.qualifiedName!!.asString() } returns className3
+        every { declaration3.packageName.asString() } returns packageName3
+
+        every { logger.error(any()) } just Runs
+
+        every { genericResolver.extractGenerics(any(), any()) } returns generics
+
+        // When
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
+            logger,
+            mockk(),
+            mockk(),
+            genericResolver,
+            emptyMap(),
+        ).extractCommonInterfaces(resolver)
+
+        // Then
+        interfaces mustBe listOf(
+            TemplateMultiSource(
+                indicator = "",
+                templateName = mockName,
+                packageName = packageName3,
+                templates = listOf(declaration1, declaration2, declaration3),
+                generics = listOf(generics, generics, generics)
+            )
+        )
+
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration1, any()) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration2, any()) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration3, any()) }
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
+        }
+    }
+
+    @Test
+    fun `Given extractCommonInterfaces is called it returns the corresponding source files`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -513,9 +619,7 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
-
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -524,46 +628,45 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
 
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(relaxed = true),
             emptyMap(),
-            emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
+    fun `Given extractCommonInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -592,10 +695,8 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
-
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -605,154 +706,55 @@ class KMockSourceAggregatorPlatformSpec {
             notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returnsMany listOf(
             MockShared::class.qualifiedName!!,
-            MockCommon::class.qualifiedName!!
+            Mock::class.qualifiedName!!
         )
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
         every { notRelatedSymbol.annotations } returns notRelatedSource
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
 
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(relaxed = true),
             emptyMap(),
-            emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = "",
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = emptyMap()
+                templates = listOf(declaration),
+                generics = listOf(emptyMap())
             )
         )
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
-        }
-    }
-
-    @Test
-    fun `Given extractPlatformInterfaces is called it returns while mapping aliases`() {
-        // Given
-        val logger: KSPLogger = mockk()
-        val symbol: KSAnnotated = mockk()
-        val resolver: Resolver = mockk()
-        val file: KSFile = mockk()
-        val sourceSetValidator: SourceSetValidator = mockk()
-
-        val annotation: KSAnnotation = mockk()
-        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
-            yield(annotation)
-        }
-
-        val annotated: Sequence<KSAnnotated> = sequence {
-            yield(symbol)
-        }
-
-        val type: KSType = mockk(relaxed = true)
-        val declaration: KSClassDeclaration = mockk(relaxed = true)
-        val arguments: List<KSValueArgument> = mockk()
-
-        val values: List<KSType> = listOf(type)
-
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
-        val packageName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-
-        val genericResolver: ProcessorContract.GenericResolver = mockk()
-        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
-            emptyMap()
-        } else {
-            null
-        }
-
-        val mapping = mapOf(qualifiedName to alias)
-
-        every {
-            resolver.getSymbolsWithAnnotation(any(), any())
-        } returns annotated
-
-        every {
-            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
-
-        every { symbol.annotations } returns sourceAnnotations
-
-        every { annotation.arguments } returns arguments
-        every { arguments.isEmpty() } returns false
-
-        every { arguments.size } returns 1
-        every { arguments[0].value } returns values
-
-        every { type.declaration } returns declaration
-        every { declaration.classKind } returns ClassKind.INTERFACE
-
-        every { file.parent } returns null
-        every { symbol.parent } returns file
-
-        every { declaration.parentDeclaration } returns null
-        every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
-
-        every { logger.error(any()) } just Runs
-
-        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
-
-        every { genericResolver.extractGenerics(any(), any()) } returns generics
-
-        // When
-        val (_, interfaces, _) = KMockSourceAggregator(
-            logger,
-            mockk(),
-            sourceSetValidator,
-            genericResolver,
-            emptyMap(),
-            mapping,
-        ).extractPlatformInterfaces(resolver)
-
-        // Then
-        interfaces mustBe listOf(
-            TemplateSource(
-                indicator = "",
-                templateName = alias,
-                packageName = packageName,
-                template = declaration,
-                generics = generics
-            )
-        )
-
-        verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
-        verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockCommon::class.qualifiedName!!, false)
         }
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorFactorySpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorFactorySpec.kt
@@ -14,22 +14,22 @@ import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.processor.ProcessorContract.AggregatorFactory
 import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
 import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.MultiSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.mapFixture
 import tech.antibytes.util.test.fulfils
 
-class KMockSourceAggregatorFactorySpec {
+class KMockMultiSourceAggregatorFactorySpec {
     private val fixture = kotlinFixture()
 
     @Test
     fun `It fulfils AggregatorFactory`() {
-        KMockSourceAggregator fulfils AggregatorFactory::class
+        KMockMultiSourceAggregator fulfils AggregatorFactory::class
     }
 
     @Test
-    fun `Given getInstance is called it returns a SourceAggregator`() {
+    fun `Given getInstance is called it returns a MultiSourceAggregator`() {
         // Given
         val logger: KSPLogger = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -42,7 +42,7 @@ class KMockSourceAggregatorFactorySpec {
         every { annotationFilter.filterAnnotation(any()) } returns customAnnotations
 
         // When
-        val actual = KMockSourceAggregator.getInstance(
+        val actual = KMockMultiSourceAggregator.getInstance(
             logger = logger,
             sourceSetValidator = sourceSetValidator,
             annotationFilter = annotationFilter,
@@ -52,7 +52,7 @@ class KMockSourceAggregatorFactorySpec {
         )
 
         // Then
-        actual fulfils SourceAggregator::class
+        actual fulfils MultiSourceAggregator::class
 
         verify(exactly = 1) {
             annotationFilter.filterAnnotation(customAnnotations)

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorFactorySpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorFactorySpec.kt
@@ -16,6 +16,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
 import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.MultiSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
+import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.mapFixture
 import tech.antibytes.util.test.fulfils
@@ -44,6 +45,7 @@ class KMockMultiSourceAggregatorFactorySpec {
         // When
         val actual = KMockMultiSourceAggregator.getInstance(
             logger = logger,
+            rootPackage = fixture.fixture(),
             sourceSetValidator = sourceSetValidator,
             annotationFilter = annotationFilter,
             generics = generics,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorPlatformSpec.kt
@@ -24,14 +24,13 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.Mock
-import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
+import tech.antibytes.kmock.MultiMock
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
-import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.ProcessorContract.MultiSourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.qualifier.named
@@ -39,7 +38,7 @@ import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 import kotlin.test.assertFailsWith
 
-class KMockSourceAggregatorPlatformSpec {
+class KMockMultiSourceAggregatorPlatformSpec {
     private val fixture = kotlinFixture { configuration ->
         configuration.addGenerator(
             String::class,
@@ -50,26 +49,24 @@ class KMockSourceAggregatorPlatformSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockSourceAggregator(
+        KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
-            emptyMap(),
             emptyMap(),
         ) fulfils Aggregator::class
     }
 
     @Test
-    fun `It fulfils SourceAggregator`() {
-        KMockSourceAggregator(
+    fun `It fulfils MultiSourceAggregator`() {
+        KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
-            emptyMap(),
-        ) fulfils SourceAggregator::class
+        ) fulfils MultiSourceAggregator::class
     }
 
     @Test
@@ -104,19 +101,18 @@ class KMockSourceAggregatorPlatformSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
-            emptyMap(),
             emptyMap(),
         ).extractPlatformInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 
@@ -143,24 +139,23 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
-            emptyMap(),
             emptyMap(),
         ).extractPlatformInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 
@@ -186,6 +181,7 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -193,14 +189,16 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { file.parent } returns null
         every { symbol.parent } returns file
@@ -209,12 +207,11 @@ class KMockSourceAggregatorPlatformSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
                 mockk(),
-                emptyMap(),
                 emptyMap(),
             ).extractPlatformInterfaces(resolver)
         }
@@ -223,7 +220,7 @@ class KMockSourceAggregatorPlatformSpec {
         error.message mustBe "Cannot stub non interfaces."
         verify(exactly = 1) { logger.error("Cannot stub non interfaces.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 
@@ -259,10 +256,11 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -270,21 +268,23 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns selection[selector]
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
         every { declaration.simpleName.asString() } returns simpleName
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
@@ -293,12 +293,11 @@ class KMockSourceAggregatorPlatformSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
                 mockk(),
-                emptyMap(),
                 emptyMap(),
             ).extractPlatformInterfaces(resolver)
         }
@@ -307,7 +306,7 @@ class KMockSourceAggregatorPlatformSpec {
         error.message mustBe "Cannot stub non interface $packageName.$qualifiedName."
         verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$qualifiedName.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 
@@ -333,9 +332,7 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
-
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -351,58 +348,146 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
 
         every { logger.error(any()) } just Runs
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             genericResolver,
             emptyMap(),
-            emptyMap(),
         ).extractPlatformInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = "",
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             )
         )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns all found interfaces while filtering douplets`() {
+    fun `Given extractPlatformInterfaces is called it returns all found interfaces, while filtering douplets`() {
+        // Given
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+            yield(annotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(symbol)
+            yield(symbol)
+        }
+
+        val type: KSType = mockk(relaxed = true)
+        val declaration: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
+        val packageName: String = fixture.fixture(named("stringAlpha"))
+
+        val genericResolver: ProcessorContract.GenericResolver = mockk()
+        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
+            emptyMap()
+        } else {
+            null
+        }
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns MultiMock::class.qualifiedName!!
+
+        every { symbol.annotations } returns sourceAnnotations
+
+        every { annotation.arguments } returns arguments
+        every { arguments.size } returns 2
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
+        every { type.declaration } returns declaration
+        every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
+
+        every { declaration.packageName.asString() } returns packageName
+
+        every { logger.error(any()) } just Runs
+
+        every { genericResolver.extractGenerics(any(), any()) } returns generics
+
+        // When
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
+            logger,
+            mockk(),
+            mockk(),
+            genericResolver,
+            emptyMap(),
+        ).extractPlatformInterfaces(resolver)
+
+        // Then
+        interfaces mustBe listOf(
+            TemplateMultiSource(
+                indicator = "",
+                templateName = mockName,
+                packageName = packageName,
+                templates = listOf(declaration),
+                generics = listOf(generics)
+            )
+        )
+
+        verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
+        }
+    }
+
+    @Test
+    fun `Given extractPlatformInterfaces is called it returns all found interfaces while using the shortest package name`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -418,15 +503,23 @@ class KMockSourceAggregatorPlatformSpec {
             yield(symbol)
         }
 
-        val type: KSType = mockk(relaxed = true)
-        val declaration: KSClassDeclaration = mockk(relaxed = true)
+        val type1: KSType = mockk(relaxed = true)
+        val type2: KSType = mockk(relaxed = true)
+        val type3: KSType = mockk(relaxed = true)
+        val declaration1: KSClassDeclaration = mockk(relaxed = true)
+        val declaration2: KSClassDeclaration = mockk(relaxed = true)
+        val declaration3: KSClassDeclaration = mockk(relaxed = true)
         val arguments: List<KSValueArgument> = mockk()
 
-        val values: List<KSType> = listOf(type, type)
+        val values: List<KSType> = listOf(type1, type2, type3)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val packageName: String = fixture.fixture(named("stringAlpha"))
+        val className1: String = fixture.fixture(named("stringAlpha"))
+        val packageName1 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className2: String = fixture.fixture(named("stringAlpha"))
+        val packageName2 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className3: String = fixture.fixture(named("stringAlpha"))
+        val packageName3 = fixture.fixture<String>(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
         val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
@@ -439,55 +532,68 @@ class KMockSourceAggregatorPlatformSpec {
             resolver.getSymbolsWithAnnotation(any(), any())
         } returns annotated
 
-        every {
-            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
-
         every { symbol.annotations } returns sourceAnnotations
 
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns MultiMock::class.qualifiedName!!
+
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
-        every { type.declaration } returns declaration
-        every { declaration.classKind } returns ClassKind.INTERFACE
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
-        every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { type1.declaration } returns declaration1
+        every { declaration1.classKind } returns ClassKind.INTERFACE
+        every { declaration1.parentDeclaration } returns null
+        every { declaration1.qualifiedName!!.asString() } returns className1
+        every { declaration1.packageName.asString() } returns packageName1
+
+        every { type2.declaration } returns declaration2
+        every { declaration2.classKind } returns ClassKind.INTERFACE
+        every { declaration2.parentDeclaration } returns null
+        every { declaration2.qualifiedName!!.asString() } returns className2
+        every { declaration2.packageName.asString() } returns packageName2
+
+        every { type3.declaration } returns declaration3
+        every { declaration3.classKind } returns ClassKind.INTERFACE
+        every { declaration3.parentDeclaration } returns null
+        every { declaration3.qualifiedName!!.asString() } returns className3
+        every { declaration3.packageName.asString() } returns packageName3
 
         every { logger.error(any()) } just Runs
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             genericResolver,
             emptyMap(),
-            emptyMap(),
         ).extractPlatformInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = "",
-                templateName = simpleName,
-                packageName = packageName,
-                template = declaration,
-                generics = generics
+                templateName = mockName,
+                packageName = packageName3,
+                templates = listOf(declaration1, declaration2, declaration3),
+                generics = listOf(generics, generics, generics)
             )
         )
 
-        verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration1, any()) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration2, any()) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration3, any()) }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 
@@ -513,9 +619,7 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
-
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -524,41 +628,40 @@ class KMockSourceAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
 
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(relaxed = true),
-            emptyMap(),
             emptyMap(),
         ).extractPlatformInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 
@@ -592,10 +695,8 @@ class KMockSourceAggregatorPlatformSpec {
         val arguments: List<KSValueArgument> = mockk()
 
         val values: List<KSType> = listOf(type)
-
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -605,154 +706,55 @@ class KMockSourceAggregatorPlatformSpec {
             notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returnsMany listOf(
             MockShared::class.qualifiedName!!,
-            MockCommon::class.qualifiedName!!
+            Mock::class.qualifiedName!!
         )
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MultiMock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
         every { notRelatedSymbol.annotations } returns notRelatedSource
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
+        every { arguments.size } returns 2
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
+
+        every { declaration.parentDeclaration } returns null
 
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
 
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(relaxed = true),
-            emptyMap(),
             emptyMap(),
         ).extractPlatformInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = "",
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = emptyMap()
+                templates = listOf(declaration),
+                generics = listOf(emptyMap())
             )
         )
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
-        }
-    }
-
-    @Test
-    fun `Given extractPlatformInterfaces is called it returns while mapping aliases`() {
-        // Given
-        val logger: KSPLogger = mockk()
-        val symbol: KSAnnotated = mockk()
-        val resolver: Resolver = mockk()
-        val file: KSFile = mockk()
-        val sourceSetValidator: SourceSetValidator = mockk()
-
-        val annotation: KSAnnotation = mockk()
-        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
-            yield(annotation)
-        }
-
-        val annotated: Sequence<KSAnnotated> = sequence {
-            yield(symbol)
-        }
-
-        val type: KSType = mockk(relaxed = true)
-        val declaration: KSClassDeclaration = mockk(relaxed = true)
-        val arguments: List<KSValueArgument> = mockk()
-
-        val values: List<KSType> = listOf(type)
-
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
-        val packageName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-
-        val genericResolver: ProcessorContract.GenericResolver = mockk()
-        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
-            emptyMap()
-        } else {
-            null
-        }
-
-        val mapping = mapOf(qualifiedName to alias)
-
-        every {
-            resolver.getSymbolsWithAnnotation(any(), any())
-        } returns annotated
-
-        every {
-            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
-
-        every { symbol.annotations } returns sourceAnnotations
-
-        every { annotation.arguments } returns arguments
-        every { arguments.isEmpty() } returns false
-
-        every { arguments.size } returns 1
-        every { arguments[0].value } returns values
-
-        every { type.declaration } returns declaration
-        every { declaration.classKind } returns ClassKind.INTERFACE
-
-        every { file.parent } returns null
-        every { symbol.parent } returns file
-
-        every { declaration.parentDeclaration } returns null
-        every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
-
-        every { logger.error(any()) } just Runs
-
-        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
-
-        every { genericResolver.extractGenerics(any(), any()) } returns generics
-
-        // When
-        val (_, interfaces, _) = KMockSourceAggregator(
-            logger,
-            mockk(),
-            sourceSetValidator,
-            genericResolver,
-            emptyMap(),
-            mapping,
-        ).extractPlatformInterfaces(resolver)
-
-        // Then
-        interfaces mustBe listOf(
-            TemplateSource(
-                indicator = "",
-                templateName = alias,
-                packageName = packageName,
-                template = declaration,
-                generics = generics
-            )
-        )
-
-        verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
-        verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMock::class.qualifiedName!!, false)
         }
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorPlatformSpec.kt
@@ -51,6 +51,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
     fun `It fulfils Aggregator`() {
         KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -62,6 +63,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
     fun `It fulfils MultiSourceAggregator`() {
         KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -103,6 +105,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -146,6 +149,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -209,6 +213,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 mockk(),
                 mockk(),
                 mockk(),
@@ -295,6 +300,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 mockk(),
                 mockk(),
                 mockk(),
@@ -317,6 +323,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -374,6 +381,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             genericResolver,
@@ -385,7 +393,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -398,12 +406,13 @@ class KMockMultiSourceAggregatorPlatformSpec {
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns all found interfaces, while filtering douplets`() {
+    fun `Given extractPlatformInterfaces is called it returns all found interfaces while filtering doublets`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -463,6 +472,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             genericResolver,
@@ -474,7 +484,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -487,12 +497,13 @@ class KMockMultiSourceAggregatorPlatformSpec {
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns all found interfaces while using the shortest package name`() {
+    fun `Given extractPlatformInterfaces is called it returns all found interfaces while using the rootPackage name`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -572,6 +583,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             genericResolver,
@@ -583,7 +595,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName3,
+                packageName = rootPackage,
                 templates = listOf(declaration1, declaration2, declaration3),
                 generics = listOf(generics, generics, generics)
             )
@@ -652,6 +664,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         // When
         val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(relaxed = true),
@@ -673,6 +686,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         val notRelatedSymbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val notRelatedAnnotation: KSAnnotation = mockk()
@@ -736,6 +750,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
         // When
         val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             mockk(),
             mockk(relaxed = true),
@@ -748,7 +763,7 @@ class KMockMultiSourceAggregatorPlatformSpec {
             TemplateMultiSource(
                 indicator = "",
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(emptyMap())
             )

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorSharedSpec.kt
@@ -25,14 +25,14 @@ import io.mockk.verify
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
-import tech.antibytes.kmock.MockShared
+import tech.antibytes.kmock.MultiMockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
 import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.MultiSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.mapFixture
@@ -41,7 +41,7 @@ import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 import kotlin.test.assertFailsWith
 
-class KMockSourceAggregatorSharedSpec {
+class KMockMultiSourceAggregatorSharedSpec {
     private val fixture = kotlinFixture { configuration ->
         configuration.addGenerator(
             String::class,
@@ -52,26 +52,24 @@ class KMockSourceAggregatorSharedSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockSourceAggregator(
+        KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
-            emptyMap(),
             emptyMap(),
         ) fulfils Aggregator::class
     }
 
     @Test
-    fun `It fulfils SourceAggregator`() {
-        KMockSourceAggregator(
+    fun `It fulfils MultiSourceAggregator`() {
+        KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
-            emptyMap(),
-        ) fulfils SourceAggregator::class
+        ) fulfils MultiSourceAggregator::class
     }
 
     @Test
@@ -107,19 +105,18 @@ class KMockSourceAggregatorSharedSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             customAnnotations,
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol, symbol, symbol, symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
 
         customAnnotations.forEach { (annotation, _) ->
@@ -159,7 +156,7 @@ class KMockSourceAggregatorSharedSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { annotation.arguments } returns arguments
         every { arguments[0].value } returns null
@@ -167,12 +164,11 @@ class KMockSourceAggregatorSharedSpec {
         every { sourceSetValidator.isValidateSourceSet(any()) } returns false
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
             mockk(),
-            emptyMap(),
             emptyMap(),
         ).extractSharedInterfaces(resolver)
 
@@ -183,7 +179,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -224,16 +220,15 @@ class KMockSourceAggregatorSharedSpec {
         every { annotation.arguments } returns arguments
         every { arguments[0].value } returns null
 
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns false
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns false
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
             mockk(),
             customAnnotations,
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
@@ -243,10 +238,10 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {
@@ -281,17 +276,16 @@ class KMockSourceAggregatorSharedSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
             mockk(),
             sourceSetValidator,
             mockk(),
-            emptyMap(),
             emptyMap(),
         ).extractSharedInterfaces(resolver)
 
@@ -301,7 +295,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -333,18 +327,17 @@ class KMockSourceAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns customAnnotations.keys.random()
 
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
 
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
             annotationFilter,
             sourceSetValidator,
             mockk(),
             customAnnotations,
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
@@ -353,10 +346,10 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {
@@ -391,21 +384,24 @@ class KMockSourceAggregatorSharedSpec {
 
         val allowedSourceSets: Set<String> = setOf(fixture.fixture())
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
+
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
         } returns annotated
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
         every { arguments[0].value } returns allowedSourceSets.first()
-        every { arguments[1].value } returns values
-        every { arguments.size } returns 2
+        every { arguments[1].value } returns mockName
+        every { arguments[2].value } returns values
+        every { arguments.size } returns 3
         every { type.declaration } returns declaration
 
         every { file.parent } returns null
@@ -417,12 +413,11 @@ class KMockSourceAggregatorSharedSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 mockk(),
                 sourceSetValidator,
                 mockk(),
-                emptyMap(),
                 emptyMap(),
             ).extractSharedInterfaces(resolver)
         }
@@ -434,7 +429,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -464,6 +459,8 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
+
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
         } returns annotated
@@ -477,8 +474,9 @@ class KMockSourceAggregatorSharedSpec {
         every { annotation.arguments } returns arguments
 
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
-        every { arguments.size } returns 1
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
+        every { arguments.size } returns 2
 
         every { type.declaration } returns declaration
         every { file.parent } returns null
@@ -486,17 +484,16 @@ class KMockSourceAggregatorSharedSpec {
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 annotationFilter,
                 sourceSetValidator,
                 mockk(),
                 customAnnotations,
-                emptyMap(),
             ).extractSharedInterfaces(resolver)
         }
 
@@ -507,10 +504,10 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {
@@ -553,8 +550,8 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(fixture.fixture())
 
@@ -564,15 +561,16 @@ class KMockSourceAggregatorSharedSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
         every { arguments[0].value } returns allowedSourceSets.first()
-        every { arguments[1].value } returns values
-        every { arguments.size } returns 2
+        every { arguments[1].value } returns mockName
+        every { arguments[2].value } returns values
+        every { arguments.size } returns 3
 
         every { type.declaration } returns declaration
         every { declaration.classKind } returns selection[selector]
@@ -584,7 +582,6 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
@@ -592,12 +589,11 @@ class KMockSourceAggregatorSharedSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 mockk(),
                 sourceSetValidator,
                 mockk(),
-                emptyMap(),
                 emptyMap(),
             ).extractSharedInterfaces(resolver)
         }
@@ -609,7 +605,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -649,8 +645,8 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -665,8 +661,9 @@ class KMockSourceAggregatorSharedSpec {
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
-        every { arguments.size } returns 1
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
+        every { arguments.size } returns 2
 
         every { type.declaration } returns declaration
         every { declaration.classKind } returns selection[selector]
@@ -678,21 +675,19 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
 
         every { logger.error(any()) } just Runs
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockMultiSourceAggregator(
                 logger,
                 annotationFilter,
                 sourceSetValidator,
                 mockk(),
                 customAnnotations,
-                emptyMap(),
             ).extractSharedInterfaces(resolver)
         }
 
@@ -703,10 +698,10 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {
@@ -740,8 +735,8 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -757,15 +752,16 @@ class KMockSourceAggregatorSharedSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
         every { arguments[0].value } returns marker
-        every { arguments[1].value } returns values
-        every { arguments.size } returns 2
+        every { arguments[1].value } returns mockName
+        every { arguments[2].value } returns values
+        every { arguments.size } returns 3
 
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
@@ -777,7 +773,6 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -786,23 +781,22 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
             genericResolver,
             emptyMap(),
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = marker,
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             )
         )
 
@@ -811,7 +805,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -844,8 +838,8 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
@@ -867,8 +861,9 @@ class KMockSourceAggregatorSharedSpec {
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
-        every { arguments.size } returns 1
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
+        every { arguments.size } returns 2
 
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
@@ -880,32 +875,30 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
             genericResolver,
             customAnnotations,
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = marker,
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             )
         )
 
@@ -915,10 +908,10 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 2) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {
@@ -982,8 +975,8 @@ class KMockSourceAggregatorSharedSpec {
             null
         }
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -992,19 +985,19 @@ class KMockSourceAggregatorSharedSpec {
 
         every {
             annotation0.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every {
             annotation1.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every {
             annotation2.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every {
             annotation3.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { source0.annotations } returns sourceAnnotations0
         every { source1.annotations } returns sourceAnnotations1
@@ -1014,16 +1007,18 @@ class KMockSourceAggregatorSharedSpec {
         every { annotation0.arguments } returns arguments0
         every { arguments0.isEmpty() } returns false
         every { arguments0[0].value } returns marker0
-        every { arguments0[1].value } returns values
-        every { arguments0.size } returns 2
+        every { arguments0[1].value } returns mockName
+        every { arguments0[2].value } returns values
+        every { arguments0.size } returns 3
 
         every { annotation2.arguments } returns arguments0
 
         every { annotation1.arguments } returns arguments1
         every { arguments1.isEmpty() } returns false
         every { arguments1[0].value } returns marker1
-        every { arguments1[1].value } returns values
-        every { arguments1.size } returns 2
+        every { arguments1[1].value } returns mockName
+        every { arguments1[2].value } returns values
+        every { arguments1.size } returns 3
 
         every { annotation3.arguments } returns arguments1
 
@@ -1040,7 +1035,6 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
@@ -1049,30 +1043,29 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
             genericResolver,
             emptyMap(),
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = marker0,
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             ),
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = marker1,
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             )
         )
 
@@ -1090,7 +1083,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation3)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -1152,8 +1145,8 @@ class KMockSourceAggregatorSharedSpec {
             null
         }
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -1183,15 +1176,17 @@ class KMockSourceAggregatorSharedSpec {
 
         every { annotation0.arguments } returns arguments0
         every { arguments0.isEmpty() } returns false
-        every { arguments0[0].value } returns values
-        every { arguments0.size } returns 1
+        every { arguments0[0].value } returns mockName
+        every { arguments0[1].value } returns values
+        every { arguments0.size } returns 2
 
         every { annotation2.arguments } returns arguments0
 
         every { annotation1.arguments } returns arguments1
         every { arguments1.isEmpty() } returns false
-        every { arguments1[0].value } returns values
-        every { arguments1.size } returns 1
+        every { arguments1[0].value } returns mockName
+        every { arguments1[1].value } returns values
+        every { arguments1.size } returns 2
 
         every { annotation3.arguments } returns arguments1
 
@@ -1208,48 +1203,46 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
             genericResolver,
             customAnnotations,
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = marker0,
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             ),
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = marker1,
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
+                templates = listOf(declaration),
+                generics = listOf(generics)
             )
         )
 
         verify(exactly = 12) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 3) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation0)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation0)
         }
         verify(exactly = 3) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation1)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation1)
         }
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation0)
@@ -1259,7 +1252,249 @@ class KMockSourceAggregatorSharedSpec {
         }
 
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
+        }
+        customAnnotations.forEach { (annotation, _) ->
+            verify(exactly = 1) {
+                resolver.getSymbolsWithAnnotation(annotation, false)
+            }
+        }
+    }
+
+    @Test
+    fun `Given extractSharedInterfaces is called it returns all found interfaces while using the shortest package name`() {
+        // Given
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val sourceSetValidator: SourceSetValidator = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(symbol)
+        }
+
+        val type1: KSType = mockk(relaxed = true)
+        val type2: KSType = mockk(relaxed = true)
+        val type3: KSType = mockk(relaxed = true)
+        val declaration1: KSClassDeclaration = mockk(relaxed = true)
+        val declaration2: KSClassDeclaration = mockk(relaxed = true)
+        val declaration3: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type1, type2, type3)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
+
+        val className1: String = fixture.fixture(named("stringAlpha"))
+        val packageName1 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className2: String = fixture.fixture(named("stringAlpha"))
+        val packageName2 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className3: String = fixture.fixture(named("stringAlpha"))
+        val packageName3 = fixture.fixture<String>(named("stringAlpha"))
+
+        val genericResolver: ProcessorContract.GenericResolver = mockk()
+        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
+            emptyMap()
+        } else {
+            null
+        }
+        val allowedSourceSets: Set<String> = setOf(
+            fixture.fixture()
+        )
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every { symbol.annotations } returns sourceAnnotations
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns MultiMockShared::class.qualifiedName!!
+
+        every { annotation.arguments } returns arguments
+        every { arguments.size } returns 3
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns allowedSourceSets.first()
+        every { arguments[1].value } returns mockName
+        every { arguments[2].value } returns values
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
+
+        every { type1.declaration } returns declaration1
+        every { declaration1.classKind } returns ClassKind.INTERFACE
+        every { declaration1.parentDeclaration } returns null
+        every { declaration1.qualifiedName!!.asString() } returns className1
+        every { declaration1.packageName.asString() } returns packageName1
+
+        every { type2.declaration } returns declaration2
+        every { declaration2.classKind } returns ClassKind.INTERFACE
+        every { declaration2.parentDeclaration } returns null
+        every { declaration2.qualifiedName!!.asString() } returns className2
+        every { declaration2.packageName.asString() } returns packageName2
+
+        every { type3.declaration } returns declaration3
+        every { declaration3.classKind } returns ClassKind.INTERFACE
+        every { declaration3.parentDeclaration } returns null
+        every { declaration3.qualifiedName!!.asString() } returns className3
+        every { declaration3.packageName.asString() } returns packageName3
+
+        every { logger.error(any()) } just Runs
+
+        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
+
+        every { genericResolver.extractGenerics(any(), any()) } returns generics
+
+        // When
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
+            logger,
+            mockk(),
+            sourceSetValidator,
+            genericResolver,
+            emptyMap(),
+        ).extractSharedInterfaces(resolver)
+
+        // Then
+        interfaces mustBe listOf(
+            TemplateMultiSource(
+                indicator = allowedSourceSets.first(),
+                templateName = mockName,
+                packageName = packageName3,
+                templates = listOf(declaration1, declaration2, declaration3),
+                generics = listOf(generics, generics, generics)
+            )
+        )
+
+        verify(exactly = 1) { sourceSetValidator.isValidateSourceSet(annotation) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration1, any()) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration2, any()) }
+        verify(exactly = 1) { genericResolver.extractGenerics(declaration3, any()) }
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
+        }
+    }
+
+    @Test
+    fun `Given extractSharedInterfaces is called it returns all found interfaces while using the shortest package name for custom Annotations`() {
+        // Given
+        val customAnnotations: Map<String, String> = fixture.mapFixture(size = 1)
+        val logger: KSPLogger = mockk()
+        val symbol: KSAnnotated = mockk()
+        val resolver: Resolver = mockk()
+        val annotationFilter: AnnotationFilter = mockk()
+        val sourceSetValidator: SourceSetValidator = mockk()
+        val file: KSFile = mockk()
+
+        val annotation: KSAnnotation = mockk()
+        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
+            yield(annotation)
+        }
+
+        val annotated: Sequence<KSAnnotated> = sequence {
+            yield(symbol)
+        }
+
+        val type1: KSType = mockk(relaxed = true)
+        val type2: KSType = mockk(relaxed = true)
+        val type3: KSType = mockk(relaxed = true)
+        val declaration1: KSClassDeclaration = mockk(relaxed = true)
+        val declaration2: KSClassDeclaration = mockk(relaxed = true)
+        val declaration3: KSClassDeclaration = mockk(relaxed = true)
+        val arguments: List<KSValueArgument> = mockk()
+
+        val values: List<KSType> = listOf(type1, type2, type3)
+        val mockName: String = fixture.fixture(named("stringAlpha"))
+
+        val className1: String = fixture.fixture(named("stringAlpha"))
+        val packageName1 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className2: String = fixture.fixture(named("stringAlpha"))
+        val packageName2 = "${fixture.fixture<String>(named("stringAlpha"))}.${fixture.fixture<String>(named("stringAlpha"))}"
+        val className3: String = fixture.fixture(named("stringAlpha"))
+        val packageName3 = fixture.fixture<String>(named("stringAlpha"))
+
+        val genericResolver: ProcessorContract.GenericResolver = mockk()
+        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
+            emptyMap()
+        } else {
+            null
+        }
+
+        every {
+            resolver.getSymbolsWithAnnotation(any(), any())
+        } returns annotated
+
+        every { symbol.annotations } returns sourceAnnotations
+
+        every {
+            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
+        } returns customAnnotations.keys.random()
+
+        every { annotation.arguments } returns arguments
+        every { arguments.size } returns 2
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
+
+        every { file.parent } returns null
+        every { symbol.parent } returns file
+
+        every { type1.declaration } returns declaration1
+        every { declaration1.classKind } returns ClassKind.INTERFACE
+        every { declaration1.parentDeclaration } returns null
+        every { declaration1.qualifiedName!!.asString() } returns className1
+        every { declaration1.packageName.asString() } returns packageName1
+
+        every { type2.declaration } returns declaration2
+        every { declaration2.classKind } returns ClassKind.INTERFACE
+        every { declaration2.parentDeclaration } returns null
+        every { declaration2.qualifiedName!!.asString() } returns className2
+        every { declaration2.packageName.asString() } returns packageName2
+
+        every { type3.declaration } returns declaration3
+        every { declaration3.classKind } returns ClassKind.INTERFACE
+        every { declaration3.parentDeclaration } returns null
+        every { declaration3.qualifiedName!!.asString() } returns className3
+        every { declaration3.packageName.asString() } returns packageName3
+
+        every { logger.error(any()) } just Runs
+
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
+
+        every { genericResolver.extractGenerics(any(), any()) } returns generics
+
+        // When
+        val (_, interfaces, _) = KMockMultiSourceAggregator(
+            logger,
+            annotationFilter,
+            sourceSetValidator,
+            genericResolver,
+            customAnnotations,
+        ).extractSharedInterfaces(resolver)
+
+        // Then
+        interfaces mustBe listOf(
+            TemplateMultiSource(
+                indicator = customAnnotations.values.first(),
+                templateName = mockName,
+                packageName = packageName3,
+                templates = listOf(declaration1, declaration2, declaration3),
+                generics = listOf(generics, generics, generics)
+            )
+        )
+
+        verify(exactly = 2) { annotationFilter.isApplicableMultiSourceAnnotation(annotation) }
+        verify(exactly = 2) { genericResolver.extractGenerics(declaration1, any()) }
+        verify(exactly = 2) { genericResolver.extractGenerics(declaration2, any()) }
+        verify(exactly = 2) { genericResolver.extractGenerics(declaration3, any()) }
+
+        verify(exactly = 1) {
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {
@@ -1292,8 +1527,8 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(
             fixture.fixture()
@@ -1305,15 +1540,16 @@ class KMockSourceAggregatorSharedSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
         every { arguments[0].value } returns allowedSourceSets.first()
-        every { arguments[1].value } returns values
-        every { arguments.size } returns 2
+        every { arguments[1].value } returns mockName
+        every { arguments[2].value } returns values
+        every { arguments.size } returns 3
 
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
@@ -1325,19 +1561,17 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
             mockk(relaxed = true),
-            emptyMap(),
             emptyMap(),
         ).extractSharedInterfaces(resolver)
 
@@ -1347,7 +1581,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -1377,8 +1611,8 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
         every {
@@ -1393,8 +1627,9 @@ class KMockSourceAggregatorSharedSpec {
 
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
-        every { arguments.size } returns 1
+        every { arguments[0].value } returns mockName
+        every { arguments[1].value } returns values
+        every { arguments.size } returns 2
 
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
@@ -1406,33 +1641,31 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
             mockk(relaxed = true),
             customAnnotations,
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file, file)
         verify(exactly = 2) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation)
         }
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
 
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {
@@ -1473,9 +1706,9 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
 
         val allowedSourceSets: Set<String> = setOf(
             fixture.fixture()
@@ -1494,7 +1727,7 @@ class KMockSourceAggregatorSharedSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
+        } returns MultiMockShared::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
         every { notRelatedSymbol.annotations } returns notRelatedSource
@@ -1502,8 +1735,9 @@ class KMockSourceAggregatorSharedSpec {
         every { annotation.arguments } returns arguments
         every { arguments.isEmpty() } returns false
         every { arguments[0].value } returns allowedSourceSets.first()
-        every { arguments[1].value } returns values
-        every { arguments.size } returns 2
+        every { arguments[1].value } returns mockName
+        every { arguments[2].value } returns values
+        every { arguments.size } returns 3
 
         every { declaration.parentDeclaration } returns null
 
@@ -1515,30 +1749,28 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
         // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
             mockk(relaxed = true),
             emptyMap(),
-            emptyMap(),
         ).extractSharedInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = allowedSourceSets.first(),
-                templateName = simpleName,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = emptyMap()
+                templates = listOf(declaration),
+                generics = listOf(emptyMap())
             ),
         )
         sourceFiles mustBe listOf(file)
@@ -1546,7 +1778,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
     }
 
@@ -1584,9 +1816,9 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
+        val mockName: String = fixture.fixture(named("stringAlpha"))
         val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -1607,119 +1839,9 @@ class KMockSourceAggregatorSharedSpec {
         every { notRelatedSymbol.annotations } returns notRelatedSource
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
-        every { arguments.isEmpty() } returns false
-        every { arguments[0].value } returns values
-        every { type.declaration } returns declaration
-        every { declaration.classKind } returns ClassKind.INTERFACE
-
-        every { declaration.parentDeclaration } returns null
-
-        every { file.parent } returns null
-        every { symbol.parent } returns file
-
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
-        every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-
-        every { logger.error(any()) } just Runs
-
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
-
-        // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
-            logger,
-            annotationFilter,
-            sourceSetValidator,
-            mockk(relaxed = true),
-            customAnnotations,
-            emptyMap(),
-        ).extractSharedInterfaces(resolver)
-
-        // Then
-        interfaces mustBe listOf(
-            TemplateSource(
-                indicator = customAnnotations.values.first(),
-                templateName = simpleName,
-                packageName = packageName,
-                template = declaration,
-                generics = emptyMap()
-            ),
-        )
-        sourceFiles mustBe listOf(file, file)
-        verify(exactly = 2) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
-        }
-        verify(exactly = 0) {
-            sourceSetValidator.isValidateSourceSet(annotation)
-        }
-
-        verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
-        }
-        customAnnotations.forEach { (annotation, _) ->
-            verify(exactly = 1) {
-                resolver.getSymbolsWithAnnotation(annotation, false)
-            }
-        }
-    }
-
-    @Test
-    fun `Given extractSharedInterfaces is called it returns while mapping aliases`() {
-        // Given
-        val logger: KSPLogger = mockk()
-        val symbol: KSAnnotated = mockk()
-        val resolver: Resolver = mockk()
-        val file: KSFile = mockk()
-        val sourceSetValidator: SourceSetValidator = mockk()
-
-        val annotation: KSAnnotation = mockk()
-        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
-            yield(annotation)
-        }
-
-        val annotated: Sequence<KSAnnotated> = sequence {
-            yield(symbol)
-        }
-
-        val type: KSType = mockk(relaxed = true)
-        val declaration: KSClassDeclaration = mockk(relaxed = true)
-        val arguments: List<KSValueArgument> = mockk()
-
-        val values: List<KSType> = listOf(type)
-
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val packageName: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
-        val allowedSourceSets: Set<String> = setOf(
-            fixture.fixture()
-        )
-
-        val genericResolver: ProcessorContract.GenericResolver = mockk()
-        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
-            emptyMap()
-        } else {
-            null
-        }
-
-        val mapping = mapOf(qualifiedName to alias)
-
-        every {
-            resolver.getSymbolsWithAnnotation(any(), any())
-        } returns annotated
-
-        every {
-            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockShared::class.qualifiedName!!
-
-        every { symbol.annotations } returns sourceAnnotations
-
-        every { annotation.arguments } returns arguments
-        every { arguments.isEmpty() } returns false
-
         every { arguments.size } returns 2
-        every { arguments[0].value } returns allowedSourceSets.first()
+        every { arguments.isEmpty() } returns false
+        every { arguments[0].value } returns mockName
         every { arguments[1].value } returns values
 
         every { type.declaration } returns declaration
@@ -1732,145 +1854,40 @@ class KMockSourceAggregatorSharedSpec {
 
         every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
 
         every { logger.error(any()) } just Runs
 
-        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
-
-        every { genericResolver.extractGenerics(any(), any()) } returns generics
+        every { annotationFilter.isApplicableMultiSourceAnnotation(any()) } returns true
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
-            logger,
-            mockk(),
-            sourceSetValidator,
-            genericResolver,
-            emptyMap(),
-            mapping,
-        ).extractSharedInterfaces(resolver)
-
-        // Then
-        interfaces mustBe listOf(
-            TemplateSource(
-                indicator = allowedSourceSets.first(),
-                templateName = alias,
-                packageName = packageName,
-                template = declaration,
-                generics = generics
-            )
-        )
-
-        verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
-        verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
-        }
-    }
-
-    @Test
-    fun `Given extractSharedInterfaces is called it returns while mapping aliases for custom`() {
-        // Given
-        val customAnnotations: Map<String, String> = fixture.mapFixture(size = 1)
-        val logger: KSPLogger = mockk()
-        val symbol: KSAnnotated = mockk()
-        val resolver: Resolver = mockk()
-        val file: KSFile = mockk()
-        val annotationFilter: AnnotationFilter = mockk()
-        val sourceSetValidator: SourceSetValidator = mockk()
-
-        val annotation: KSAnnotation = mockk()
-        val sourceAnnotations: Sequence<KSAnnotation> = sequence {
-            yield(annotation)
-        }
-
-        val annotated: Sequence<KSAnnotated> = sequence {
-            yield(symbol)
-        }
-
-        val type: KSType = mockk(relaxed = true)
-        val declaration: KSClassDeclaration = mockk(relaxed = true)
-        val arguments: List<KSValueArgument> = mockk()
-
-        val values: List<KSType> = listOf(type)
-
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val packageName: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
-
-        val genericResolver: ProcessorContract.GenericResolver = mockk()
-        val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
-            emptyMap()
-        } else {
-            null
-        }
-
-        val mapping = mapOf(qualifiedName to alias)
-
-        every {
-            resolver.getSymbolsWithAnnotation(any(), any())
-        } returns annotated
-
-        every {
-            annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns customAnnotations.keys.first()
-
-        every { symbol.annotations } returns sourceAnnotations
-
-        every { annotation.arguments } returns arguments
-        every { arguments.isEmpty() } returns false
-
-        every { arguments.size } returns 1
-        every { arguments[0].value } returns values
-
-        every { type.declaration } returns declaration
-        every { declaration.classKind } returns ClassKind.INTERFACE
-
-        every { declaration.parentDeclaration } returns null
-
-        every { file.parent } returns null
-        every { symbol.parent } returns file
-
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
-        every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-
-        every { logger.error(any()) } just Runs
-
-        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
-
-        every { genericResolver.extractGenerics(any(), any()) } returns generics
-
-        // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
-            genericResolver,
+            mockk(relaxed = true),
             customAnnotations,
-            mapping,
         ).extractSharedInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
-            TemplateSource(
+            TemplateMultiSource(
                 indicator = customAnnotations.values.first(),
-                templateName = alias,
+                templateName = mockName,
                 packageName = packageName,
-                template = declaration,
-                generics = generics
-            )
+                templates = listOf(declaration),
+                generics = listOf(emptyMap())
+            ),
         )
-
-        verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
+        sourceFiles mustBe listOf(file, file)
         verify(exactly = 2) {
-            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
+            annotationFilter.isApplicableMultiSourceAnnotation(annotation)
         }
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
+
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MultiMockShared::class.qualifiedName!!, false)
         }
         customAnnotations.forEach { (annotation, _) ->
             verify(exactly = 1) {

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockMultiSourceAggregatorSharedSpec.kt
@@ -54,6 +54,7 @@ class KMockMultiSourceAggregatorSharedSpec {
     fun `It fulfils Aggregator`() {
         KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -65,6 +66,7 @@ class KMockMultiSourceAggregatorSharedSpec {
     fun `It fulfils MultiSourceAggregator`() {
         KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -107,6 +109,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -166,6 +169,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             logger,
+            fixture.fixture(),
             mockk(),
             sourceSetValidator,
             mockk(),
@@ -225,6 +229,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             logger,
+            fixture.fixture(),
             annotationFilter,
             sourceSetValidator,
             mockk(),
@@ -283,6 +288,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             mockk(),
             sourceSetValidator,
             mockk(),
@@ -334,6 +340,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (illegal, _, _) = KMockMultiSourceAggregator(
             mockk(),
+            fixture.fixture(),
             annotationFilter,
             sourceSetValidator,
             mockk(),
@@ -415,6 +422,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 mockk(),
                 sourceSetValidator,
                 mockk(),
@@ -490,6 +498,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 annotationFilter,
                 sourceSetValidator,
                 mockk(),
@@ -591,6 +600,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 mockk(),
                 sourceSetValidator,
                 mockk(),
@@ -684,6 +694,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val error = assertFailsWith<IllegalArgumentException> {
             KMockMultiSourceAggregator(
                 logger,
+                fixture.fixture(),
                 annotationFilter,
                 sourceSetValidator,
                 mockk(),
@@ -717,6 +728,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
         val sourceSetValidator: SourceSetValidator = mockk()
         val marker = fixture.fixture<String>()
 
@@ -783,6 +795,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             sourceSetValidator,
             genericResolver,
@@ -794,7 +807,7 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = marker,
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -820,6 +833,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
         val annotationFilter: AnnotationFilter = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
 
@@ -885,6 +899,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             annotationFilter,
             sourceSetValidator,
             genericResolver,
@@ -896,7 +911,7 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = marker,
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -932,6 +947,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val source3: KSAnnotated = mockk()
 
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
         val sourceSetValidator: SourceSetValidator = mockk()
 
         val marker0 = fixture.fixture<String>()
@@ -1045,6 +1061,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             sourceSetValidator,
             genericResolver,
@@ -1056,14 +1073,14 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = marker0,
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             ),
             TemplateMultiSource(
                 indicator = marker1,
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -1104,6 +1121,7 @@ class KMockMultiSourceAggregatorSharedSpec {
 
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
         val annotationFilter: AnnotationFilter = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
 
@@ -1213,6 +1231,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             annotationFilter,
             sourceSetValidator,
             genericResolver,
@@ -1224,14 +1243,14 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = marker0,
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             ),
             TemplateMultiSource(
                 indicator = marker1,
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(generics)
             )
@@ -1262,13 +1281,14 @@ class KMockMultiSourceAggregatorSharedSpec {
     }
 
     @Test
-    fun `Given extractSharedInterfaces is called it returns all found interfaces while using the shortest package name`() {
+    fun `Given extractSharedInterfaces is called it returns all found interfaces while using the rootPackage name`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -1354,6 +1374,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             sourceSetValidator,
             genericResolver,
@@ -1365,7 +1386,7 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = allowedSourceSets.first(),
                 templateName = mockName,
-                packageName = packageName3,
+                packageName = rootPackage,
                 templates = listOf(declaration1, declaration2, declaration3),
                 generics = listOf(generics, generics, generics)
             )
@@ -1381,7 +1402,7 @@ class KMockMultiSourceAggregatorSharedSpec {
     }
 
     @Test
-    fun `Given extractSharedInterfaces is called it returns all found interfaces while using the shortest package name for custom Annotations`() {
+    fun `Given extractSharedInterfaces is called it returns all found interfaces while using the rootPackage name for custom Annotations`() {
         // Given
         val customAnnotations: Map<String, String> = fixture.mapFixture(size = 1)
         val logger: KSPLogger = mockk()
@@ -1390,6 +1411,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val annotationFilter: AnnotationFilter = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -1471,6 +1493,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, _) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             annotationFilter,
             sourceSetValidator,
             genericResolver,
@@ -1482,7 +1505,7 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = customAnnotations.values.first(),
                 templateName = mockName,
-                packageName = packageName3,
+                packageName = rootPackage,
                 templates = listOf(declaration1, declaration2, declaration3),
                 generics = listOf(generics, generics, generics)
             )
@@ -1569,6 +1592,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            fixture.fixture(),
             mockk(),
             sourceSetValidator,
             mockk(relaxed = true),
@@ -1649,6 +1673,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, _, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            fixture.fixture(),
             annotationFilter,
             sourceSetValidator,
             mockk(relaxed = true),
@@ -1683,6 +1708,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val notRelatedSymbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val notRelatedAnnotation: KSAnnotation = mockk()
@@ -1757,6 +1783,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             mockk(),
             sourceSetValidator,
             mockk(relaxed = true),
@@ -1768,7 +1795,7 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = allowedSourceSets.first(),
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(emptyMap())
             ),
@@ -1793,6 +1820,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         val notRelatedSymbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val rootPackage: String = fixture.fixture()
 
         val annotation: KSAnnotation = mockk()
         val notRelatedAnnotation: KSAnnotation = mockk()
@@ -1862,6 +1890,7 @@ class KMockMultiSourceAggregatorSharedSpec {
         // When
         val (_, interfaces, sourceFiles) = KMockMultiSourceAggregator(
             logger,
+            rootPackage,
             annotationFilter,
             sourceSetValidator,
             mockk(relaxed = true),
@@ -1873,7 +1902,7 @@ class KMockMultiSourceAggregatorSharedSpec {
             TemplateMultiSource(
                 indicator = customAnnotations.values.first(),
                 templateName = mockName,
-                packageName = packageName,
+                packageName = rootPackage,
                 templates = listOf(declaration),
                 generics = listOf(emptyMap())
             ),

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockRelaxationAggregatorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockRelaxationAggregatorSpec.kt
@@ -4,7 +4,7 @@
  * Use of this source code is governed by Apache v2.0
  */
 
-package tech.antibytes.kmock.processor
+package tech.antibytes.kmock.processor.aggregation
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
@@ -22,13 +22,16 @@ import io.mockk.verify
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.Relaxer
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
+import tech.antibytes.kmock.processor.ProcessorContract.RelaxationAggregator
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.qualifier.named
 import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 
-class KMockAggregatorRelaxerSpec {
+class KMockRelaxationAggregatorSpec {
     private val fixture = kotlinFixture { configuration ->
         configuration.addGenerator(
             String::class,
@@ -39,14 +42,16 @@ class KMockAggregatorRelaxerSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockAggregator(
+        KMockRelaxationAggregator(
             mockk(),
+        ) fulfils Aggregator::class
+    }
+
+    @Test
+    fun `It fulfils RelaxationAggregator`() {
+        KMockRelaxationAggregator(
             mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ) fulfils ProcessorContract.Aggregator::class
+        ) fulfils RelaxationAggregator::class
     }
 
     @Test
@@ -61,14 +66,7 @@ class KMockAggregatorRelaxerSpec {
         } returns annotated
 
         // When
-        val relaxer = KMockAggregator(
-            logger,
-            mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ).extractRelaxer(resolver)
+        val relaxer = KMockRelaxationAggregator(logger).extractRelaxer(resolver)
 
         // Then
         relaxer mustBe null
@@ -111,14 +109,7 @@ class KMockAggregatorRelaxerSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
-            logger,
-            mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ).extractRelaxer(resolver)
+        KMockRelaxationAggregator(logger).extractRelaxer(resolver)
 
         // Then
         verify(exactly = 1) {
@@ -164,14 +155,7 @@ class KMockAggregatorRelaxerSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
-            logger,
-            mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ).extractRelaxer(resolver)
+        KMockRelaxationAggregator(logger).extractRelaxer(resolver)
 
         // Then
         verify(exactly = 1) {
@@ -217,14 +201,7 @@ class KMockAggregatorRelaxerSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
-            logger,
-            mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ).extractRelaxer(resolver)
+        KMockRelaxationAggregator(logger).extractRelaxer(resolver)
 
         // Then
         verify(exactly = 1) {
@@ -274,14 +251,7 @@ class KMockAggregatorRelaxerSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
-            logger,
-            mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ).extractRelaxer(resolver)
+        KMockRelaxationAggregator(logger).extractRelaxer(resolver)
 
         // Then
         verify(exactly = 1) {
@@ -327,14 +297,7 @@ class KMockAggregatorRelaxerSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
-            logger,
-            mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ).extractRelaxer(resolver)
+        KMockRelaxationAggregator(logger).extractRelaxer(resolver)
 
         // Then
         verify(exactly = 1) {
@@ -380,14 +343,7 @@ class KMockAggregatorRelaxerSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val actual = KMockAggregator(
-            logger,
-            mockk(),
-            mockk(),
-            mockk(),
-            emptyMap(),
-            emptyMap(),
-        ).extractRelaxer(resolver)
+        val actual = KMockRelaxationAggregator(logger).extractRelaxer(resolver)
 
         // Then
         verify(exactly = 0) { logger.error(any()) }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorCommonSpec.kt
@@ -29,7 +29,7 @@ import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SingleSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
@@ -50,7 +50,7 @@ class KMockSourceAggregatorCommonSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockSourceAggregator(
+        KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -62,14 +62,14 @@ class KMockSourceAggregatorCommonSpec {
 
     @Test
     fun `It fulfils SourceAggregator`() {
-        KMockSourceAggregator(
+        KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ) fulfils SourceAggregator::class
+        ) fulfils SingleSourceAggregator::class
     }
 
     @Test
@@ -104,7 +104,7 @@ class KMockSourceAggregatorCommonSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -148,7 +148,7 @@ class KMockSourceAggregatorCommonSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -209,7 +209,7 @@ class KMockSourceAggregatorCommonSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
@@ -293,7 +293,7 @@ class KMockSourceAggregatorCommonSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
@@ -375,7 +375,7 @@ class KMockSourceAggregatorCommonSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -465,7 +465,7 @@ class KMockSourceAggregatorCommonSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -546,7 +546,7 @@ class KMockSourceAggregatorCommonSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -633,7 +633,7 @@ class KMockSourceAggregatorCommonSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -730,7 +730,7 @@ class KMockSourceAggregatorCommonSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorCommonSpec.kt
@@ -4,7 +4,7 @@
  * Use of this source code is governed by Apache v2.0
  */
 
-package tech.antibytes.kmock.processor
+package tech.antibytes.kmock.processor.aggregation
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
@@ -27,6 +27,10 @@ import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
@@ -34,7 +38,7 @@ import tech.antibytes.util.test.fixture.qualifier.named
 import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 
-class KMockAggregatorPlatformSpec {
+class KMockSourceAggregatorCommonSpec {
     private val fixture = kotlinFixture { configuration ->
         configuration.addGenerator(
             String::class,
@@ -45,18 +49,30 @@ class KMockAggregatorPlatformSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockAggregator(
+        KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ) fulfils ProcessorContract.Aggregator::class
+        ) fulfils Aggregator::class
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
+    fun `It fulfils SourceAggregator`() {
+        KMockSourceAggregator(
+            mockk(),
+            mockk(),
+            mockk(),
+            mockk(),
+            emptyMap(),
+            emptyMap(),
+        ) fulfils SourceAggregator::class
+    }
+
+    @Test
+    fun `Given extractCommonInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
         // Given
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
@@ -87,24 +103,24 @@ class KMockAggregatorPlatformSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it filters all ill Annotations`() {
+    fun `Given extractCommonInterfaces is called it filters all ill Annotations`() {
         // Given
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
@@ -126,29 +142,29 @@ class KMockAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it filters all non class types and reports an error`() {
+    fun `Given extractCommonInterfaces is called it filters all non class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -176,7 +192,7 @@ class KMockAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -191,24 +207,24 @@ class KMockAggregatorPlatformSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         verify(exactly = 1) { logger.error("Cannot stub non interfaces.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it filters all implementation class types and reports an error`() {
+    fun `Given extractCommonInterfaces is called it filters all implementation class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -250,7 +266,7 @@ class KMockAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -273,24 +289,24 @@ class KMockAggregatorPlatformSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$className.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns all found interfaces`() {
+    fun `Given extractCommonInterfaces is called it returns all found interfaces`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -329,7 +345,7 @@ class KMockAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -354,14 +370,14 @@ class KMockAggregatorPlatformSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             genericResolver,
             emptyMap(),
             emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
@@ -375,14 +391,13 @@ class KMockAggregatorPlatformSpec {
         )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
-
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns the corresponding source files`() {
+    fun `Given extractCommonInterfaces is called it returns the corresponding source files`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -414,7 +429,7 @@ class KMockAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -443,17 +458,17 @@ class KMockAggregatorPlatformSpec {
             mockk(relaxed = true),
             emptyMap(),
             emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
+    fun `Given extractCommonInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -485,7 +500,6 @@ class KMockAggregatorPlatformSpec {
 
         val className: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
-        val simpleName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -495,22 +509,20 @@ class KMockAggregatorPlatformSpec {
             notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returnsMany listOf(
             MockShared::class.qualifiedName!!,
-            MockCommon::class.qualifiedName!!
+            Mock::class.qualifiedName!!
         )
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
         every { notRelatedSymbol.annotations } returns notRelatedSource
 
         every { annotation.arguments } returns arguments
-        every { arguments.isEmpty() } returns false
-
         every { arguments.size } returns 1
+        every { arguments.isEmpty() } returns false
         every { arguments[0].value } returns values
-
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
 
@@ -526,29 +538,30 @@ class KMockAggregatorPlatformSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, _, sourceFiles) = KMockAggregator(
+        val (_, _, sourceFiles) = KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(relaxed = true),
             emptyMap(),
             emptyMap(),
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractPlatformInterfaces is called it returns while mapping aliases`() {
+    fun `Given extractCommonInterfaces is called it returns while mapping aliases`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
+        val sourceSetValidator: SourceSetValidator = mockk()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -567,8 +580,8 @@ class KMockAggregatorPlatformSpec {
 
         val className: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val packageName: String = fixture.fixture(named("stringAlpha"))
         val alias: String = fixture.fixture(named("stringAlpha"))
+        val packageName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
         val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
@@ -585,7 +598,7 @@ class KMockAggregatorPlatformSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns Mock::class.qualifiedName!!
+        } returns MockCommon::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -609,17 +622,19 @@ class KMockAggregatorPlatformSpec {
 
         every { logger.error(any()) } just Runs
 
+        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
+
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             mockk(),
-            mockk(),
+            sourceSetValidator,
             genericResolver,
             emptyMap(),
             mapping,
-        ).extractPlatformInterfaces(resolver)
+        ).extractCommonInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
@@ -633,9 +648,8 @@ class KMockAggregatorPlatformSpec {
         )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
-
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorCommonSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorCommonSpec.kt
@@ -260,7 +260,6 @@ class KMockSourceAggregatorCommonSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -286,8 +285,7 @@ class KMockSourceAggregatorCommonSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -304,8 +302,8 @@ class KMockSourceAggregatorCommonSpec {
         }
 
         // Then
-        error.message mustBe "Cannot stub non interface $packageName.$qualifiedName."
-        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$qualifiedName.") }
+        error.message mustBe "Cannot stub non interface $packageName.$simpleName."
+        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$simpleName.") }
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
         }
@@ -334,7 +332,6 @@ class KMockSourceAggregatorCommonSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -367,8 +364,7 @@ class KMockSourceAggregatorCommonSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -424,7 +420,6 @@ class KMockSourceAggregatorCommonSpec {
 
         val values: List<KSType> = listOf(type, type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -457,8 +452,7 @@ class KMockSourceAggregatorCommonSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -514,7 +508,6 @@ class KMockSourceAggregatorCommonSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -540,8 +533,7 @@ class KMockSourceAggregatorCommonSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -595,7 +587,6 @@ class KMockSourceAggregatorCommonSpec {
 
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -627,8 +618,7 @@ class KMockSourceAggregatorCommonSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -685,7 +675,6 @@ class KMockSourceAggregatorCommonSpec {
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val alias: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
         val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
@@ -694,7 +683,7 @@ class KMockSourceAggregatorCommonSpec {
             null
         }
 
-        val mapping = mapOf(qualifiedName to alias)
+        val mapping = mapOf("$packageName.$simpleName" to alias)
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -720,8 +709,7 @@ class KMockSourceAggregatorCommonSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
@@ -11,7 +11,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
-import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.AggregatorFactory
 import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
 import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
@@ -29,7 +29,7 @@ class KMockSourceAggregatorFactorySpec {
     }
 
     @Test
-    fun `Given getInstance is called it returns a Aggregator`() {
+    fun `Given getInstance is called it returns a SourceAggregator`() {
         // Given
         val logger: KSPLogger = mockk()
         val sourceSetValidator: SourceSetValidator = mockk()
@@ -52,7 +52,7 @@ class KMockSourceAggregatorFactorySpec {
         )
 
         // Then
-        actual fulfils Aggregator::class
+        actual fulfils SourceAggregator::class
 
         verify(exactly = 1) {
             annotationFilter.filterAnnotation(customAnnotations)

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
@@ -16,6 +16,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
 import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.SingleSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
+import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.mapFixture
 import tech.antibytes.util.test.fulfils
@@ -44,6 +45,7 @@ class KMockSourceAggregatorFactorySpec {
         // When
         val actual = KMockSingleSourceAggregator.getInstance(
             logger = logger,
+            rootPackage = fixture.fixture(),
             sourceSetValidator = sourceSetValidator,
             annotationFilter = annotationFilter,
             generics = generics,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
@@ -4,7 +4,7 @@
  * Use of this source code is governed by Apache v2.0
  */
 
-package tech.antibytes.kmock.processor
+package tech.antibytes.kmock.processor.aggregation
 
 import com.google.devtools.ksp.processing.KSPLogger
 import io.mockk.every
@@ -20,12 +20,12 @@ import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.mapFixture
 import tech.antibytes.util.test.fulfils
 
-class KMockAggregatorFactorySpec {
+class KMockSourceAggregatorFactorySpec {
     private val fixture = kotlinFixture()
 
     @Test
     fun `It fulfils AggregatorFactory`() {
-        KMockAggregator fulfils AggregatorFactory::class
+        KMockSourceAggregator fulfils AggregatorFactory::class
     }
 
     @Test
@@ -42,7 +42,7 @@ class KMockAggregatorFactorySpec {
         every { annotationFilter.filterAnnotation(any()) } returns customAnnotations
 
         // When
-        val actual = KMockAggregator.getInstance(
+        val actual = KMockSourceAggregator.getInstance(
             logger = logger,
             sourceSetValidator = sourceSetValidator,
             annotationFilter = annotationFilter,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorFactorySpec.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.processor.ProcessorContract.AggregatorFactory
 import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
 import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SingleSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.mapFixture
@@ -25,7 +25,7 @@ class KMockSourceAggregatorFactorySpec {
 
     @Test
     fun `It fulfils AggregatorFactory`() {
-        KMockSourceAggregator fulfils AggregatorFactory::class
+        KMockSingleSourceAggregator fulfils AggregatorFactory::class
     }
 
     @Test
@@ -42,7 +42,7 @@ class KMockSourceAggregatorFactorySpec {
         every { annotationFilter.filterAnnotation(any()) } returns customAnnotations
 
         // When
-        val actual = KMockSourceAggregator.getInstance(
+        val actual = KMockSingleSourceAggregator.getInstance(
             logger = logger,
             sourceSetValidator = sourceSetValidator,
             annotationFilter = annotationFilter,
@@ -52,7 +52,7 @@ class KMockSourceAggregatorFactorySpec {
         )
 
         // Then
-        actual fulfils SourceAggregator::class
+        actual fulfils SingleSourceAggregator::class
 
         verify(exactly = 1) {
             annotationFilter.filterAnnotation(customAnnotations)

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorPlatformSpec.kt
@@ -29,7 +29,7 @@ import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SingleSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
@@ -50,7 +50,7 @@ class KMockSourceAggregatorPlatformSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockSourceAggregator(
+        KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -62,14 +62,14 @@ class KMockSourceAggregatorPlatformSpec {
 
     @Test
     fun `It fulfils SourceAggregator`() {
-        KMockSourceAggregator(
+        KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ) fulfils SourceAggregator::class
+        ) fulfils SingleSourceAggregator::class
     }
 
     @Test
@@ -104,7 +104,7 @@ class KMockSourceAggregatorPlatformSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -148,7 +148,7 @@ class KMockSourceAggregatorPlatformSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -209,7 +209,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
@@ -293,7 +293,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 mockk(),
                 mockk(),
@@ -375,7 +375,7 @@ class KMockSourceAggregatorPlatformSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -465,7 +465,7 @@ class KMockSourceAggregatorPlatformSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -546,7 +546,7 @@ class KMockSourceAggregatorPlatformSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -633,7 +633,7 @@ class KMockSourceAggregatorPlatformSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             mockk(),
@@ -730,7 +730,7 @@ class KMockSourceAggregatorPlatformSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorPlatformSpec.kt
@@ -260,7 +260,6 @@ class KMockSourceAggregatorPlatformSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -286,8 +285,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -304,8 +302,8 @@ class KMockSourceAggregatorPlatformSpec {
         }
 
         // Then
-        error.message mustBe "Cannot stub non interface $packageName.$qualifiedName."
-        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$qualifiedName.") }
+        error.message mustBe "Cannot stub non interface $packageName.$simpleName."
+        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$simpleName.") }
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
@@ -334,7 +332,6 @@ class KMockSourceAggregatorPlatformSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -367,8 +364,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -424,7 +420,6 @@ class KMockSourceAggregatorPlatformSpec {
 
         val values: List<KSType> = listOf(type, type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -457,8 +452,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -514,7 +508,6 @@ class KMockSourceAggregatorPlatformSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -540,8 +533,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -595,7 +587,6 @@ class KMockSourceAggregatorPlatformSpec {
 
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -627,8 +618,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -685,7 +675,6 @@ class KMockSourceAggregatorPlatformSpec {
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val alias: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
         val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
@@ -694,7 +683,7 @@ class KMockSourceAggregatorPlatformSpec {
             null
         }
 
-        val mapping = mapOf(qualifiedName to alias)
+        val mapping = mapOf("$packageName.$simpleName" to alias)
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -720,8 +709,7 @@ class KMockSourceAggregatorPlatformSpec {
 
         every { declaration.parentDeclaration } returns null
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorPlatformSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorPlatformSpec.kt
@@ -4,7 +4,7 @@
  * Use of this source code is governed by Apache v2.0
  */
 
-package tech.antibytes.kmock.processor
+package tech.antibytes.kmock.processor.aggregation
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
@@ -27,7 +27,9 @@ import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
-import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
@@ -35,7 +37,7 @@ import tech.antibytes.util.test.fixture.qualifier.named
 import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 
-class KMockAggregatorCommonSpec {
+class KMockSourceAggregatorPlatformSpec {
     private val fixture = kotlinFixture { configuration ->
         configuration.addGenerator(
             String::class,
@@ -46,18 +48,30 @@ class KMockAggregatorCommonSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockAggregator(
+        KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ) fulfils ProcessorContract.Aggregator::class
+        ) fulfils Aggregator::class
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
+    fun `It fulfils SourceAggregator`() {
+        KMockSourceAggregator(
+            mockk(),
+            mockk(),
+            mockk(),
+            mockk(),
+            emptyMap(),
+            emptyMap(),
+        ) fulfils SourceAggregator::class
+    }
+
+    @Test
+    fun `Given extractPlatformInterfaces is called it resolves the Annotated Thing as ill, if no KMockAnnotation was found`() {
         // Given
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
@@ -88,24 +102,24 @@ class KMockAggregatorCommonSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it filters all ill Annotations`() {
+    fun `Given extractPlatformInterfaces is called it filters all ill Annotations`() {
         // Given
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
@@ -127,29 +141,29 @@ class KMockAggregatorCommonSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockCommon::class.qualifiedName!!
+        } returns Mock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         illegal mustBe listOf(symbol)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it filters all non class types and reports an error`() {
+    fun `Given extractPlatformInterfaces is called it filters all non class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -177,7 +191,7 @@ class KMockAggregatorCommonSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockCommon::class.qualifiedName!!
+        } returns Mock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -192,24 +206,24 @@ class KMockAggregatorCommonSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         verify(exactly = 1) { logger.error("Cannot stub non interfaces.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it filters all implementation class types and reports an error`() {
+    fun `Given extractPlatformInterfaces is called it filters all implementation class types and reports an error`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -251,7 +265,7 @@ class KMockAggregatorCommonSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockCommon::class.qualifiedName!!
+        } returns Mock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -274,24 +288,24 @@ class KMockAggregatorCommonSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$className.") }
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it returns all found interfaces`() {
+    fun `Given extractPlatformInterfaces is called it returns all found interfaces`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -330,7 +344,7 @@ class KMockAggregatorCommonSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockCommon::class.qualifiedName!!
+        } returns Mock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -355,14 +369,14 @@ class KMockAggregatorCommonSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             genericResolver,
             emptyMap(),
             emptyMap(),
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
@@ -376,13 +390,14 @@ class KMockAggregatorCommonSpec {
         )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
+
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it returns the corresponding source files`() {
+    fun `Given extractPlatformInterfaces is called it returns the corresponding source files`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -414,7 +429,7 @@ class KMockAggregatorCommonSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockCommon::class.qualifiedName!!
+        } returns Mock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -436,24 +451,24 @@ class KMockAggregatorCommonSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, _, sourceFiles) = KMockAggregator(
+        val (_, _, sourceFiles) = KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(relaxed = true),
             emptyMap(),
             emptyMap(),
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
+    fun `Given extractPlatformInterfaces is called it returns the corresponding source files, while filter non related annotations`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
@@ -485,6 +500,7 @@ class KMockAggregatorCommonSpec {
 
         val className: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val simpleName: String = fixture.fixture(named("stringAlpha"))
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -494,20 +510,22 @@ class KMockAggregatorCommonSpec {
             notRelatedAnnotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returnsMany listOf(
             MockShared::class.qualifiedName!!,
-            Mock::class.qualifiedName!!
+            MockCommon::class.qualifiedName!!
         )
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockCommon::class.qualifiedName!!
+        } returns Mock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
         every { notRelatedSymbol.annotations } returns notRelatedSource
 
         every { annotation.arguments } returns arguments
-        every { arguments.size } returns 1
         every { arguments.isEmpty() } returns false
+
+        every { arguments.size } returns 1
         every { arguments[0].value } returns values
+
         every { type.declaration } returns declaration
         every { declaration.classKind } returns ClassKind.INTERFACE
 
@@ -523,30 +541,29 @@ class KMockAggregatorCommonSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        val (_, _, sourceFiles) = KMockAggregator(
+        val (_, _, sourceFiles) = KMockSourceAggregator(
             logger,
             mockk(),
             mockk(),
             mockk(relaxed = true),
             emptyMap(),
             emptyMap(),
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         sourceFiles mustBe listOf(file)
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 
     @Test
-    fun `Given extractCommonInterfaces is called it returns while mapping aliases`() {
+    fun `Given extractPlatformInterfaces is called it returns while mapping aliases`() {
         // Given
         val logger: KSPLogger = mockk()
         val symbol: KSAnnotated = mockk()
         val resolver: Resolver = mockk()
         val file: KSFile = mockk()
-        val sourceSetValidator: SourceSetValidator = mockk()
 
         val annotation: KSAnnotation = mockk()
         val sourceAnnotations: Sequence<KSAnnotation> = sequence {
@@ -565,8 +582,8 @@ class KMockAggregatorCommonSpec {
 
         val className: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
-        val alias: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
+        val alias: String = fixture.fixture(named("stringAlpha"))
 
         val genericResolver: ProcessorContract.GenericResolver = mockk()
         val generics: Map<String, List<KSTypeReference>>? = if (fixture.fixture()) {
@@ -583,7 +600,7 @@ class KMockAggregatorCommonSpec {
 
         every {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
-        } returns MockCommon::class.qualifiedName!!
+        } returns Mock::class.qualifiedName!!
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -607,19 +624,17 @@ class KMockAggregatorCommonSpec {
 
         every { logger.error(any()) } just Runs
 
-        every { sourceSetValidator.isValidateSourceSet(any()) } returns true
-
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             mockk(),
-            sourceSetValidator,
+            mockk(),
             genericResolver,
             emptyMap(),
             mapping,
-        ).extractCommonInterfaces(resolver)
+        ).extractPlatformInterfaces(resolver)
 
         // Then
         interfaces mustBe listOf(
@@ -633,8 +648,9 @@ class KMockAggregatorCommonSpec {
         )
 
         verify(exactly = 1) { genericResolver.extractGenerics(declaration, any()) }
+
         verify(exactly = 1) {
-            resolver.getSymbolsWithAnnotation(MockCommon::class.qualifiedName!!, false)
+            resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!, false)
         }
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
@@ -30,7 +30,7 @@ import tech.antibytes.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
 import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
-import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
+import tech.antibytes.kmock.processor.ProcessorContract.SingleSourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
@@ -52,7 +52,7 @@ class KMockSourceAggregatorSharedSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockSourceAggregator(
+        KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -64,14 +64,14 @@ class KMockSourceAggregatorSharedSpec {
 
     @Test
     fun `It fulfils SourceAggregator`() {
-        KMockSourceAggregator(
+        KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ) fulfils SourceAggregator::class
+        ) fulfils SingleSourceAggregator::class
     }
 
     @Test
@@ -107,7 +107,7 @@ class KMockSourceAggregatorSharedSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -167,7 +167,7 @@ class KMockSourceAggregatorSharedSpec {
         every { sourceSetValidator.isValidateSourceSet(any()) } returns false
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -227,7 +227,7 @@ class KMockSourceAggregatorSharedSpec {
         every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns false
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -286,7 +286,7 @@ class KMockSourceAggregatorSharedSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             mockk(),
             mockk(),
             sourceSetValidator,
@@ -338,7 +338,7 @@ class KMockSourceAggregatorSharedSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockSourceAggregator(
+        val (illegal, _, _) = KMockSingleSourceAggregator(
             mockk(),
             annotationFilter,
             sourceSetValidator,
@@ -417,7 +417,7 @@ class KMockSourceAggregatorSharedSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 mockk(),
                 sourceSetValidator,
@@ -490,7 +490,7 @@ class KMockSourceAggregatorSharedSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 annotationFilter,
                 sourceSetValidator,
@@ -592,7 +592,7 @@ class KMockSourceAggregatorSharedSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 mockk(),
                 sourceSetValidator,
@@ -686,7 +686,7 @@ class KMockSourceAggregatorSharedSpec {
 
         // When
         val error = assertFailsWith<IllegalArgumentException> {
-            KMockSourceAggregator(
+            KMockSingleSourceAggregator(
                 logger,
                 annotationFilter,
                 sourceSetValidator,
@@ -786,7 +786,7 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -889,7 +889,7 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -1049,7 +1049,7 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -1217,7 +1217,7 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -1332,7 +1332,7 @@ class KMockSourceAggregatorSharedSpec {
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -1413,7 +1413,7 @@ class KMockSourceAggregatorSharedSpec {
         every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         // When
-        val (_, _, sourceFiles) = KMockSourceAggregator(
+        val (_, _, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -1522,7 +1522,7 @@ class KMockSourceAggregatorSharedSpec {
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
         // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -1627,7 +1627,7 @@ class KMockSourceAggregatorSharedSpec {
         every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         // When
-        val (_, interfaces, sourceFiles) = KMockSourceAggregator(
+        val (_, interfaces, sourceFiles) = KMockSingleSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -1741,7 +1741,7 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -1842,7 +1842,7 @@ class KMockSourceAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockSourceAggregator(
+        val (_, interfaces, _) = KMockSingleSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
@@ -553,7 +553,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(fixture.fixture())
@@ -582,9 +581,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
@@ -603,8 +601,8 @@ class KMockSourceAggregatorSharedSpec {
         }
 
         // Then
-        error.message mustBe "Cannot stub non interface $packageName.$qualifiedName."
-        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$qualifiedName.") }
+        error.message mustBe "Cannot stub non interface $packageName.$simpleName."
+        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$simpleName.") }
         verify(exactly = 1) {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
@@ -649,7 +647,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -676,9 +673,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
@@ -697,8 +693,8 @@ class KMockSourceAggregatorSharedSpec {
         }
 
         // Then
-        error.message mustBe "Cannot stub non interface $packageName.$qualifiedName."
-        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$qualifiedName.") }
+        error.message mustBe "Cannot stub non interface $packageName.$simpleName."
+        verify(exactly = 1) { logger.error("Cannot stub non interface $packageName.$simpleName.") }
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
@@ -740,7 +736,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -775,9 +770,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -844,7 +838,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -878,9 +871,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -982,7 +974,6 @@ class KMockSourceAggregatorSharedSpec {
             null
         }
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -1038,9 +1029,8 @@ class KMockSourceAggregatorSharedSpec {
         every { source2.parent } returns file
         every { source3.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -1152,7 +1142,6 @@ class KMockSourceAggregatorSharedSpec {
             null
         }
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -1206,9 +1195,8 @@ class KMockSourceAggregatorSharedSpec {
         every { source2.parent } returns file
         every { source3.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -1292,7 +1280,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val allowedSourceSets: Set<String> = setOf(
@@ -1323,9 +1310,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -1377,7 +1363,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
 
@@ -1404,9 +1389,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -1473,7 +1457,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
 
@@ -1513,9 +1496,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -1584,7 +1566,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
 
@@ -1618,9 +1599,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -1688,7 +1668,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val alias: String = fixture.fixture(named("stringAlpha"))
@@ -1703,7 +1682,7 @@ class KMockSourceAggregatorSharedSpec {
             null
         }
 
-        val mapping = mapOf(qualifiedName to alias)
+        val mapping = mapOf("$packageName.$simpleName" to alias)
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -1730,9 +1709,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 
@@ -1793,7 +1771,6 @@ class KMockSourceAggregatorSharedSpec {
 
         val values: List<KSType> = listOf(type)
 
-        val qualifiedName: String = fixture.fixture(named("stringAlpha"))
         val simpleName: String = fixture.fixture(named("stringAlpha"))
         val packageName: String = fixture.fixture(named("stringAlpha"))
         val alias: String = fixture.fixture(named("stringAlpha"))
@@ -1805,7 +1782,7 @@ class KMockSourceAggregatorSharedSpec {
             null
         }
 
-        val mapping = mapOf(qualifiedName to alias)
+        val mapping = mapOf("$packageName.$simpleName" to alias)
 
         every {
             resolver.getSymbolsWithAnnotation(any(), any())
@@ -1831,9 +1808,8 @@ class KMockSourceAggregatorSharedSpec {
         every { file.parent } returns null
         every { symbol.parent } returns file
 
-        every { declaration.qualifiedName!!.asString() } returns qualifiedName
         every { declaration.packageName.asString() } returns packageName
-        every { declaration.simpleName.asString() } returns simpleName
+        every { declaration.qualifiedName!!.asString() } returns "$packageName.$simpleName"
 
         every { logger.error(any()) } just Runs
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
@@ -4,7 +4,7 @@
  * Use of this source code is governed by Apache v2.0
  */
 
-package tech.antibytes.kmock.processor
+package tech.antibytes.kmock.processor.aggregation
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
@@ -27,7 +27,10 @@ import tech.antibytes.kmock.Mock
 import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.MockShared
 import tech.antibytes.kmock.fixture.StringAlphaGenerator
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregator
 import tech.antibytes.kmock.processor.ProcessorContract.AnnotationFilter
+import tech.antibytes.kmock.processor.ProcessorContract.SourceAggregator
 import tech.antibytes.kmock.processor.ProcessorContract.SourceSetValidator
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
@@ -37,7 +40,7 @@ import tech.antibytes.util.test.fixture.qualifier.named
 import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 
-class KMockAggregatorSharedSpec {
+class KMockSourceAggregatorSharedSpec {
     private val fixture = kotlinFixture { configuration ->
         configuration.addGenerator(
             String::class,
@@ -48,14 +51,26 @@ class KMockAggregatorSharedSpec {
 
     @Test
     fun `It fulfils Aggregator`() {
-        KMockAggregator(
+        KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
             mockk(),
             emptyMap(),
             emptyMap(),
-        ) fulfils ProcessorContract.Aggregator::class
+        ) fulfils Aggregator::class
+    }
+
+    @Test
+    fun `It fulfils SourceAggregator`() {
+        KMockSourceAggregator(
+            mockk(),
+            mockk(),
+            mockk(),
+            mockk(),
+            emptyMap(),
+            emptyMap(),
+        ) fulfils SourceAggregator::class
     }
 
     @Test
@@ -91,7 +106,7 @@ class KMockAggregatorSharedSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             mockk(),
             mockk(),
             mockk(),
@@ -151,7 +166,7 @@ class KMockAggregatorSharedSpec {
         every { sourceSetValidator.isValidateSourceSet(any()) } returns false
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -211,7 +226,7 @@ class KMockAggregatorSharedSpec {
         every { annotationFilter.isApplicableAnnotation(any()) } returns false
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -270,7 +285,7 @@ class KMockAggregatorSharedSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             mockk(),
             mockk(),
             sourceSetValidator,
@@ -322,7 +337,7 @@ class KMockAggregatorSharedSpec {
         every { symbol.annotations } returns sourceAnnotations
 
         // When
-        val (illegal, _, _) = KMockAggregator(
+        val (illegal, _, _) = KMockSourceAggregator(
             mockk(),
             annotationFilter,
             sourceSetValidator,
@@ -399,7 +414,7 @@ class KMockAggregatorSharedSpec {
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -472,7 +487,7 @@ class KMockAggregatorSharedSpec {
         every { annotationFilter.isApplicableAnnotation(any()) } returns true
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -570,7 +585,7 @@ class KMockAggregatorSharedSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -662,7 +677,7 @@ class KMockAggregatorSharedSpec {
         every { logger.error(any()) } just Runs
 
         // When
-        KMockAggregator(
+        KMockSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -759,7 +774,7 @@ class KMockAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -862,7 +877,7 @@ class KMockAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -992,7 +1007,7 @@ class KMockAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -1127,7 +1142,7 @@ class KMockAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -1241,7 +1256,7 @@ class KMockAggregatorSharedSpec {
         every { sourceSetValidator.isValidateSourceSet(any()) } returns true
 
         // When
-        val (_, _, sourceFiles) = KMockAggregator(
+        val (_, _, sourceFiles) = KMockSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -1520,7 +1535,7 @@ class KMockAggregatorSharedSpec {
         every { annotationFilter.isApplicableAnnotation(any()) } returns true
 
         // When
-        val (_, _, sourceFiles) = KMockAggregator(
+        val (_, _, sourceFiles) = KMockSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,
@@ -1625,7 +1640,7 @@ class KMockAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             mockk(),
             sourceSetValidator,
@@ -1730,7 +1745,7 @@ class KMockAggregatorSharedSpec {
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
         // When
-        val (_, interfaces, _) = KMockAggregator(
+        val (_, interfaces, _) = KMockSourceAggregator(
             logger,
             annotationFilter,
             sourceSetValidator,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/aggregation/KMockSourceAggregatorSharedSpec.kt
@@ -223,7 +223,7 @@ class KMockSourceAggregatorSharedSpec {
         every { annotation.arguments } returns arguments
         every { arguments[0].value } returns null
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns false
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns false
 
         // When
         val (illegal, _, _) = KMockSourceAggregator(
@@ -242,7 +242,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableAnnotation(annotation)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
@@ -332,7 +332,7 @@ class KMockSourceAggregatorSharedSpec {
             annotation.annotationType.resolve().declaration.qualifiedName!!.asString()
         } returns customAnnotations.keys.random()
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         every { symbol.annotations } returns sourceAnnotations
 
@@ -352,7 +352,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableAnnotation(annotation)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
@@ -484,7 +484,7 @@ class KMockSourceAggregatorSharedSpec {
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         // When
         KMockSourceAggregator(
@@ -502,7 +502,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableAnnotation(annotation)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
@@ -672,7 +672,7 @@ class KMockSourceAggregatorSharedSpec {
         every { declaration.packageName.asString() } returns packageName
         every { declaration.simpleName.asString() } returns simpleName
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         every { logger.error(any()) } just Runs
 
@@ -692,7 +692,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 4) {
-            annotationFilter.isApplicableAnnotation(annotation)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
@@ -872,7 +872,7 @@ class KMockSourceAggregatorSharedSpec {
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
@@ -903,7 +903,7 @@ class KMockSourceAggregatorSharedSpec {
             sourceSetValidator.isValidateSourceSet(annotation)
         }
         verify(exactly = 2) {
-            annotationFilter.isApplicableAnnotation(annotation)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
         }
         verify(exactly = 1) {
             resolver.getSymbolsWithAnnotation(MockShared::class.qualifiedName!!, false)
@@ -1137,7 +1137,7 @@ class KMockSourceAggregatorSharedSpec {
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
@@ -1171,10 +1171,10 @@ class KMockSourceAggregatorSharedSpec {
 
         verify(exactly = 6) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 3) {
-            annotationFilter.isApplicableAnnotation(annotation0)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation0)
         }
         verify(exactly = 3) {
-            annotationFilter.isApplicableAnnotation(annotation1)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation1)
         }
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation0)
@@ -1532,7 +1532,7 @@ class KMockSourceAggregatorSharedSpec {
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         // When
         val (_, _, sourceFiles) = KMockSourceAggregator(
@@ -1547,7 +1547,7 @@ class KMockSourceAggregatorSharedSpec {
         // Then
         sourceFiles mustBe listOf(file, file)
         verify(exactly = 2) {
-            annotationFilter.isApplicableAnnotation(annotation)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
         }
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation)
@@ -1740,7 +1740,7 @@ class KMockSourceAggregatorSharedSpec {
 
         every { logger.error(any()) } just Runs
 
-        every { annotationFilter.isApplicableAnnotation(any()) } returns true
+        every { annotationFilter.isApplicableSingleSourceAnnotation(any()) } returns true
 
         every { genericResolver.extractGenerics(any(), any()) } returns generics
 
@@ -1767,7 +1767,7 @@ class KMockSourceAggregatorSharedSpec {
 
         verify(exactly = 2) { genericResolver.extractGenerics(declaration, any()) }
         verify(exactly = 2) {
-            annotationFilter.isApplicableAnnotation(annotation)
+            annotationFilter.isApplicableSingleSourceAnnotation(annotation)
         }
         verify(exactly = 0) {
             sourceSetValidator.isValidateSourceSet(annotation)

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/mock/KMockGeneratorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/mock/KMockGeneratorSpec.kt
@@ -23,6 +23,7 @@ class KMockGeneratorSpec {
             mockk(),
             mockk(),
             mockk(),
+            mockk(),
             mockk()
         ) fulfils ProcessorContract.MockGenerator::class
     }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/MultiInterfaceBinderSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/MultiInterfaceBinderSpec.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.multi
+
+import io.mockk.mockk
+import org.junit.Test
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.util.test.fulfils
+
+class MultiInterfaceBinderSpec {
+    @Test
+    fun `It fulfils MultiInterfaceBinder`() {
+        KMockMultiInterfaceBinder(mockk(), mockk()) fulfils ProcessorContract.MultiInterfaceBinder::class
+    }
+}

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/MultiInterfaceBinderSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/MultiInterfaceBinderSpec.kt
@@ -14,6 +14,10 @@ import tech.antibytes.util.test.fulfils
 class MultiInterfaceBinderSpec {
     @Test
     fun `It fulfils MultiInterfaceBinder`() {
-        KMockMultiInterfaceBinder(mockk(), mockk()) fulfils ProcessorContract.MultiInterfaceBinder::class
+        KMockMultiInterfaceBinder(
+            mockk(),
+            "any",
+            mockk()
+        ) fulfils ProcessorContract.MultiInterfaceBinder::class
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/ParentFinderSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/ParentFinderSpec.kt
@@ -10,14 +10,13 @@ import com.google.devtools.ksp.symbol.KSFile
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.processor.ProcessorContract
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
-import tech.antibytes.util.test.sameAs
 
 class ParentFinderSpec {
     private val fixture = kotlinFixture()
@@ -49,23 +48,20 @@ class ParentFinderSpec {
             generics = emptyList()
         )
 
-        val singleDependency: KSFile = mockk()
         val multiDependency: KSFile = mockk()
 
         // When
-        val (parents, dependency) = KMockParentFinder.find(
+        val parents = KMockParentFinder.find(
             templateSource = templateSource,
             templateMultiSources = Aggregated(
                 illFormed = emptyList(),
                 extractedTemplates = listOf(templateMultiSource),
                 dependencies = listOf(multiDependency)
             ),
-            dependency = singleDependency
         )
 
         // Then
         parents mustBe emptyList()
-        dependency sameAs singleDependency
     }
 
     @Test
@@ -90,23 +86,20 @@ class ParentFinderSpec {
             generics = emptyList()
         )
 
-        val singleDependency: KSFile = mockk()
         val multiDependency: KSFile = mockk()
 
         // When
-        val (parents, dependency) = KMockParentFinder.find(
+        val parents = KMockParentFinder.find(
             templateSource = templateSource,
             templateMultiSources = Aggregated(
                 illFormed = emptyList(),
                 extractedTemplates = listOf(templateMultiSource),
                 dependencies = listOf(multiDependency)
             ),
-            dependency = singleDependency
         )
 
         // Then
         parents mustBe emptyList()
-        dependency sameAs singleDependency
     }
 
     @Test
@@ -131,23 +124,20 @@ class ParentFinderSpec {
             generics = emptyList()
         )
 
-        val singleDependency: KSFile = mockk()
         val multiDependency: KSFile = mockk()
 
         // When
-        val (parents, dependency) = KMockParentFinder.find(
+        val parents = KMockParentFinder.find(
             templateSource = templateSource,
             templateMultiSources = Aggregated(
                 illFormed = emptyList(),
                 extractedTemplates = listOf(templateMultiSource),
                 dependencies = listOf(multiDependency)
             ),
-            dependency = singleDependency
         )
 
         // Then
         parents mustBe emptyList()
-        dependency sameAs singleDependency
     }
 
     @Test
@@ -173,22 +163,19 @@ class ParentFinderSpec {
             generics = emptyList()
         )
 
-        val singleDependency: KSFile = mockk()
         val multiDependency: KSFile = mockk()
 
         // When
-        val (parents, dependency) = KMockParentFinder.find(
+        val parents = KMockParentFinder.find(
             templateSource = templateSource,
             templateMultiSources = Aggregated(
                 illFormed = emptyList(),
                 extractedTemplates = listOf(templateMultiSource),
                 dependencies = listOf(multiDependency)
             ),
-            dependency = singleDependency
         )
 
         // Then
         parents mustBe templateMultiSource.templates
-        dependency sameAs multiDependency
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/ParentFinderSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/ParentFinderSpec.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.multi
+
+import com.google.devtools.ksp.symbol.KSFile
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.fulfils
+import tech.antibytes.util.test.mustBe
+import tech.antibytes.util.test.sameAs
+
+class ParentFinderSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    fun `It fulfils ParentFinder`() {
+        KMockParentFinder fulfils ProcessorContract.ParentFinder::class
+    }
+
+    @Test
+    fun `Given find is called with a TemplateSource and TemplateMultiSource and a KSFile, it returns a empty list and the given KSFile if no Parent with a matching packageName was found`() {
+        // Given
+        val indicator: String = fixture.fixture()
+        val templateName: String = fixture.fixture()
+
+        val templateSource = TemplateSource(
+            indicator = indicator,
+            packageName = fixture.fixture(),
+            templateName = templateName,
+            template = mockk(),
+            generics = emptyMap()
+        )
+
+        val templateMultiSource = TemplateMultiSource(
+            indicator = indicator,
+            packageName = fixture.fixture(),
+            templateName = templateName,
+            templates = mockk(),
+            generics = emptyList()
+        )
+
+        val singleDependency: KSFile = mockk()
+        val multiDependency: KSFile = mockk()
+
+        // When
+        val (parents, dependency) = KMockParentFinder.find(
+            templateSource = templateSource,
+            templateMultiSources = Aggregated(
+                illFormed = emptyList(),
+                extractedTemplates = listOf(templateMultiSource),
+                dependencies = listOf(multiDependency)
+            ),
+            dependency = singleDependency
+        )
+
+        // Then
+        parents mustBe emptyList()
+        dependency sameAs singleDependency
+    }
+
+    @Test
+    fun `Given find is called with a TemplateSource and TemplateMultiSource and a KSFile, it returns a empty list and the given KSFile if no Parent with a matching indicator was found`() {
+        // Given
+        val packageName: String = fixture.fixture()
+        val templateName: String = fixture.fixture()
+
+        val templateSource = TemplateSource(
+            indicator = fixture.fixture(),
+            packageName = packageName,
+            templateName = templateName,
+            template = mockk(),
+            generics = emptyMap()
+        )
+
+        val templateMultiSource = TemplateMultiSource(
+            indicator = fixture.fixture(),
+            packageName = packageName,
+            templateName = templateName,
+            templates = mockk(),
+            generics = emptyList()
+        )
+
+        val singleDependency: KSFile = mockk()
+        val multiDependency: KSFile = mockk()
+
+        // When
+        val (parents, dependency) = KMockParentFinder.find(
+            templateSource = templateSource,
+            templateMultiSources = Aggregated(
+                illFormed = emptyList(),
+                extractedTemplates = listOf(templateMultiSource),
+                dependencies = listOf(multiDependency)
+            ),
+            dependency = singleDependency
+        )
+
+        // Then
+        parents mustBe emptyList()
+        dependency sameAs singleDependency
+    }
+
+    @Test
+    fun `Given find is called with a TemplateSource and TemplateMultiSource and a KSFile, it returns a empty list and the given KSFile if no Parent with a matching templateName was found`() {
+        // Given
+        val packageName: String = fixture.fixture()
+        val indicator: String = fixture.fixture()
+
+        val templateSource = TemplateSource(
+            indicator = indicator,
+            packageName = packageName,
+            templateName = fixture.fixture(),
+            template = mockk(),
+            generics = emptyMap()
+        )
+
+        val templateMultiSource = TemplateMultiSource(
+            indicator = indicator,
+            packageName = packageName,
+            templateName = fixture.fixture(),
+            templates = mockk(),
+            generics = emptyList()
+        )
+
+        val singleDependency: KSFile = mockk()
+        val multiDependency: KSFile = mockk()
+
+        // When
+        val (parents, dependency) = KMockParentFinder.find(
+            templateSource = templateSource,
+            templateMultiSources = Aggregated(
+                illFormed = emptyList(),
+                extractedTemplates = listOf(templateMultiSource),
+                dependencies = listOf(multiDependency)
+            ),
+            dependency = singleDependency
+        )
+
+        // Then
+        parents mustBe emptyList()
+        dependency sameAs singleDependency
+    }
+
+    @Test
+    fun `Given find is called with a TemplateSource and TemplateMultiSource and a KSFile, it returns a TemplateMultiSource Interfaces and its KSFile`() {
+        // Given
+        val packageName: String = fixture.fixture()
+        val indicator: String = fixture.fixture()
+        val templateName: String = fixture.fixture()
+
+        val templateSource = TemplateSource(
+            indicator = indicator,
+            packageName = packageName,
+            templateName = templateName,
+            template = mockk(),
+            generics = emptyMap()
+        )
+
+        val templateMultiSource = TemplateMultiSource(
+            indicator = indicator,
+            packageName = packageName,
+            templateName = templateName,
+            templates = mockk(),
+            generics = emptyList()
+        )
+
+        val singleDependency: KSFile = mockk()
+        val multiDependency: KSFile = mockk()
+
+        // When
+        val (parents, dependency) = KMockParentFinder.find(
+            templateSource = templateSource,
+            templateMultiSources = Aggregated(
+                illFormed = emptyList(),
+                extractedTemplates = listOf(templateMultiSource),
+                dependencies = listOf(multiDependency)
+            ),
+            dependency = singleDependency
+        )
+
+        // Then
+        parents mustBe templateMultiSource.templates
+        dependency sameAs multiDependency
+    }
+}

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilterSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilterSpec.kt
@@ -133,7 +133,7 @@ class AnnotationFilterSpec {
     }
 
     @Test
-    fun `Given isApplicableAnnotation is called with a KSAnnotation it returns false if it takes less then 1 argument`() {
+    fun `Given isApplicableSingleSourceAnnotation is called with a KSAnnotation it returns false if it takes less then 1 argument`() {
         // Given
         val annotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk(relaxUnitFun = true)
@@ -148,14 +148,14 @@ class AnnotationFilterSpec {
         val actual = AnnotationFilter(
             logger,
             annotations.values.toSet()
-        ).isApplicableAnnotation(annotation)
+        ).isApplicableSingleSourceAnnotation(annotation)
 
         // Then
         actual mustBe false
     }
 
     @Test
-    fun `Given isApplicableAnnotation is called with a KSAnnotation it returns false if it takes more then 1 argument`() {
+    fun `Given isApplicableSingleSourceAnnotation is called with a KSAnnotation it returns false if it takes more then 1 argument`() {
         // Given
         val annotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk(relaxUnitFun = true)
@@ -170,14 +170,14 @@ class AnnotationFilterSpec {
         val actual = AnnotationFilter(
             logger,
             annotations.values.toSet()
-        ).isApplicableAnnotation(annotation)
+        ).isApplicableSingleSourceAnnotation(annotation)
 
         // Then
         actual mustBe false
     }
 
     @Test
-    fun `Given isApplicableAnnotation is called with a KSAnnotation it returns false if its argument is not an Array`() {
+    fun `Given isApplicableSingleSourceAnnotation is called with a KSAnnotation it returns false if its argument is not a ListType`() {
         // Given
         val annotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk(relaxUnitFun = true)
@@ -197,14 +197,14 @@ class AnnotationFilterSpec {
         val actual = AnnotationFilter(
             logger,
             annotations.values.toSet()
-        ).isApplicableAnnotation(annotation)
+        ).isApplicableSingleSourceAnnotation(annotation)
 
         // Then
         actual mustBe false
     }
 
     @Test
-    fun `Given isApplicableAnnotation is called with a KSAnnotation it returns false if its argument contains not an List of KSType`() {
+    fun `Given isApplicableSingleSourceAnnotation is called with a KSAnnotation it returns false if its argument contains not a List of KSType`() {
         // Given
         val annotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk(relaxUnitFun = true)
@@ -224,14 +224,14 @@ class AnnotationFilterSpec {
         val actual = AnnotationFilter(
             logger,
             annotations.values.toSet()
-        ).isApplicableAnnotation(annotation)
+        ).isApplicableSingleSourceAnnotation(annotation)
 
         // Then
         actual mustBe false
     }
 
     @Test
-    fun `Given isApplicableAnnotation is called with a KSAnnotation it returns true if its argument contains an empty List`() {
+    fun `Given isApplicableSingleSourceAnnotation is called with a KSAnnotation it returns true if its argument contains an empty List`() {
         // Given
         val annotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk(relaxUnitFun = true)
@@ -251,14 +251,14 @@ class AnnotationFilterSpec {
         val actual = AnnotationFilter(
             logger,
             annotations.values.toSet()
-        ).isApplicableAnnotation(annotation)
+        ).isApplicableSingleSourceAnnotation(annotation)
 
         // Then
         actual mustBe true
     }
 
     @Test
-    fun `Given isApplicableAnnotation is called with a KSAnnotation it returns true if its argument contains an List of KSType`() {
+    fun `Given isApplicableSingleSourceAnnotation is called with a KSAnnotation it returns true if its argument contains a List of KSType`() {
         // Given
         val annotations: Map<String, String> = fixture.mapFixture(size = 3)
         val logger: KSPLogger = mockk(relaxUnitFun = true)
@@ -278,7 +278,206 @@ class AnnotationFilterSpec {
         val actual = AnnotationFilter(
             logger,
             annotations.values.toSet()
-        ).isApplicableAnnotation(annotation)
+        ).isApplicableSingleSourceAnnotation(annotation)
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given isApplicableMultiSourceAnnotation is called with a KSAnnotation it returns false if it takes less then 2 argument`() {
+        // Given
+        val annotations: Map<String, String> = fixture.mapFixture(size = 3)
+        val logger: KSPLogger = mockk(relaxUnitFun = true)
+
+        val annotation: KSAnnotation = mockk()
+
+        every {
+            annotation.arguments
+        } returns listOf(mockk())
+
+        // When
+        val actual = AnnotationFilter(
+            logger,
+            annotations.values.toSet()
+        ).isApplicableMultiSourceAnnotation(annotation)
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given isApplicableMultiSourceAnnotation is called with a KSAnnotation it returns false if it takes more then 2 argument`() {
+        // Given
+        val annotations: Map<String, String> = fixture.mapFixture(size = 3)
+        val logger: KSPLogger = mockk(relaxUnitFun = true)
+
+        val annotation: KSAnnotation = mockk()
+
+        every {
+            annotation.arguments
+        } returns listOf(mockk(), mockk(), mockk())
+
+        // When
+        val actual = AnnotationFilter(
+            logger,
+            annotations.values.toSet()
+        ).isApplicableMultiSourceAnnotation(annotation)
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given isApplicableMultiSourceAnnotation is called with a KSAnnotation it returns false if its first argument is not a String`() {
+        // Given
+        val annotations: Map<String, String> = fixture.mapFixture(size = 3)
+        val logger: KSPLogger = mockk(relaxUnitFun = true)
+
+        val annotation: KSAnnotation = mockk()
+        val argument: KSValueArgument = mockk()
+
+        every {
+            annotation.arguments
+        } returns listOf(argument, mockk())
+
+        every {
+            argument.value
+        } returns Any()
+
+        // When
+        val actual = AnnotationFilter(
+            logger,
+            annotations.values.toSet()
+        ).isApplicableMultiSourceAnnotation(annotation)
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given isApplicableMultiSourceAnnotation is called with a KSAnnotation it returns false if its second argument is not a ListType`() {
+        // Given
+        val annotations: Map<String, String> = fixture.mapFixture(size = 3)
+        val logger: KSPLogger = mockk(relaxUnitFun = true)
+
+        val annotation: KSAnnotation = mockk()
+        val argument1: KSValueArgument = mockk()
+        val argument2: KSValueArgument = mockk()
+
+        every {
+            annotation.arguments
+        } returns listOf(argument1, argument2)
+
+        every {
+            argument1.value
+        } returns fixture.fixture<String>()
+
+        every {
+            argument2.value
+        } returns Any()
+
+        // When
+        val actual = AnnotationFilter(
+            logger,
+            annotations.values.toSet()
+        ).isApplicableMultiSourceAnnotation(annotation)
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given isApplicableMultiSourceAnnotation is called with a KSAnnotation it returns false if its argument contains not a List of KSType`() {
+        // Given
+        val annotations: Map<String, String> = fixture.mapFixture(size = 3)
+        val logger: KSPLogger = mockk(relaxUnitFun = true)
+
+        val annotation: KSAnnotation = mockk()
+        val argument1: KSValueArgument = mockk()
+        val argument2: KSValueArgument = mockk()
+
+        every {
+            annotation.arguments
+        } returns listOf(argument1, argument2)
+
+        every {
+            argument1.value
+        } returns fixture.fixture<String>()
+
+        every {
+            argument2.value
+        } returns listOf(Any(), Any())
+
+        // When
+        val actual = AnnotationFilter(
+            logger,
+            annotations.values.toSet()
+        ).isApplicableMultiSourceAnnotation(annotation)
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given isApplicableMultiSourceAnnotation is called with a KSAnnotation it returns true if its argument contains an empty List`() {
+        // Given
+        val annotations: Map<String, String> = fixture.mapFixture(size = 3)
+        val logger: KSPLogger = mockk(relaxUnitFun = true)
+
+        val annotation: KSAnnotation = mockk()
+        val argument1: KSValueArgument = mockk()
+        val argument2: KSValueArgument = mockk()
+
+        every {
+            annotation.arguments
+        } returns listOf(argument1, argument2)
+
+        every {
+            argument1.value
+        } returns fixture.fixture<String>()
+
+        every {
+            argument2.value
+        } returns listOf<Any?>()
+
+        // When
+        val actual = AnnotationFilter(
+            logger,
+            annotations.values.toSet()
+        ).isApplicableMultiSourceAnnotation(annotation)
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given isApplicableMultiSourceAnnotation is called with a KSAnnotation it returns true if its argument contains a List of KSType`() {
+        // Given
+        val annotations: Map<String, String> = fixture.mapFixture(size = 3)
+        val logger: KSPLogger = mockk(relaxUnitFun = true)
+
+        val annotation: KSAnnotation = mockk()
+        val argument1: KSValueArgument = mockk()
+        val argument2: KSValueArgument = mockk()
+
+        every {
+            annotation.arguments
+        } returns listOf(argument1, argument2)
+
+        every {
+            argument1.value
+        } returns fixture.fixture<String>()
+
+        every {
+            argument2.value
+        } returns listOf(mockk<KSType>(), mockk<KSType>())
+
+        // When
+        val actual = AnnotationFilter(
+            logger,
+            annotations.values.toSet()
+        ).isApplicableMultiSourceAnnotation(annotation)
 
         // Then
         actual mustBe true

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilterSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/AnnotationFilterSpec.kt
@@ -15,8 +15,11 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_COMMON_MULTI_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_COMMON_NAME
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_PLATFORM_MULTI_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_PLATFORM_NAME
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_SHARED_MULTI_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ANNOTATION_SHARED_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.RELAXATION_NAME
 import tech.antibytes.util.test.fixture.fixture
@@ -84,8 +87,11 @@ class AnnotationFilterSpec {
         // Given
         val annotations: Map<String, String> = mapOf(
             ANNOTATION_PLATFORM_NAME to fixture.fixture(),
-            ANNOTATION_COMMON_NAME to fixture.fixture(),
+            ANNOTATION_PLATFORM_MULTI_NAME to fixture.fixture(),
             ANNOTATION_SHARED_NAME to fixture.fixture(),
+            ANNOTATION_SHARED_MULTI_NAME to fixture.fixture(),
+            ANNOTATION_COMMON_NAME to fixture.fixture(),
+            ANNOTATION_COMMON_MULTI_NAME to fixture.fixture(),
             RELAXATION_NAME to fixture.fixture(),
         )
         val logger: KSPLogger = mockk(relaxUnitFun = true)

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/KSClassDeclarationSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/KSClassDeclarationSpec.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.utils
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.mustBe
+import kotlin.test.assertFailsWith
+
+class KSClassDeclarationSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    fun `Given deriveSimpleName is called it fails if the qualified name is empty`() {
+        // Given
+        val qualified = null
+        val declaration: KSClassDeclaration = mockk()
+
+        every { declaration.qualifiedName?.asString() } returns qualified
+
+        // When
+        val error = assertFailsWith<IllegalStateException> {
+            declaration.deriveSimpleName(fixture.fixture())
+        }
+
+        // Then
+        error.message mustBe "Expected non null class name!"
+    }
+
+    @Test
+    fun `Given deriveSimpleName is called it fails if the package name is not part of the qualified name`() {
+        // Given
+        val qualified: String = fixture.fixture()
+        val declaration: KSClassDeclaration = mockk()
+
+        every { declaration.qualifiedName?.asString() } returns qualified
+
+        // When
+        val error = assertFailsWith<IllegalStateException> {
+            declaration.deriveSimpleName(fixture.fixture())
+        }
+
+        // Then
+        error.message mustBe "Malformed class name!"
+    }
+
+    @Test
+    fun `Given deriveSimpleName is called it fails if the package name is the qualified name`() {
+        // Given
+        val qualified: String = fixture.fixture()
+        val declaration: KSClassDeclaration = mockk()
+
+        every { declaration.qualifiedName?.asString() } returns qualified
+
+        // When
+        val error = assertFailsWith<IllegalStateException> {
+            declaration.deriveSimpleName(qualified)
+        }
+
+        // Then
+        error.message mustBe "Malformed class name!"
+    }
+
+    @Test
+    fun `Given deriveSimpleName is called it returns the derived SimpleName`() {
+        // Given
+        val simpleName: String = fixture.fixture()
+        val packageName: String = fixture.fixture()
+        val declaration: KSClassDeclaration = mockk()
+
+        every { declaration.qualifiedName?.asString() } returns "$packageName.$simpleName"
+
+        // When
+        val actual = declaration.deriveSimpleName(packageName)
+
+        // Then
+        actual mustBe simpleName
+    }
+}

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SourceFilterSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SourceFilterSpec.kt
@@ -37,13 +37,33 @@ class SourceFilterSpec {
         val source0_1: KSClassDeclaration = mockk()
 
         val sources0 = listOf(
-            TemplateSource("", source0_0, null, null),
-            TemplateSource("", source0_1, null, null)
+            TemplateSource(
+                indicator = "",
+                template = source0_0,
+                templateName = fixture.fixture(),
+                generics = null
+            ),
+            TemplateSource(
+                indicator = "",
+                template = source0_1,
+                templateName = fixture.fixture(),
+                generics = null
+            )
         )
 
         val sources1 = listOf(
-            TemplateSource("", source1_0, null, null),
-            TemplateSource("", source1_1, null, null)
+            TemplateSource(
+                indicator = "",
+                template = source1_0,
+                templateName = fixture.fixture(),
+                generics = null
+            ),
+            TemplateSource(
+                indicator = "",
+                template = source1_1,
+                templateName = fixture.fixture(),
+                generics = null
+            )
         )
 
         val sameSource: String = fixture.fixture()
@@ -70,8 +90,18 @@ class SourceFilterSpec {
         val source1: KSClassDeclaration = mockk()
 
         val sources = listOf(
-            TemplateSource(fixture.fixture(), source0, null, null),
-            TemplateSource(fixture.fixture(), source1, null, null)
+            TemplateSource(
+                indicator = fixture.fixture(),
+                template = source0,
+                templateName = fixture.fixture(),
+                generics = null
+            ),
+            TemplateSource(
+                indicator = fixture.fixture(),
+                template = source1,
+                templateName = fixture.fixture(),
+                generics = null
+            )
         )
 
         every { source0.qualifiedName!!.asString() } returns fixture.fixture()
@@ -95,8 +125,18 @@ class SourceFilterSpec {
         val marker1: String = fixture.fixture()
 
         val sources = listOf(
-            TemplateSource(marker0, source0, null, null),
-            TemplateSource(marker1, source1, null, null)
+            TemplateSource(
+                indicator = marker0,
+                template = source0,
+                templateName = fixture.fixture(),
+                generics = null
+            ),
+            TemplateSource(
+                indicator = marker1,
+                template = source0,
+                templateName = fixture.fixture(),
+                generics = null
+            )
         )
 
         val interfaceName: String = fixture.fixture()
@@ -124,9 +164,24 @@ class SourceFilterSpec {
         val marker2: String = fixture.fixture()
 
         val sources = listOf(
-            TemplateSource(marker0, source0, null, null),
-            TemplateSource(marker1, source1, null, null),
-            TemplateSource(marker2, source2, null, null),
+            TemplateSource(
+                indicator = marker0,
+                template = source0,
+                templateName = fixture.fixture(),
+                generics = null
+            ),
+            TemplateSource(
+                indicator = marker1,
+                template = source1,
+                templateName = fixture.fixture(),
+                generics = null
+            ),
+            TemplateSource(
+                indicator = marker2,
+                template = source2,
+                templateName = fixture.fixture(),
+                generics = null
+            )
         )
 
         val interfaceName: String = fixture.fixture()

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SourceFilterSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SourceFilterSpec.kt
@@ -8,7 +8,6 @@ package tech.antibytes.kmock.processor.utils
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
@@ -33,20 +32,28 @@ class SourceFilterSpec {
         val source0_0: KSClassDeclaration = mockk()
         val source1_1: KSClassDeclaration = mockk()
 
+        val packageName0: String = fixture.fixture()
+        val interfaceName0: String = fixture.fixture()
+
         val source1_0: KSClassDeclaration = mockk()
         val source0_1: KSClassDeclaration = mockk()
+
+        val packageName1: String = fixture.fixture()
+        val interfaceName1: String = fixture.fixture()
 
         val sources0 = listOf(
             TemplateSource(
                 indicator = "",
                 template = source0_0,
-                templateName = fixture.fixture(),
+                templateName = packageName0,
+                packageName = interfaceName0,
                 generics = null
             ),
             TemplateSource(
                 indicator = "",
                 template = source0_1,
-                templateName = fixture.fixture(),
+                templateName = packageName0,
+                packageName = interfaceName1,
                 generics = null
             )
         )
@@ -55,24 +62,18 @@ class SourceFilterSpec {
             TemplateSource(
                 indicator = "",
                 template = source1_0,
-                templateName = fixture.fixture(),
+                templateName = packageName1,
+                packageName = interfaceName0,
                 generics = null
             ),
             TemplateSource(
                 indicator = "",
                 template = source1_1,
-                templateName = fixture.fixture(),
+                templateName = packageName0,
+                packageName = interfaceName1,
                 generics = null
             )
         )
-
-        val sameSource: String = fixture.fixture()
-
-        every { source0_0.qualifiedName!!.asString() } returns fixture.fixture()
-        every { source0_1.qualifiedName!!.asString() } returns sameSource
-
-        every { source1_0.qualifiedName!!.asString() } returns fixture.fixture()
-        every { source1_1.qualifiedName!!.asString() } returns sameSource
 
         // When
         val actual = SourceFilter(emptyMap(), mockk()).filter(sources0, sources1)
@@ -94,18 +95,17 @@ class SourceFilterSpec {
                 indicator = fixture.fixture(),
                 template = source0,
                 templateName = fixture.fixture(),
+                packageName = fixture.fixture(),
                 generics = null
             ),
             TemplateSource(
                 indicator = fixture.fixture(),
                 template = source1,
                 templateName = fixture.fixture(),
+                packageName = fixture.fixture(),
                 generics = null
             )
         )
-
-        every { source0.qualifiedName!!.asString() } returns fixture.fixture()
-        every { source1.qualifiedName!!.asString() } returns fixture.fixture()
 
         // When
         val actual = SourceFilter(emptyMap(), mockk()).filterSharedSources(sources)
@@ -121,6 +121,9 @@ class SourceFilterSpec {
         val source0: KSClassDeclaration = mockk()
         val source1: KSClassDeclaration = mockk()
 
+        val packageName: String = fixture.fixture()
+        val interfaceName: String = fixture.fixture()
+
         val marker0: String = fixture.fixture()
         val marker1: String = fixture.fixture()
 
@@ -128,21 +131,18 @@ class SourceFilterSpec {
             TemplateSource(
                 indicator = marker0,
                 template = source0,
-                templateName = fixture.fixture(),
+                templateName = interfaceName,
+                packageName = packageName,
                 generics = null
             ),
             TemplateSource(
                 indicator = marker1,
-                template = source0,
-                templateName = fixture.fixture(),
+                template = source1,
+                templateName = interfaceName,
+                packageName = packageName,
                 generics = null
             )
         )
-
-        val interfaceName: String = fixture.fixture()
-
-        every { source0.qualifiedName!!.asString() } returns interfaceName
-        every { source1.qualifiedName!!.asString() } returns interfaceName
 
         // When
         SourceFilter(emptyMap(), logger).filterSharedSources(sources)
@@ -163,38 +163,38 @@ class SourceFilterSpec {
         val marker1: String = fixture.fixture()
         val marker2: String = fixture.fixture()
 
+        val packageName: String = fixture.fixture()
+        val interfaceName: String = fixture.fixture()
+
         val sources = listOf(
             TemplateSource(
                 indicator = marker0,
                 template = source0,
-                templateName = fixture.fixture(),
+                templateName = interfaceName,
+                packageName = packageName,
                 generics = null
             ),
             TemplateSource(
                 indicator = marker1,
                 template = source1,
-                templateName = fixture.fixture(),
+                templateName = interfaceName,
+                packageName = packageName,
                 generics = null
             ),
             TemplateSource(
                 indicator = marker2,
                 template = source2,
-                templateName = fixture.fixture(),
+                templateName = interfaceName,
+                packageName = packageName,
                 generics = null
             )
         )
-
-        val interfaceName: String = fixture.fixture()
 
         val precedences = mapOf(
             marker0 to 1,
             marker1 to 2,
             marker2 to 0,
         )
-
-        every { source0.qualifiedName!!.asString() } returns interfaceName
-        every { source1.qualifiedName!!.asString() } returns interfaceName
-        every { source2.qualifiedName!!.asString() } returns interfaceName
 
         // When
         val actual = SourceFilter(precedences, mockk()).filterSharedSources(sources)

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SourceSetValidatorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SourceSetValidatorSpec.kt
@@ -34,12 +34,16 @@ class SourceSetValidatorSpec {
     fun `Given isValidateSourceSet with a non string it returns false`() {
         // Given
         val any: Any = fixture.fixture()
+        val logger: KSPLogger = mockk()
+
+        every { logger.warn(any()) } just Runs
 
         // When
-        val actual = SourceSetValidator(mockk(), mockk()).isValidateSourceSet(any)
+        val actual = SourceSetValidator(logger, mockk()).isValidateSourceSet(any)
 
         // Then
         actual mustBe false
+        verify(exactly = 1) { logger.warn("Unexpected annotation payload!") }
     }
 
     @Test
@@ -102,8 +106,8 @@ class SourceSetValidatorSpec {
         // Then
         actual mustBe false
 
-        verify(exactly = 0) {
-            logger.warn(any())
+        verify(exactly = 1) {
+            logger.warn("Unexpected annotation payload!")
         }
     }
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/StringExtensionsSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/StringExtensionsSpec.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.utils
+
+import org.junit.jupiter.api.Test
+import tech.antibytes.util.test.mustBe
+import kotlin.test.assertFailsWith
+
+class StringExtensionsSpec {
+    @Test
+    fun `Given titleCase is called it does nothing if the String starts with an uppercase character`() {
+        // Given
+        val string = "Potato"
+
+        // When
+        val actual = string.titleCase()
+
+        // Then
+        actual mustBe string
+    }
+
+    @Test
+    fun `Given titleCase is called it uppercases the first character if the String starts not with an uppercase character`() {
+        // Given
+        val string = "potato"
+
+        // When
+        val actual = string.titleCase()
+
+        // Then
+        actual mustBe "Potato"
+    }
+
+    @Test
+    fun `Given ensureNotNullClassName is called it does nothing if the string is not null`() {
+        // Given
+        val string = "Potato"
+
+        // When
+        val actual = ensureNotNullClassName(string)
+
+        // Then
+        actual mustBe string
+    }
+
+    @Test
+    fun `Given ensureNotNullClassName is called it fails if the string is null`() {
+        // Given
+        val string = null
+
+        // When
+        val error = assertFailsWith<IllegalStateException> {
+            ensureNotNullClassName(string)
+        }
+
+        // Then
+        error.message mustBe "Expected non null class name!"
+    }
+}

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/Alias.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/Alias.kt
@@ -2,6 +2,7 @@
 
 package generatorTest
 
+import factory.template.interfaze.Contract
 import factory.template.interfaze.Platform1
 import kotlin.Any
 import kotlin.Boolean
@@ -30,6 +31,12 @@ private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
     factory.template.interfaze.Platform3Mock::class ->
         factory.template.interfaze.Platform3Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
             freeze = freeze, spyOn = spyOn as factory.template.interfaze.Platform3?) as Mock
+    factory.template.interfaze.Contract.Platform4::class ->
+        factory.template.interfaze.Platform4Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
+            freeze = freeze, spyOn = spyOn as factory.template.interfaze.Contract.Platform4?) as Mock
+    factory.template.interfaze.Platform4Mock::class ->
+        factory.template.interfaze.Platform4Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
+            freeze = freeze, spyOn = spyOn as factory.template.interfaze.Contract.Platform4?) as Mock
     else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
 }
 
@@ -97,6 +104,55 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : 
     verifier: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
     templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+): Mock where L : Any, L : Comparable<L> = getMockInstance(
+    spyOn = spyOn,
+    verifier = verifier,
+    relaxed = false,
+    relaxUnitFun = false,
+    freeze = freeze,
+    templateType = templateType,
+)
+
+private inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, L>, K : Any, L>
+    getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
+    factory.template.interfaze.Contract.Platform5::class ->
+        factory.template.interfaze.Platform5Mock<K, L>(verifier = verifier, relaxUnitFun =
+        relaxUnitFun, freeze = freeze, spyOn = spyOn as
+            factory.template.interfaze.Contract.Platform5<K, L>?) as Mock
+    factory.template.interfaze.Platform5Mock::class -> factory.template.interfaze.Platform5Mock<K,
+        L>(verifier = verifier, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
+        factory.template.interfaze.Contract.Platform5<K, L>?) as Mock
+    else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
+}
+
+internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
+    verifier: KMockContract.Collector = NoopCollector,
+    relaxed: Boolean = false,
+    relaxUnitFun: Boolean = false,
+    freeze: Boolean = true,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+): Mock where L : Any, L : Comparable<L> = getMockInstance(
+    spyOn = null,
+    verifier = verifier,
+    relaxed = relaxed,
+    relaxUnitFun = relaxUnitFun,
+    freeze = freeze,
+    templateType = templateType,
+)
+
+internal inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, L>, K : Any, L>
+    kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector = NoopCollector,
+    freeze: Boolean = true,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     verifier = verifier,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/NoSpy.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/NoSpy.kt
@@ -2,6 +2,7 @@
 
 package generatorTest
 
+import factory.template.interfaze.Contract
 import factory.template.interfaze.Platform1
 import kotlin.Any
 import kotlin.Boolean
@@ -30,6 +31,12 @@ private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
     factory.template.interfaze.Platform3Mock::class ->
         factory.template.interfaze.Platform3Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
             freeze = freeze, spyOn = spyOn as factory.template.interfaze.Platform3?) as Mock
+    factory.template.interfaze.Contract.Platform4::class ->
+        factory.template.interfaze.Platform4Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
+            freeze = freeze, spyOn = spyOn as factory.template.interfaze.Contract.Platform4?) as Mock
+    factory.template.interfaze.Platform4Mock::class ->
+        factory.template.interfaze.Platform4Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
+            freeze = freeze, spyOn = spyOn as factory.template.interfaze.Contract.Platform4?) as Mock
     else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
 }
 
@@ -70,6 +77,40 @@ internal inline fun <reified Mock : Platform1<K, L>, K : Any, L> kmock(
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
     templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+): Mock where L : Any, L : Comparable<L> = getMockInstance(
+    spyOn = null,
+    verifier = verifier,
+    relaxed = relaxed,
+    relaxUnitFun = relaxUnitFun,
+    freeze = freeze,
+    templateType = templateType,
+)
+
+private inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, L>, K : Any, L>
+    getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
+    factory.template.interfaze.Contract.Platform5::class ->
+        factory.template.interfaze.Platform5Mock<K, L>(verifier = verifier, relaxUnitFun =
+        relaxUnitFun, freeze = freeze, spyOn = spyOn as
+            factory.template.interfaze.Contract.Platform5<K, L>?) as Mock
+    factory.template.interfaze.Platform5Mock::class -> factory.template.interfaze.Platform5Mock<K,
+        L>(verifier = verifier, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
+        factory.template.interfaze.Contract.Platform5<K, L>?) as Mock
+    else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
+}
+
+internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
+    verifier: KMockContract.Collector = NoopCollector,
+    relaxed: Boolean = false,
+    relaxUnitFun: Boolean = false,
+    freeze: Boolean = true,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     verifier = verifier,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/Platform.kt
@@ -2,6 +2,7 @@
 
 package generatorTest
 
+import factory.template.interfaze.Contract
 import factory.template.interfaze.Platform1
 import kotlin.Any
 import kotlin.Boolean
@@ -30,6 +31,12 @@ private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
     factory.template.interfaze.Platform3Mock::class ->
         factory.template.interfaze.Platform3Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
             freeze = freeze, spyOn = spyOn as factory.template.interfaze.Platform3?) as Mock
+    factory.template.interfaze.Contract.Platform4::class ->
+        factory.template.interfaze.Platform4Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
+            freeze = freeze, spyOn = spyOn as factory.template.interfaze.Contract.Platform4?) as Mock
+    factory.template.interfaze.Platform4Mock::class ->
+        factory.template.interfaze.Platform4Mock(verifier = verifier, relaxUnitFun = relaxUnitFun,
+            freeze = freeze, spyOn = spyOn as factory.template.interfaze.Contract.Platform4?) as Mock
     else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
 }
 
@@ -96,6 +103,55 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : 
     verifier: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
     templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+): Mock where L : Any, L : Comparable<L> = getMockInstance(
+    spyOn = spyOn,
+    verifier = verifier,
+    relaxed = false,
+    relaxUnitFun = false,
+    freeze = freeze,
+    templateType = templateType,
+)
+
+private inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, L>, K : Any, L>
+    getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
+    factory.template.interfaze.Contract.Platform5::class ->
+        factory.template.interfaze.Platform5Mock<K, L>(verifier = verifier, relaxUnitFun =
+        relaxUnitFun, freeze = freeze, spyOn = spyOn as
+            factory.template.interfaze.Contract.Platform5<K, L>?) as Mock
+    factory.template.interfaze.Platform5Mock::class -> factory.template.interfaze.Platform5Mock<K,
+        L>(verifier = verifier, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
+        factory.template.interfaze.Contract.Platform5<K, L>?) as Mock
+    else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
+}
+
+internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
+    verifier: KMockContract.Collector = NoopCollector,
+    relaxed: Boolean = false,
+    relaxUnitFun: Boolean = false,
+    freeze: Boolean = true,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+): Mock where L : Any, L : Comparable<L> = getMockInstance(
+    spyOn = null,
+    verifier = verifier,
+    relaxed = relaxed,
+    relaxUnitFun = relaxUnitFun,
+    freeze = freeze,
+    templateType = templateType,
+)
+
+internal inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, L>, K : Any, L>
+    kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector = NoopCollector,
+    freeze: Boolean = true,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     verifier = verifier,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/SharedActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/SharedActual.kt
@@ -2,6 +2,7 @@
 
 package generatorTest
 
+import factory.template.interfaze.Shared
 import factory.template.interfaze.Shared1
 import kotlin.Any
 import kotlin.Boolean
@@ -20,6 +21,9 @@ private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
     factory.template.interfaze.Shared2Mock::class -> factory.template.interfaze.Shared2Mock(verifier =
     verifier, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
         factory.template.interfaze.Shared2?) as Mock
+    factory.template.interfaze.Shared3Mock::class -> factory.template.interfaze.Shared3Mock(verifier =
+    verifier, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
+        factory.template.interfaze.Shared.Shared3?) as Mock
     else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
 }
 
@@ -83,6 +87,51 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>,
     verifier: KMockContract.Collector,
     freeze: Boolean,
     templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared1<*, *>>,
+): Mock where L : Any, L : Comparable<L> = getMockInstance(
+    spyOn = spyOn,
+    verifier = verifier,
+    relaxed = false,
+    relaxUnitFun = false,
+    freeze = freeze,
+    templateType = templateType,
+)
+
+private inline fun <reified Mock : SpyOn, reified SpyOn : Shared.Shared4<K, L>, K : Any, L>
+    getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
+): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
+    factory.template.interfaze.Shared4Mock::class -> factory.template.interfaze.Shared4Mock<K,
+        L>(verifier = verifier, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
+        factory.template.interfaze.Shared.Shared4<K, L>?) as Mock
+    else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
+}
+
+internal actual inline fun <reified Mock : Shared.Shared4<K, L>, K : Any, L> kmock(
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
+): Mock where L : Any, L : Comparable<L> = getMockInstance(
+    spyOn = null,
+    verifier = verifier,
+    relaxed = relaxed,
+    relaxUnitFun = relaxUnitFun,
+    freeze = freeze,
+    templateType = templateType,
+)
+
+internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Shared.Shared4<K, L>, K : Any, L>
+    kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector,
+    freeze: Boolean,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     verifier = verifier,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/SharedExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/SharedExpect.kt
@@ -2,6 +2,7 @@
 
 package generatorTest
 
+import factory.template.interfaze.Shared
 import factory.template.interfaze.Shared1
 import kotlin.Any
 import kotlin.Boolean
@@ -24,4 +25,20 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>,
     verifier: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
     templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared1<*, *>>,
+): Mock where L : Any, L : Comparable<L>
+
+internal expect inline fun <reified Mock : Shared.Shared4<K, L>, K : Any, L> kmock(
+    verifier: KMockContract.Collector = NoopCollector,
+    relaxed: Boolean = false,
+    relaxUnitFun: Boolean = false,
+    freeze: Boolean = true,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
+): Mock where L : Any, L : Comparable<L>
+
+internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Shared.Shared4<K, L>, K : Any, L>
+    kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector = NoopCollector,
+    freeze: Boolean = true,
+    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/template/interfaze/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/template/interfaze/Platform.kt
@@ -14,6 +14,8 @@ interface SomeGeneric<T>
     Platform1::class,
     Platform2::class,
     Platform3::class,
+    Contract.Platform4::class,
+    Contract.Platform5::class,
 )
 interface Platform1<K, L> where L : Any, L : Comparable<L>, K : Any {
     var template: L
@@ -85,4 +87,16 @@ interface Platform2 {
 interface Platform3 {
     var template: Int
     fun abc()
+}
+
+interface Contract {
+    interface Platform4 {
+        var template: Int
+        fun abc()
+        fun <R, T> iss(arg0: T, arg1: R) where R : SomeGeneric<String>, R : Comparable<List<Array<T>>>
+    }
+
+    interface Platform5<K, L> where L : Any, L : Comparable<L>, K : Any {
+        fun kiss(arg0: K, arg1: L)
+    }
 }

--- a/kmock-processor/src/test/resources/factory/template/interfaze/Shared.kt
+++ b/kmock-processor/src/test/resources/factory/template/interfaze/Shared.kt
@@ -13,7 +13,9 @@ interface SomeGeneric<T>
 @MockShared(
     "sharedTest",
     Shared1::class,
-    Shared2::class
+    Shared2::class,
+    Shared.Shared3::class,
+    Shared.Shared4::class,
 )
 interface Shared1<K, L> where L : Any, L : Comparable<L>, K : Any {
     var template: L
@@ -79,4 +81,16 @@ interface Shared1<K, L> where L : Any, L : Comparable<L>, K : Any {
 interface Shared2 {
     var template: Int
     fun abc()
+}
+
+interface Shared {
+    interface Shared3 {
+        var template: Int
+        fun abc()
+        fun <R, T> iss(arg0: T, arg1: R) where R : SomeGeneric<String>, R : Comparable<List<Array<T>>>
+    }
+
+    interface Shared4<K, L> where L : Any, L : Comparable<L>, K : Any {
+        fun kiss(arg0: K, arg1: L)
+    }
 }

--- a/kmock-processor/src/test/resources/multi/expected/common/RegularActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/common/RegularActualFactory.kt
@@ -1,0 +1,33 @@
+@file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+
+package multi
+
+import kotlin.Boolean
+import kotlin.Suppress
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+
+private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+): Mock = when (Mock::class) {
+    multi.CommonMultiMock::class -> multi.CommonMultiMock<multi.CommonMultiMock<*>>(verifier =
+    verifier, relaxUnitFun = relaxUnitFun, freeze = freeze) as Mock
+    else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
+}
+
+internal actual inline fun <reified Mock> kmock(
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+): Mock = getMockInstance(
+    spyOn = null,
+    verifier = verifier,
+    relaxed = relaxed,
+    relaxUnitFun = relaxUnitFun,
+    freeze = freeze,
+)

--- a/kmock-processor/src/test/resources/multi/expected/common/RegularInterface.kt
+++ b/kmock-processor/src/test/resources/multi/expected/common/RegularInterface.kt
@@ -1,0 +1,9 @@
+package multi
+
+import multi.template.common.CommonContractRegular
+import multi.template.common.Regular1
+import multi.template.common.nested.Regular3
+import tech.antibytes.kmock.MockCommon
+
+@MockCommon(CommonMulti::class)
+public interface CommonMulti : Regular1, CommonContractRegular.Regular2, Regular3

--- a/kmock-processor/src/test/resources/multi/expected/common/RegularInterface.kt
+++ b/kmock-processor/src/test/resources/multi/expected/common/RegularInterface.kt
@@ -6,4 +6,4 @@ import multi.template.common.nested.Regular3
 import tech.antibytes.kmock.MockCommon
 
 @MockCommon(CommonMulti::class)
-public interface CommonMulti : Regular1, CommonContractRegular.Regular2, Regular3
+private interface CommonMulti : Regular1, CommonContractRegular.Regular2, Regular3

--- a/kmock-processor/src/test/resources/multi/expected/common/RegularMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/common/RegularMock.kt
@@ -1,0 +1,75 @@
+package multi
+
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import multi.template.common.CommonContractRegular
+import multi.template.common.Regular1
+import multi.template.common.nested.Regular3
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+import tech.antibytes.kmock.proxy.ProxyFactory
+
+internal class CommonMultiMock<MultiMock>(
+    verifier: KMockContract.Collector = NoopCollector,
+    @Suppress("UNUSED_PARAMETER")
+    spyOn: MultiMock? = null,
+    freeze: Boolean = true,
+    @Suppress("unused")
+    private val relaxUnitFun: Boolean = false,
+    @Suppress("unused")
+    private val relaxed: Boolean = false,
+) : Regular1, CommonContractRegular.Regular2, Regular3 where MultiMock : Regular1, MultiMock :
+CommonContractRegular.Regular2, MultiMock : Regular3 {
+    public override val something: Int
+        get() = _something.onGet()
+
+    public val _something: KMockContract.PropertyProxy<Int> =
+        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_something", collector = verifier,
+            freeze = freeze)
+
+    public override val anything: Any
+        get() = _anything.onGet()
+
+    public val _anything: KMockContract.PropertyProxy<Any> =
+        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_anything", collector = verifier,
+            freeze = freeze)
+
+    public override val somethingElse: String
+        get() = _somethingElse.onGet()
+
+    public val _somethingElse: KMockContract.PropertyProxy<String> =
+        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_somethingElse", collector = verifier,
+            freeze = freeze)
+
+    public val _doSomething: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doSomething", collector = verifier,
+            freeze = freeze)
+
+    public val _doAnything: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doAnything", collector = verifier,
+            freeze = freeze)
+
+    public val _doSomethingElse: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
+        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doSomethingElse", collector =
+        verifier, freeze = freeze)
+
+    public override fun doSomething(): Int = _doSomething.invoke()
+
+    public override fun doAnything(): Any = _doAnything.invoke()
+
+    public override fun doSomethingElse(): String = _doSomethingElse.invoke()
+
+    public fun _clearMock(): Unit {
+        _something.clear()
+        _anything.clear()
+        _somethingElse.clear()
+        _doSomething.clear()
+        _doAnything.clear()
+        _doSomethingElse.clear()
+    }
+}

--- a/kmock-processor/src/test/resources/multi/template/common/Regular1.kt
+++ b/kmock-processor/src/test/resources/multi/template/common/Regular1.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package multi.template.common
+
+import multi.template.common.nested.Regular3
+import tech.antibytes.kmock.MultiMockCommon
+
+@MultiMockCommon(
+    "CommonMulti",
+    Regular1::class,
+    CommonContractRegular.Regular2::class,
+    Regular3::class,
+)
+interface Regular1 {
+    val something: Int
+
+    fun doSomething(): Int
+}

--- a/kmock-processor/src/test/resources/multi/template/common/Regular2.kt
+++ b/kmock-processor/src/test/resources/multi/template/common/Regular2.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package multi.template.common
+
+interface CommonContractRegular {
+    interface Regular2 {
+        val anything: Any
+
+        fun doAnything(): Any
+    }
+}

--- a/kmock-processor/src/test/resources/multi/template/common/nested/Regular3.kt
+++ b/kmock-processor/src/test/resources/multi/template/common/nested/Regular3.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package multi.template.common.nested
+
+import tech.antibytes.kmock.MultiMockCommon
+
+interface Regular3 {
+    val somethingElse: String
+
+    fun doSomethingElse(): String
+}

--- a/kmock/src/commonMain/kotlin/tech/antibytes/kmock/Annotation.kt
+++ b/kmock/src/commonMain/kotlin/tech/antibytes/kmock/Annotation.kt
@@ -20,6 +20,24 @@ import kotlin.reflect.KClass
  */
 annotation class Mock(vararg val interfaces: KClass<*>)
 
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+@MustBeDocumented
+/**
+ * Determines which interfaces should be stubbed/mocked as a union of them.
+ *
+ * @param name name which used for the mock.
+ * @param interfaces variable amount of interfaces.
+ * @property interfaces which will be propagated to the (KSP) processor.
+ * @property name name which will be propagated to the (KSP) processor.
+ * @author Matthias Geisler
+ */
+annotation class MultiMock(
+    val name: String,
+    vararg val interfaces: KClass<*>
+)
+
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
@@ -31,6 +49,24 @@ annotation class Mock(vararg val interfaces: KClass<*>)
  * @author Matthias Geisler
  */
 annotation class MockCommon(vararg val interfaces: KClass<*>)
+
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+@MustBeDocumented
+/**
+ * Determines which interfaces should be stubbed/mocked as a union of them for CommonCode.
+ *
+ * @param name name which used for the mock.
+ * @param interfaces variable amount of interfaces.
+ * @property name name which will be propagated to the (KSP) processor.
+ * @property interfaces which will be propagated to the (KSP) processor.
+ * @author Matthias Geisler
+ */
+annotation class MultiMockCommon(
+    val name: String,
+    vararg val interfaces: KClass<*>
+)
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
@@ -45,6 +81,27 @@ annotation class MockCommon(vararg val interfaces: KClass<*>)
  * @author Matthias Geisler
  */
 annotation class MockShared(val sourceSetName: String, vararg val interfaces: KClass<*>)
+
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+@MustBeDocumented
+/**
+ * Determines which interfaces should be stubbed/mocked as a union of them for CommonCode.
+ *
+ * @param sourceSetName to bind the given interface to a sourceSet (e.g. nativeTest).
+ * @param name name which used for the mock.
+ * @param interfaces variable amount of interfaces.
+ * @property sourceSetName which will be propagated to the (KSP) processor.
+ * @property name name which will be propagated to the (KSP) processor.
+ * @property interfaces which will be propagated to the (KSP) processor.
+ * @author Matthias Geisler
+ */
+annotation class MultiMockShared(
+    val sourceSetName: String,
+    val name: String,
+    vararg val interfaces: KClass<*>
+)
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FUNCTION)

--- a/kmock/src/commonTest/kotlin/tech/antibytes/kmock/verification/VerificationChainSpec.kt
+++ b/kmock/src/commonTest/kotlin/tech/antibytes/kmock/verification/VerificationChainSpec.kt
@@ -889,9 +889,6 @@ class VerificationChainSpec {
             }
         }
 
-        println(expectedValue1)
-        println(expectedValue2)
-
         val chain = VerificationChain(references)
 
         // When


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #102

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This makes the 2nd step to multi-interface support. It refactors the Aggregator in order to separate between single and multi interface Mocks and rewires the processor. Also the Generators had been adjusted to support those kinds of mocks.
The support however is for this PR restricted to `kmock` and Common as source set, while the runtime library already has all needed Annotations in place.
The mental model takes advantages of the multi-round processing of KSP (see the integration test).
The first round will generate single sourced mocks and the factories (including those for multi-source interfaces). Additionally this round will generate intermediate artifacts (`KMockMultiInterfaceArtifacts`) which simply are the combined interfaces.
Round 2 will pick up the intermediate artifacts and generate from them the actual mocks.
This is done to avoid problems which the compiler can solve for us (like resolving which methods can be merged and which has do be overloaded).

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [ ] My changes are reflected in the changelog.
