### PR TITLE
Change kspy generation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,7 +31,7 @@ toc::[]
 
 * `or` ArgumentConstraint
 * `not` ArgumentConstraint
-* `spiesOnly` in the Gradle extension, in order to tell the processor to only create `kspy`, while adding all known mocks
+* `spiesOnly` in the Gradle extension, in order to tell the processor to only create `kspy`. Also `spyOn` is not needed in this configuration
 * `vararg` is now supported by Mocks
 * `freezeOnDefault` in the Gradle extension, which sets a default freeze value for `kspy` and `kmock`
 * `enableNewOverloadingNames` and `useTypePrefixFor` for overloaded names in order to ease them
@@ -54,6 +54,8 @@ toc::[]
 * Expectation-methods do not bleed into the global context any longer
 * `verifyStrictOrder` is now used for total order of certain Proxies but allows partial order between different Proxies
 * Android MinSDK 23 -> 21
+* `spyOn` is now capable of picking up KMock defined Aliases
+* `kspy` in terms of generics not longer exposed if not declared via `spyOn` or `spiesOnly`
 
 === Deprecated
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -36,11 +36,13 @@ import tech.antibytes.kmock.processor.multi.KMockParentFinder
 import tech.antibytes.kmock.processor.utils.AnnotationFilter
 import tech.antibytes.kmock.processor.utils.SourceFilter
 import tech.antibytes.kmock.processor.utils.SourceSetValidator
+import tech.antibytes.kmock.processor.utils.SpyContainer
 
 class KMockProcessorProvider : SymbolProcessorProvider {
     private fun determineFactoryGenerator(
         options: Options,
         logger: KSPLogger,
+        spyContainer: SpyContainer,
         codeGenerator: KmpCodeGenerator
     ): Pair<MockFactoryGenerator, MockFactoryEntryPointGenerator> {
         return if (options.disableFactories) {
@@ -63,11 +65,12 @@ class KMockProcessorProvider : SymbolProcessorProvider {
                     ),
                     genericGenerator = KMockFactoryWithGenerics(
                         isKmp = options.isKmp,
+                        spyContainer = spyContainer,
                         allowInterfaces = options.allowInterfaces,
                         utils = factoryUtils,
                         genericResolver = KMockGenerics,
                     ),
-                    spyOn = options.spyOn,
+                    spyContainer = spyContainer,
                     spiesOnly = options.spiesOnly,
                     utils = factoryUtils,
                     codeGenerator = codeGenerator,
@@ -76,7 +79,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
                     isKmp = options.isKmp,
                     rootPackage = options.rootPackage,
                     utils = factoryUtils,
-                    spyOn = options.spyOn,
+                    spyContainer = spyContainer,
                     spiesOnly = options.spiesOnly,
                     genericResolver = KMockGenerics,
                     codeGenerator = codeGenerator,
@@ -89,6 +92,11 @@ class KMockProcessorProvider : SymbolProcessorProvider {
         val logger = environment.logger
 
         val options = KMockOptionExtractor.convertOptions(environment.options)
+
+        val spyContainer = SpyContainer(
+            spiesOnly = options.spiesOnly,
+            spyOn = options.spyOn
+        )
 
         val codeGenerator = KMockCodeGenerator(
             kspDir = options.kspDir,
@@ -135,7 +143,8 @@ class KMockProcessorProvider : SymbolProcessorProvider {
         val (factoryGenerator, entryPointGenerator) = determineFactoryGenerator(
             options = options,
             logger = logger,
-            codeGenerator = codeGenerator
+            spyContainer = spyContainer,
+            codeGenerator = codeGenerator,
         )
 
         return KMockProcessor(
@@ -149,7 +158,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
             ),
             mockGenerator = KMockGenerator(
                 logger = logger,
-                spyOn = options.spyOn,
+                spyContainer = spyContainer,
                 useBuildInProxiesOn = options.useBuildInProxiesOn,
                 codeGenerator = codeGenerator,
                 genericsResolver = KMockGenerics,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -67,6 +67,15 @@ internal interface ProcessorContract {
         fun convertOptions(kspRawOptions: Map<String, String>): Options
     }
 
+    interface SpyContainer {
+        fun isSpyable(
+            template: KSClassDeclaration?,
+            packageName: String,
+            templateName: String
+        ): Boolean
+        fun hasSpies(): Boolean
+    }
+
     sealed interface Source {
         val indicator: String
         val templateName: String
@@ -399,7 +408,7 @@ internal interface ProcessorContract {
 
     data class FactoryBundle(
         val kmock: FunSpec,
-        val kspy: FunSpec,
+        val kspy: FunSpec?,
         val shared: FunSpec
     )
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
@@ -20,22 +20,21 @@ import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithGenerics
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithoutGenerics
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
+import tech.antibytes.kmock.processor.ProcessorContract.SpyContainer
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 
 internal class KMockFactoryGenerator(
     private val logger: KSPLogger,
-    spyOn: Set<String>,
     private val rootPackage: String,
     private val isKmp: Boolean,
+    private val spyContainer: SpyContainer,
     private val spiesOnly: Boolean,
     private val nonGenericGenerator: MockFactoryWithoutGenerics,
     private val genericGenerator: MockFactoryWithGenerics,
     private val utils: MockFactoryGeneratorUtil,
     private val codeGenerator: CodeGenerator,
 ) : MockFactoryGenerator {
-    private val hasSpies = spyOn.isNotEmpty() || spiesOnly
-
     private fun writeFactoryImplementation(
         templateSources: List<TemplateSource>,
         templateMultiSources: List<TemplateMultiSource>,
@@ -74,7 +73,7 @@ internal class KMockFactoryGenerator(
             )
         }
 
-        if (hasSpies) {
+        if (spyContainer.hasSpies()) {
             file.addFunction(
                 nonGenericGenerator.buildSpyFactory()
             )
@@ -88,7 +87,7 @@ internal class KMockFactoryGenerator(
                 file.addFunction(factories.kmock)
             }
 
-            if (hasSpies) {
+            if (factories.kspy != null) {
                 file.addFunction(factories.kspy)
             }
         }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
@@ -17,11 +17,13 @@ import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithGenerics
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
+import tech.antibytes.kmock.processor.ProcessorContract.SpyContainer
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.kmock.processor.utils.ensureNotNullClassName
 
 internal class KMockFactoryWithGenerics(
     private val isKmp: Boolean,
+    private val spyContainer: SpyContainer,
     private val allowInterfaces: Boolean,
     private val utils: MockFactoryGeneratorUtil,
     private val genericResolver: GenericResolver,
@@ -234,6 +236,16 @@ internal class KMockFactoryWithGenerics(
         ).build()
     }
 
+    private fun resolveKSpyFactory(
+        source: TemplateSource
+    ): FunSpec? {
+        return if (spyContainer.isSpyable(source.template, source.packageName, source.templateName)) {
+            buildGenericSpyFactory(source)
+        } else {
+            null
+        }
+    }
+
     override fun buildGenericFactories(
         templateSources: List<TemplateSource>,
         relaxer: Relaxer?
@@ -242,7 +254,9 @@ internal class KMockFactoryWithGenerics(
 
         templateSources.forEach { source ->
             val kmock = buildGenericMockFactory(source)
-            val kspy = buildGenericSpyFactory(source)
+
+            val kspy = resolveKSpyFactory(source)
+
             val shared = buildGenericSharedMockFactory(
                 templateSource = source,
                 relaxer = relaxer

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SpyContainer.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SpyContainer.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.utils
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import tech.antibytes.kmock.processor.ProcessorContract
+
+internal class SpyContainer(
+    private val spiesOnly: Boolean,
+    private val spyOn: Set<String>,
+) : ProcessorContract.SpyContainer {
+    override fun isSpyable(
+        template: KSClassDeclaration?,
+        packageName: String,
+        templateName: String
+    ): Boolean {
+        return template?.qualifiedName?.asString() in spyOn ||
+            "$packageName.$templateName" in spyOn ||
+            spiesOnly
+    }
+
+    override fun hasSpies(): Boolean = spyOn.isNotEmpty() || spiesOnly
+}

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
@@ -533,7 +533,7 @@ class KMockFactoriesSpec {
             provider,
             isKmp = false,
             kspArguments = mapOf(
-                "${KMOCK_PREFIX}spyOn_0" to "factory.template.interfaze.Platform1",
+                "${KMOCK_PREFIX}spyOn_0" to "factory.template.interfaze.AliasPlatform",
                 "${KMOCK_PREFIX}spyOn_1" to "factory.template.interfaze.Platform2",
                 "${KMOCK_PREFIX}alias_factory.template.interfaze.Platform1" to "AliasPlatform",
                 "${KMOCK_PREFIX}allowInterfaces" to "true",
@@ -571,6 +571,9 @@ class KMockFactoriesSpec {
         )
         val actualActual = resolveGenerated("ksp/sources/kotlin/$rootPackage/MockFactory.kt")
         val actualExpect = resolveGenerated("kotlin/shared/sharedTest/kotlin/$rootPackage/MockFactory.kt")
+
+        println(actualActual!!.readText())
+        println(actualExpect!!.readText())
 
         // Then
         compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
@@ -746,7 +746,7 @@ class KMockMocksSpec {
             source,
             isKmp = false,
             kspArguments = mapOf(
-                "${KMOCK_PREFIX}spyOn_0" to "mock.template.spy.Platform",
+                "${KMOCK_PREFIX}spyOn_0" to "mock.template.spy.AliasPlatform",
                 "${KMOCK_PREFIX}alias_mock.template.spy.Platform" to "AliasPlatform",
             )
         )

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGeneratorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGeneratorSpec.kt
@@ -17,8 +17,8 @@ internal class KMockFactoryEntryPointGeneratorSpec {
         KMockFactoryEntryPointGenerator(
             false,
             "any",
+            mockk(),
             false,
-            setOf(),
             mockk(),
             mockk(),
             mockk()

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/factory/KMockFactorySpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/factory/KMockFactorySpec.kt
@@ -16,9 +16,9 @@ class KMockFactorySpec {
     fun `It fulfils MockFactoryGenerator`() {
         KMockFactoryGenerator(
             mockk(),
-            setOf(),
             "any",
             false,
+            mockk(),
             false,
             mockk(),
             mockk(),

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/factory/MockFactoryWithGenericsSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/factory/MockFactoryWithGenericsSpec.kt
@@ -16,7 +16,8 @@ class MockFactoryWithGenericsSpec {
     fun `It fulfils MockFactoryWithGenerics`() {
         KMockFactoryWithGenerics(
             true,
-            true,
+            mockk(),
+            false,
             mockk(),
             mockk(),
         ) fulfils ProcessorContract.MockFactoryWithGenerics::class

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SpyContainerSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/utils/SpyContainerSpec.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.utils
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.fixture.listFixture
+import tech.antibytes.util.test.fulfils
+import tech.antibytes.util.test.mustBe
+
+class SpyContainerSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    fun `It fulfils SpyContainer`() {
+        SpyContainer(fixture.fixture(), emptySet()) fulfils ProcessorContract.SpyContainer::class
+    }
+
+    @Test
+    fun `Given isSable is called it return false if nulled template nor the derivative TemplateName is not part of the enabled spies`() {
+        // Given
+        val enabledSpies = fixture.listFixture<String>(size = 3).toSet()
+
+        // When
+        val actual = SpyContainer(
+            false,
+            enabledSpies
+        ).isSpyable(
+            template = null,
+            packageName = fixture.fixture(),
+            templateName = fixture.fixture(),
+        )
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given isSable is called it return false if template nor the derivative TemplateName is not part of the enabled spies`() {
+        // Given
+        val enabledSpies = fixture.listFixture<String>(size = 3).toSet()
+
+        // When
+        val actual = SpyContainer(
+            false,
+            enabledSpies
+        ).isSpyable(
+            template = mockk(relaxed = true),
+            packageName = fixture.fixture(),
+            templateName = fixture.fixture(),
+        )
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given isSpyable is called it return true if template is part of the enabled spies`() {
+        // Given
+        val enabledSpies = fixture.listFixture<String>(size = 3)
+        val template: KSClassDeclaration = mockk()
+
+        every { template.qualifiedName!!.asString() } returns enabledSpies[2]
+
+        // When
+        val actual = SpyContainer(
+            false,
+            enabledSpies.toSet()
+        ).isSpyable(
+            template = template,
+            packageName = fixture.fixture(),
+            templateName = fixture.fixture(),
+        )
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    // Aliases & MultiMock
+    fun `Given isSpyable is called it return true if the derivative TemplateName is part of the enabled spies`() {
+        // Given
+        val packageName: String = fixture.fixture()
+        val templateName: String = fixture.fixture()
+        val enabledSpies = fixture.listFixture<String>(size = 3).toMutableList().also {
+            it.add("$packageName.$templateName")
+        }
+
+        // When
+        val actual = SpyContainer(
+            false,
+            enabledSpies.toSet()
+        ).isSpyable(
+            template = mockk(relaxed = true),
+            packageName = packageName,
+            templateName = templateName,
+        )
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given isSable is called it return true if template nor the derivative TemplateName is not part of the enabled spies, but spiesOnly is true`() {
+        // Given
+        val enabledSpies = fixture.listFixture<String>(size = 3).toSet()
+
+        // When
+        val actual = SpyContainer(
+            true,
+            enabledSpies
+        ).isSpyable(
+            template = mockk(relaxed = true),
+            packageName = fixture.fixture(),
+            templateName = fixture.fixture(),
+        )
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given hasSpies is called it return false if Spies are not enabled`() {
+        // When
+        val actual = SpyContainer(false, emptySet()).hasSpies()
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given hasSpies is called it return true if Spies are not enabled but spies only is true`() {
+        // When
+        val actual = SpyContainer(true, emptySet()).hasSpies()
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given hasSpies is called it return true if Spies are enabled`() {
+        // Given
+        val enabledSpies = fixture.listFixture<String>(size = 3).toSet()
+
+        // When
+        val actual = SpyContainer(true, enabledSpies).hasSpies()
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given hasSpies is called it return true if Spies are enabled but spies only is false`() {
+        // Given
+        val enabledSpies = fixture.listFixture<String>(size = 3).toSet()
+
+        // When
+        val actual = SpyContainer(false, enabledSpies).hasSpies()
+
+        // Then
+        actual mustBe true
+    }
+}

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/Alias.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/Alias.kt
@@ -146,18 +146,3 @@ internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
     freeze = freeze,
     templateType = templateType,
 )
-
-internal inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, L>, K : Any, L>
-    kspy(
-    spyOn: SpyOn,
-    verifier: KMockContract.Collector = NoopCollector,
-    freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
-): Mock where L : Any, L : Comparable<L> = getMockInstance(
-    spyOn = spyOn,
-    verifier = verifier,
-    relaxed = false,
-    relaxUnitFun = false,
-    freeze = freeze,
-    templateType = templateType,
-)

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/Platform.kt
@@ -145,18 +145,3 @@ internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
     freeze = freeze,
     templateType = templateType,
 )
-
-internal inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, L>, K : Any, L>
-    kspy(
-    spyOn: SpyOn,
-    verifier: KMockContract.Collector = NoopCollector,
-    freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
-): Mock where L : Any, L : Comparable<L> = getMockInstance(
-    spyOn = spyOn,
-    verifier = verifier,
-    relaxed = false,
-    relaxUnitFun = false,
-    freeze = freeze,
-    templateType = templateType,
-)

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/SharedActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/SharedActual.kt
@@ -125,18 +125,3 @@ internal actual inline fun <reified Mock : Shared.Shared4<K, L>, K : Any, L> kmo
     freeze = freeze,
     templateType = templateType,
 )
-
-internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Shared.Shared4<K, L>, K : Any, L>
-    kspy(
-    spyOn: SpyOn,
-    verifier: KMockContract.Collector,
-    freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
-): Mock where L : Any, L : Comparable<L> = getMockInstance(
-    spyOn = spyOn,
-    verifier = verifier,
-    relaxed = false,
-    relaxUnitFun = false,
-    freeze = freeze,
-    templateType = templateType,
-)

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/SharedExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/SharedExpect.kt
@@ -34,11 +34,3 @@ internal expect inline fun <reified Mock : Shared.Shared4<K, L>, K : Any, L> kmo
     freeze: Boolean = true,
     templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
 ): Mock where L : Any, L : Comparable<L>
-
-internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Shared.Shared4<K, L>, K : Any, L>
-    kspy(
-    spyOn: SpyOn,
-    verifier: KMockContract.Collector = NoopCollector,
-    freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
-): Mock where L : Any, L : Comparable<L>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #133

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This fixes the issue that `kspy` is generated, while not declared in terms of generics.
Also it resolves the small issue that declared aliases can not be used via `spyOn`.
Lastly it makes `spiesOnly` capable to enable all Spies in order to avoid error prone behaviour.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
