### PR TITLE
Add support for generic mulit-interface mocks in Common

### DIFF
--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
@@ -6,7 +6,6 @@
 
 package tech.antibytes.kmock.processor
 
-
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSType

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
@@ -121,7 +121,7 @@ internal object KMockGenerics : GenericResolver {
                 suffix = counter
             )
             val raw = parent.toClassName()
-            counter += generics[idx]?.size?.plus(1) ?: 0
+            counter += generics[idx]?.size ?: 0
 
             if (typeParameter.isNotEmpty()) {
                 aggregatedTypeParameter.addAll(typeParameter)

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -11,7 +11,6 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
-import com.squareup.kotlinpoet.ksp.KotlinPoetKspPreview
 import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
 import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryEntryPointGenerator
@@ -127,7 +126,7 @@ internal class KMockProcessor(
 
         mockGenerator.writeCommonMocks(
             templateSources = singleCommonSources.extractedTemplates,
-            templateMultiSources = commonMultiAggregated,
+            templateMultiSources = multiCommonSources.extractedTemplates,
             relaxer = relaxer,
         )
 
@@ -250,7 +249,6 @@ internal class KMockProcessor(
         return relaxer
     }
 
-    @OptIn(KotlinPoetKspPreview::class)
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val relaxer = extractRelaxer(resolver)
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessor.kt
@@ -31,6 +31,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
  */
 internal class KMockProcessor(
     private val logger: KSPLogger,
+    private val isUnderCompilerTest: Boolean, // TODO - Test Concern see: https://github.com/tschuchortdev/kotlin-compile-testing/issues/263
     private val isKmp: Boolean,
     private val codeGenerator: KmpCodeGenerator,
     private val interfaceGenerator: MultiInterfaceBinder,
@@ -117,6 +118,18 @@ internal class KMockProcessor(
             commonMultiAggregated.extractedTemplates.isEmpty() // TODO - Test Concern see: https://github.com/tschuchortdev/kotlin-compile-testing/issues/263
     }
 
+    // TODO - Test Concern see: https://github.com/tschuchortdev/kotlin-compile-testing/issues/263
+    private fun resolveMultiSources(
+        aggregated: Aggregated<TemplateMultiSource>,
+        stored: Aggregated<TemplateMultiSource>,
+    ): List<TemplateMultiSource> {
+        return if (isUnderCompilerTest) {
+            aggregated.extractedTemplates
+        } else {
+            stored.extractedTemplates
+        }
+    }
+
     private fun stubCommonSources(
         resolver: Resolver,
         relaxer: Relaxer?
@@ -126,7 +139,7 @@ internal class KMockProcessor(
 
         mockGenerator.writeCommonMocks(
             templateSources = singleCommonSources.extractedTemplates,
-            templateMultiSources = multiCommonSources.extractedTemplates,
+            templateMultiSources = resolveMultiSources(multiCommonSources, commonMultiAggregated),
             relaxer = relaxer,
         )
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -39,7 +39,9 @@ import tech.antibytes.kmock.processor.utils.SourceFilter
 import tech.antibytes.kmock.processor.utils.SourceSetValidator
 import tech.antibytes.kmock.processor.utils.SpyContainer
 
-class KMockProcessorProvider : SymbolProcessorProvider {
+class KMockProcessorProvider(
+    private val isUnderCompilerTest: Boolean = false
+) : SymbolProcessorProvider {
     private fun determineFactoryGenerator(
         options: Options,
         logger: KSPLogger,
@@ -157,6 +159,7 @@ class KMockProcessorProvider : SymbolProcessorProvider {
 
         return KMockProcessor(
             logger = logger,
+            isUnderCompilerTest = isUnderCompilerTest,
             isKmp = options.isKmp,
             codeGenerator = codeGenerator,
             interfaceGenerator = KMockMultiInterfaceBinder(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -73,8 +73,10 @@ class KMockProcessorProvider : SymbolProcessorProvider {
                         genericResolver = KMockGenerics,
                     ),
                     multiInterfaceGenerator = KMockFactoryMultiInterfaceGenerator(
+                        isKmp = options.isKmp,
                         spyContainer = spyContainer,
                         utils = factoryUtils,
+                        genericResolver = KMockGenerics,
                     ),
                     spyContainer = spyContainer,
                     spiesOnly = options.spiesOnly,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -160,7 +160,8 @@ class KMockProcessorProvider : SymbolProcessorProvider {
             interfaceGenerator = KMockMultiInterfaceBinder(
                 logger = logger,
                 rootPackage = options.rootPackage,
-                codeGenerator = codeGenerator
+                genericResolver = KMockGenerics,
+                codeGenerator = codeGenerator,
             ),
             mockGenerator = KMockGenerator(
                 logger = logger,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -21,7 +21,6 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -195,6 +195,12 @@ internal interface ProcessorContract {
             typeResolver: TypeParameterResolver
         ): List<TypeVariableName>
 
+        fun mapDeclaredGenerics(
+            generics: Map<String, List<KSTypeReference>>,
+            suffix: Int,
+            typeResolver: TypeParameterResolver
+        ): List<TypeVariableName>
+
         fun mapProxyGenerics(
             generics: Map<String, List<KSTypeReference>>,
             typeResolver: TypeParameterResolver

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -195,11 +195,10 @@ internal interface ProcessorContract {
             typeResolver: TypeParameterResolver
         ): List<TypeVariableName>
 
-        fun mapDeclaredGenerics(
-            generics: Map<String, List<KSTypeReference>>,
-            suffix: Int,
-            typeResolver: TypeParameterResolver
-        ): List<TypeVariableName>
+        fun remapTypes(
+            templates: List<KSClassDeclaration>,
+            generics: List<Map<String, List<KSTypeReference>>?>
+        ): Pair<List<TypeName>, List<TypeVariableName>>
 
         fun mapProxyGenerics(
             generics: Map<String, List<KSTypeReference>>,
@@ -329,6 +328,7 @@ internal interface ProcessorContract {
             ksFunction: KSFunctionDeclaration,
             typeResolver: TypeParameterResolver,
             enableSpy: Boolean,
+            inherited: Boolean,
             relaxer: Relaxer?,
         ): Pair<PropertySpec?, FunSpec>
     }
@@ -354,7 +354,7 @@ internal interface ProcessorContract {
 
         fun writeCommonMocks(
             templateSources: List<TemplateSource>,
-            templateMultiSources: Aggregated<TemplateMultiSource>,
+            templateMultiSources: List<TemplateMultiSource>,
             relaxer: Relaxer?
         )
     }
@@ -362,8 +362,8 @@ internal interface ProcessorContract {
     fun interface ParentFinder {
         fun find(
             templateSource: TemplateSource,
-            templateMultiSources: Aggregated<TemplateMultiSource>,
-        ): List<KSClassDeclaration>
+            templateMultiSources: List<TemplateMultiSource>,
+        ): TemplateMultiSource?
     }
 
     interface MultiInterfaceBinder {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -21,6 +21,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
@@ -402,8 +403,6 @@ internal interface ProcessorContract {
         fun resolveGenerics(templateSource: TemplateSource): List<TypeVariableName>
 
         fun resolveModifier(): KModifier?
-
-        fun toTypeNames(types: List<KSClassDeclaration>): List<TypeName>
     }
 
     interface MockFactoryWithoutGenerics {
@@ -423,6 +422,12 @@ internal interface ProcessorContract {
         val shared: FunSpec
     )
 
+    data class FactoryMultiBundle(
+        val kmock: FunSpec?,
+        val kspy: FunSpec?,
+        val shared: FunSpec?
+    )
+
     interface MockFactoryWithGenerics {
         fun buildGenericFactories(
             templateSources: List<TemplateSource>,
@@ -431,10 +436,10 @@ internal interface ProcessorContract {
     }
 
     interface MockFactoryMultiInterface {
-        fun buildSpyFactory(
+        fun buildFactories(
             templateMultiSources: List<TemplateMultiSource>,
             relaxer: Relaxer?
-        ): List<FunSpec>
+        ): List<FactoryMultiBundle>
     }
 
     interface MockFactoryGenerator {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
@@ -151,7 +151,7 @@ internal class KMockFactoryEntryPointGenerator(
         ).build()
     }
 
-    private fun buildMultiInterfaceGenericMockFactory(
+    private fun buildMultiInterfaceGenericKMockFactory(
         boundaries: List<TypeName>,
         generics: List<TypeVariableName>
     ): FunSpec {
@@ -159,6 +159,26 @@ internal class KMockFactoryEntryPointGenerator(
 
         return utils.generateKmockSignature(
             type = mockType,
+            generics = emptyList(),
+            hasDefault = true,
+            modifier = KModifier.EXPECT
+        ).addTypeVariables(generics).build()
+    }
+
+    private fun buildMultiInterfaceGenericKSpyFactory(
+        boundaries: List<TypeName>,
+        generics: List<TypeVariableName>
+    ): FunSpec {
+        val spyType = TypeVariableName(
+            KSPY_FACTORY_TYPE_NAME,
+            bounds = boundaries,
+        )
+
+        val mockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME, bounds = listOf(spyType))
+
+        return utils.generateKspySignature(
+            mockType = mockType,
+            spyType = spyType,
             generics = emptyList(),
             hasDefault = true,
             modifier = KModifier.EXPECT
@@ -173,11 +193,11 @@ internal class KMockFactoryEntryPointGenerator(
         templateSource: TemplateMultiSource,
         boundaries: List<TypeName>,
         generics: List<TypeVariableName>
-    ): FunSpec? {
+    ): FunSpec {
         return if (templateSource.isSpyable()) {
-            null
+            buildMultiInterfaceGenericKSpyFactory(boundaries, generics)
         } else {
-            buildMultiInterfaceGenericMockFactory(boundaries, generics)
+            buildMultiInterfaceGenericKMockFactory(boundaries, generics)
         }
     }
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
@@ -154,7 +154,9 @@ internal class KMockFactoryEntryPointGenerator(
         templateSource: TemplateMultiSource
     ): FunSpec? {
         return if (spyContainer.isSpyable(null, templateSource.packageName, templateSource.templateName)) {
-            buildMultiInterfaceSpyFactory(utils.toTypeNames(templateSource.templates))
+            val (types, _) = genericResolver.remapTypes(templateSource.templates, templateSource.generics)
+
+            buildMultiInterfaceSpyFactory(types)
         } else {
             null
         }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
@@ -103,7 +103,7 @@ internal class KMockFactoryGenerator(
                 file.addFunction(factories.shared)
             }
 
-            if (factories.kmock != null) {
+            if (factories.kmock != null && !spiesOnly) {
                 file.addFunction(factories.kmock)
             }
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGenerator.kt
@@ -93,13 +93,23 @@ internal class KMockFactoryGenerator(
             }
         }
 
-        val multiInterfaceMocks = multiInterfaceGenerator.buildSpyFactory(
+        val multiInterfaceMocks = multiInterfaceGenerator.buildFactories(
             templateMultiSources = templateMultiSources,
             relaxer = relaxer
         )
 
-        multiInterfaceMocks.forEach { factory ->
-            file.addFunction(factory)
+        multiInterfaceMocks.forEach { factories ->
+            if (factories.shared != null) {
+                file.addFunction(factories.shared)
+            }
+
+            if (factories.kmock != null) {
+                file.addFunction(factories.kmock)
+            }
+
+            if (factories.kspy != null) {
+                file.addFunction(factories.kspy)
+            }
         }
 
         file.build().writeTo(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGeneratorUtil.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGeneratorUtil.kt
@@ -178,13 +178,17 @@ internal class KMockFactoryGeneratorUtil(
             .addParameter(buildRelaxedParameter(hasDefault))
             .addParameter(buildUnitRelaxedParameter(hasDefault))
             .addParameter(buildFreezeParameter(hasDefault))
-            .returns(type).addTypeVariable(type)
+            .returns(type).addTypeVariable(type.copy(reified = true))
 
         if (modifier != null) {
             kmock.addModifiers(modifier)
         }
 
-        return kmock.amendGenericValues(type, generics)
+        return if (type.bounds.size > 1) {
+            kmock.amendMultiBounded(type)
+        } else {
+            kmock.amendGenericValues(type, generics)
+        }
     }
 
     private fun buildSpyParameter(nullable: Boolean = false): ParameterSpec {
@@ -240,7 +244,11 @@ internal class KMockFactoryGeneratorUtil(
             .addParameter(buildUnitRelaxedParameter(false))
             .addParameter(buildFreezeParameter(false))
 
-        return mockFactory.amendGenericValues(spyType, generics)
+        return if (spyType.bounds.size > 1) {
+            mockFactory.amendMultiBounded(spyType)
+        } else {
+            mockFactory.amendGenericValues(spyType, generics)
+        }
     }
 
     override fun splitInterfacesIntoRegularAndGenerics(
@@ -262,8 +270,4 @@ internal class KMockFactoryGeneratorUtil(
     }
 
     override fun resolveModifier(): KModifier? = modifier
-
-    override fun toTypeNames(
-        types: List<KSClassDeclaration>
-    ): List<TypeName> = types.map { source -> source.toClassName() }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGeneratorUtil.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryGeneratorUtil.kt
@@ -6,13 +6,11 @@
 
 package tech.antibytes.kmock.processor.factory
 
-import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
-import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.SHARED_MOCK_FACTORY

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryMultiInterfaceGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryMultiInterfaceGenerator.kt
@@ -64,30 +64,17 @@ internal class KMockFactoryMultiInterfaceGenerator(
         )
     }
 
-    private fun resolveTypeInfo(
-        generics: List<TypeVariableName>
-    ): String {
-        return if (generics.isNotEmpty()) {
-            "<${generics.joinToString(", ")}>"
-        } else {
-            ""
-        }
-    }
-
     private fun buildMockSelector(
         mockFactory: FunSpec.Builder,
         templateSource: TemplateMultiSource,
-        generics: List<TypeVariableName>,
         relaxer: Relaxer?
     ): FunSpec.Builder {
         val qualifiedName = "${templateSource.packageName}.${templateSource.templateName}"
-        val typeInfo = resolveTypeInfo(generics)
 
         return buildMockSelectorFlow(mockFactory, "${qualifiedName}Mock") {
             addMock(
                 mockFactory = this,
                 qualifiedName = qualifiedName,
-                typeInfo = typeInfo,
                 relaxer = relaxer
             )
         }
@@ -111,7 +98,6 @@ internal class KMockFactoryMultiInterfaceGenerator(
         return buildMockSelector(
             mockFactory = mockFactory,
             templateSource = templateSource,
-            generics = emptyList(),
             relaxer = relaxer
         )
     }
@@ -206,7 +192,6 @@ internal class KMockFactoryMultiInterfaceGenerator(
         return buildMockSelector(
             mockFactory = mockFactory,
             templateSource = templateSource,
-            generics = generics,
             relaxer = relaxer
         )
     }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryMultiInterfaceGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryMultiInterfaceGenerator.kt
@@ -9,6 +9,9 @@ package tech.antibytes.kmock.processor.factory
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
+import tech.antibytes.kmock.processor.ProcessorContract
+import tech.antibytes.kmock.processor.ProcessorContract.FactoryMultiBundle
+import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.KMOCK_FACTORY_TYPE_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.KSPY_FACTORY_TYPE_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
@@ -16,9 +19,12 @@ import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryMultiInterfac
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
 import tech.antibytes.kmock.processor.ProcessorContract.SpyContainer
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+import tech.antibytes.kmock.processor.multi.hasGenerics
 
 internal class KMockFactoryMultiInterfaceGenerator(
+    private val isKmp: Boolean,
     private val spyContainer: SpyContainer,
+    private val genericResolver: GenericResolver,
     private val utils: MockFactoryGeneratorUtil,
 ) : MockFactoryMultiInterface {
     private fun buildMockSelectorFlow(
@@ -58,17 +64,30 @@ internal class KMockFactoryMultiInterfaceGenerator(
         )
     }
 
+    private fun resolveTypeInfo(
+        generics: List<TypeVariableName>
+    ): String {
+        return if (generics.isNotEmpty()) {
+            "<${generics.joinToString(", ")}>"
+        } else {
+            ""
+        }
+    }
+
     private fun buildMockSelector(
         mockFactory: FunSpec.Builder,
         templateSource: TemplateMultiSource,
+        generics: List<TypeVariableName>,
         relaxer: Relaxer?
     ): FunSpec.Builder {
         val qualifiedName = "${templateSource.packageName}.${templateSource.templateName}"
+        val typeInfo = resolveTypeInfo(generics)
 
         return buildMockSelectorFlow(mockFactory, "${qualifiedName}Mock") {
             addMock(
                 mockFactory = this,
                 qualifiedName = qualifiedName,
+                typeInfo = typeInfo,
                 relaxer = relaxer
             )
         }
@@ -92,21 +111,26 @@ internal class KMockFactoryMultiInterfaceGenerator(
         return buildMockSelector(
             mockFactory = mockFactory,
             templateSource = templateSource,
+            generics = emptyList(),
             relaxer = relaxer
         )
     }
 
     private fun resolveBounds(
         templateMultiSource: TemplateMultiSource,
-    ): List<TypeName> = utils.toTypeNames(templateMultiSource.templates)
+    ): Pair<List<TypeName>, List<TypeVariableName>> {
+        return genericResolver.remapTypes(templateMultiSource.templates, templateMultiSource.generics)
+    }
 
     private fun buildSpyMockFactory(
         templateSource: TemplateMultiSource,
         relaxer: Relaxer?
     ): FunSpec {
+        val (bounds, _) = resolveBounds(templateSource)
+
         val spyType = TypeVariableName(
             KSPY_FACTORY_TYPE_NAME,
-            bounds = resolveBounds(templateSource)
+            bounds = bounds
         )
 
         val mockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME, bounds = listOf(spyType))
@@ -120,18 +144,166 @@ internal class KMockFactoryMultiInterfaceGenerator(
         ).build()
     }
 
-    override fun buildSpyFactory(
+    private fun fillMockFactory(
+        type: TypeVariableName,
+        generics: List<TypeVariableName>,
+    ): FunSpec.Builder {
+        val modifier = utils.resolveModifier()
+
+        return utils.generateKmockSignature(
+            type = type,
+            generics = generics,
+            hasDefault = !isKmp,
+            modifier = modifier
+        ).addTypeVariables(generics)
+    }
+
+    private fun generateTypeArgument(
+        bounds: List<TypeName>
+    ): String {
+        val typeArgumentBuilder = StringBuilder()
+
+        bounds.forEachIndexed { idx, _ ->
+            typeArgumentBuilder.append("templateType$idx = templateType$idx,\n")
+        }
+
+        return typeArgumentBuilder.toString().trimEnd()
+    }
+
+    private fun buildGenericKmockFactory(
+        bounds: List<TypeName>,
+        generics: List<TypeVariableName>,
+    ): FunSpec {
+        val type = TypeVariableName(
+            KMOCK_FACTORY_TYPE_NAME,
+            bounds = bounds
+        )
+
+        return fillMockFactory(
+            generics = generics,
+            type = type,
+        ).addCode(
+            factoryInvocationWithTemplate,
+            generateTypeArgument(bounds)
+        ).build()
+    }
+
+    private fun fillSharedMockFactory(
+        mockType: TypeVariableName,
+        spyType: TypeVariableName,
+        templateSource: TemplateMultiSource,
+        generics: List<TypeVariableName>,
+        relaxer: Relaxer?
+    ): FunSpec.Builder {
+        val mockFactory = utils.generateSharedMockFactorySignature(
+            mockType = mockType,
+            spyType = spyType,
+            generics = generics,
+        )
+
+        mockFactory.addTypeVariables(generics)
+
+        return buildMockSelector(
+            mockFactory = mockFactory,
+            templateSource = templateSource,
+            generics = generics,
+            relaxer = relaxer
+        )
+    }
+
+    private fun buildGenericSharedMockFactory(
+        templateSource: TemplateMultiSource,
+        bounds: List<TypeName>,
+        generics: List<TypeVariableName>,
+        relaxer: Relaxer?
+    ): FunSpec {
+        val spyType = TypeVariableName(
+            KSPY_FACTORY_TYPE_NAME,
+            bounds = bounds,
+        )
+
+        val mockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME, bounds = listOf(spyType))
+
+        return fillSharedMockFactory(
+            mockType = mockType,
+            spyType = spyType,
+            templateSource = templateSource,
+            generics = generics,
+            relaxer = relaxer
+        ).build()
+    }
+
+    private fun buildGenericFactories(
+        templateSource: TemplateMultiSource,
+        relaxer: Relaxer?
+    ): FactoryMultiBundle {
+        val (bounds, generics) = resolveBounds(templateSource)
+
+        return FactoryMultiBundle(
+            shared = buildGenericSharedMockFactory(
+                templateSource = templateSource,
+                bounds = bounds,
+                generics = generics,
+                relaxer = relaxer
+            ),
+            kmock = buildGenericKmockFactory(
+                bounds = bounds,
+                generics = generics,
+            ),
+            kspy = null,
+        )
+    }
+
+    private fun TemplateMultiSource.isSpyable(): Boolean {
+        return spyContainer.isSpyable(null, this.packageName, this.templateName)
+    }
+
+    override fun buildFactories(
         templateMultiSources: List<TemplateMultiSource>,
         relaxer: Relaxer?
-    ): List<FunSpec> {
-        val factories: MutableList<FunSpec> = mutableListOf()
+    ): List<FactoryMultiBundle> {
+        val factories: MutableList<FactoryMultiBundle> = mutableListOf()
 
         templateMultiSources.forEach { source ->
-            if (spyContainer.isSpyable(null, source.packageName, source.templateName)) {
-                factories.add(buildSpyMockFactory(source, relaxer))
+            if (source.isSpyable() && !source.hasGenerics()) {
+                factories.add(
+                    FactoryMultiBundle(
+                        kmock = null,
+                        shared = null,
+                        kspy = buildSpyMockFactory(source, relaxer)
+                    )
+                )
+            }
+
+            if (source.hasGenerics()) {
+                factories.add(buildGenericFactories(source, relaxer))
             }
         }
 
         return factories
+    }
+
+    private companion object {
+        private val factoryInvocationWithTemplate = """
+                |return ${ProcessorContract.SHARED_MOCK_FACTORY}(
+                |   spyOn = null,
+                |   verifier = verifier,
+                |   relaxed = relaxed,
+                |   relaxUnitFun = relaxUnitFun,
+                |   freeze = freeze,
+                |   %L
+                |)
+        """.trimMargin()
+
+        private val spyFactoryInvocationWithTemplate = """
+                |return ${ProcessorContract.SHARED_MOCK_FACTORY}(
+                |   spyOn = spyOn,
+                |   verifier = verifier,
+                |   relaxed = false,
+                |   relaxUnitFun = false,
+                |   freeze = freeze,
+                |   %L
+                |)
+        """.trimMargin()
     }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryMultiInterfaceGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryMultiInterfaceGenerator.kt
@@ -10,10 +10,10 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import tech.antibytes.kmock.processor.ProcessorContract
-import tech.antibytes.kmock.processor.ProcessorContract.FactoryMultiBundle
-import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.KMOCK_FACTORY_TYPE_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.KSPY_FACTORY_TYPE_NAME
+import tech.antibytes.kmock.processor.ProcessorContract.FactoryMultiBundle
+import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryGeneratorUtil
 import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryMultiInterface
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
@@ -166,7 +166,7 @@ internal class KMockFactoryWithGenerics(
         )
     }
 
-    private fun buildMockSelector(
+    private fun buildSharedMockSelector(
         mockFactory: FunSpec.Builder,
         templateSource: TemplateSource,
         generics: List<TypeVariableName>,
@@ -197,7 +197,7 @@ internal class KMockFactoryWithGenerics(
             generics = generics,
         )
 
-        return buildMockSelector(
+        return buildSharedMockSelector(
             mockFactory = mockFactory,
             templateSource = templateSource,
             generics = generics,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
@@ -16,6 +16,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.MockFactoryWithoutGeneri
 import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
+import tech.antibytes.kmock.processor.multi.hasGenerics
 import tech.antibytes.kmock.processor.utils.ensureNotNullClassName
 
 internal class KMockFactoryWithoutGenerics(
@@ -137,18 +138,16 @@ internal class KMockFactoryWithoutGenerics(
         relaxer: Relaxer?
     ) {
         buildMockSelectorFlow(this) {
-            if (templateSources.isNotEmpty()) {
-                templateSources.forEach { source ->
-                    amendSource(
-                        mockFactory = this,
-                        templateSource = source,
-                        relaxer = relaxer
-                    )
-                }
+            templateSources.forEach { source ->
+                amendSource(
+                    mockFactory = this,
+                    templateSource = source,
+                    relaxer = relaxer
+                )
             }
 
-            if (templateMultiSources.isNotEmpty()) {
-                templateMultiSources.forEach { source ->
+            templateMultiSources.forEach { source ->
+                if (!source.hasGenerics()) {
                     amendMultiSource(
                         mockFactory = this,
                         templateSource = source,
@@ -217,7 +216,7 @@ internal class KMockFactoryWithoutGenerics(
     override fun buildSpyFactory(): FunSpec = fillSpyFactory().build()
 
     private companion object {
-        private val kmockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME).copy(reified = true)
+        private val kmockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME)
         private val kspyType = TypeVariableName(KSPY_FACTORY_TYPE_NAME)
         private val kspyMockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME, bounds = listOf(kspyType))
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KmockProxyNameSelector.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KmockProxyNameSelector.kt
@@ -158,7 +158,7 @@ internal class KmockProxyNameSelector(
             currentName = resolveGenericName(generics[currentName], typeResolver) ?: "Any"
         } while (currentName in generics)
 
-        return currentName
+        return currentName.trimEnd('?')
     }
 
     private fun String.resolveActualName(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
@@ -16,8 +16,8 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.writeTo
 import tech.antibytes.kmock.MockCommon
-import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.INTERMEDIATE_INTERFACES_FILE_NAME
+import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MultiInterfaceBinder
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
@@ -9,13 +9,23 @@ package tech.antibytes.kmock.processor.multi
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.ksp.TypeParameterResolver
+import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import com.squareup.kotlinpoet.ksp.writeTo
 import tech.antibytes.kmock.MockCommon
+import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.INTERMEDIATE_INTERFACES_FILE_NAME
 import tech.antibytes.kmock.processor.ProcessorContract.KmpCodeGenerator
 import tech.antibytes.kmock.processor.ProcessorContract.MultiInterfaceBinder
@@ -23,17 +33,66 @@ import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 
 internal class KMockMultiInterfaceBinder(
     private val logger: KSPLogger,
+    private val genericResolver: GenericResolver,
     private val rootPackage: String,
     private val codeGenerator: KmpCodeGenerator,
 ) : MultiInterfaceBinder {
+    private fun resolveTypeParameter(
+        typeParameter: Map<String, List<KSTypeReference>>?,
+        typeResolver: TypeParameterResolver,
+        suffix: Int,
+    ): List<TypeVariableName> {
+        return if (typeParameter == null) {
+            emptyList()
+        } else {
+            genericResolver.mapDeclaredGenerics(
+                generics = typeParameter,
+                typeResolver = typeResolver,
+                suffix = suffix,
+            )
+        }
+    }
+
+    private fun remapTypes(
+        templates: List<KSClassDeclaration>,
+        generics: List<Map<String, List<KSTypeReference>>?>
+    ): Pair<List<TypeName>, List<TypeVariableName>> {
+        var counter = 0
+        val aggregatedTypeParameter: MutableList<TypeVariableName> = mutableListOf()
+        val parameterizedParents = templates.mapIndexed { idx, parent ->
+            val typeParameter = resolveTypeParameter(
+                typeParameter = generics[idx],
+                typeResolver = parent.typeParameters.toTypeParameterResolver(),
+                suffix = counter
+            )
+            val raw = parent.toClassName()
+            counter += generics[idx]?.size?.plus(1) ?: 0
+
+            if (typeParameter.isNotEmpty()) {
+                aggregatedTypeParameter.addAll(typeParameter)
+                raw.parameterizedBy(typeParameter)
+            } else {
+                raw
+            }
+        }
+
+        return Pair(parameterizedParents, aggregatedTypeParameter)
+    }
+
     private fun createInterface(
         interfaceName: String,
-        templates: List<KSClassDeclaration>
+        templates: List<KSClassDeclaration>,
+        generics: List<Map<String, List<KSTypeReference>>?>,
     ): TypeSpec {
         val interfaze = TypeSpec.interfaceBuilder(interfaceName)
-        interfaze.addSuperinterfaces(
-            templates.map { parent -> parent.asStarProjectedType().toTypeName() }
-        )
+
+        val (parents, typeParameter) = remapTypes(templates, generics)
+        interfaze.addSuperinterfaces(parents)
+
+        if (typeParameter.isNotEmpty()) {
+            interfaze.addTypeVariables(typeParameter)
+        }
+
         interfaze.addAnnotation(
             AnnotationSpec.builder(MockCommon::class).addMember("$interfaceName::class").build()
         )
@@ -54,7 +113,8 @@ internal class KMockMultiInterfaceBinder(
         templateSources.map { source ->
             val implementation = createInterface(
                 interfaceName = source.templateName,
-                templates = source.templates
+                templates = source.templates,
+                generics = source.generics
             )
 
             file.addType(implementation)

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockMultiInterfaceBinder.kt
@@ -9,20 +9,11 @@ package tech.antibytes.kmock.processor.multi
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
-import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.TypeVariableName
-import com.squareup.kotlinpoet.ksp.TypeParameterResolver
-import com.squareup.kotlinpoet.ksp.toClassName
-import com.squareup.kotlinpoet.ksp.toTypeName
-import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import com.squareup.kotlinpoet.ksp.writeTo
 import tech.antibytes.kmock.MockCommon
 import tech.antibytes.kmock.processor.ProcessorContract.GenericResolver
@@ -37,48 +28,6 @@ internal class KMockMultiInterfaceBinder(
     private val rootPackage: String,
     private val codeGenerator: KmpCodeGenerator,
 ) : MultiInterfaceBinder {
-    private fun resolveTypeParameter(
-        typeParameter: Map<String, List<KSTypeReference>>?,
-        typeResolver: TypeParameterResolver,
-        suffix: Int,
-    ): List<TypeVariableName> {
-        return if (typeParameter == null) {
-            emptyList()
-        } else {
-            genericResolver.mapDeclaredGenerics(
-                generics = typeParameter,
-                typeResolver = typeResolver,
-                suffix = suffix,
-            )
-        }
-    }
-
-    private fun remapTypes(
-        templates: List<KSClassDeclaration>,
-        generics: List<Map<String, List<KSTypeReference>>?>
-    ): Pair<List<TypeName>, List<TypeVariableName>> {
-        var counter = 0
-        val aggregatedTypeParameter: MutableList<TypeVariableName> = mutableListOf()
-        val parameterizedParents = templates.mapIndexed { idx, parent ->
-            val typeParameter = resolveTypeParameter(
-                typeParameter = generics[idx],
-                typeResolver = parent.typeParameters.toTypeParameterResolver(),
-                suffix = counter
-            )
-            val raw = parent.toClassName()
-            counter += generics[idx]?.size?.plus(1) ?: 0
-
-            if (typeParameter.isNotEmpty()) {
-                aggregatedTypeParameter.addAll(typeParameter)
-                raw.parameterizedBy(typeParameter)
-            } else {
-                raw
-            }
-        }
-
-        return Pair(parameterizedParents, aggregatedTypeParameter)
-    }
-
     private fun createInterface(
         interfaceName: String,
         templates: List<KSClassDeclaration>,
@@ -86,7 +35,7 @@ internal class KMockMultiInterfaceBinder(
     ): TypeSpec {
         val interfaze = TypeSpec.interfaceBuilder(interfaceName)
 
-        val (parents, typeParameter) = remapTypes(templates, generics)
+        val (parents, typeParameter) = genericResolver.remapTypes(templates, generics)
         interfaze.addSuperinterfaces(parents)
 
         if (typeParameter.isNotEmpty()) {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
@@ -15,18 +15,12 @@ import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 internal object KMockParentFinder : ParentFinder {
     override fun find(
         templateSource: TemplateSource,
-        templateMultiSources: Aggregated<TemplateMultiSource>,
-    ): List<KSClassDeclaration> {
-        val parentsIdx = templateMultiSources.extractedTemplates.indexOfFirst { parent ->
+        templateMultiSources: List<TemplateMultiSource>,
+    ): TemplateMultiSource? {
+        return templateMultiSources.firstOrNull { parent ->
             templateSource.packageName == parent.packageName &&
                 templateSource.indicator == parent.indicator &&
                 templateSource.templateName == parent.templateName
-        }
-
-        return if (parentsIdx == -1) {
-            emptyList()
-        } else {
-            templateMultiSources.extractedTemplates[parentsIdx].templates
         }
     }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/KMockParentFinder.kt
@@ -6,8 +6,6 @@
 
 package tech.antibytes.kmock.processor.multi
 
-import com.google.devtools.ksp.symbol.KSClassDeclaration
-import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
 import tech.antibytes.kmock.processor.ProcessorContract.ParentFinder
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/TemplateMultiSource.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/multi/TemplateMultiSource.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.multi
+
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+
+internal fun TemplateMultiSource.hasGenerics(): Boolean = this.generics.any { item -> item != null }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/KotlinPoet.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/KotlinPoet.kt
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.utils
+
+import com.google.devtools.ksp.isLocal
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.Variance
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.WildcardTypeName
+import com.squareup.kotlinpoet.ksp.TypeParameterResolver
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
+import com.squareup.kotlinpoet.tags.TypeAliasTag
+
+// see: https://github.com/square/kotlinpoet/blob/9af3f67bb4338f6f35fcd29cb9228227981ae1ce/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/utils.kt#L16
+private fun TypeName.rawType(): ClassName {
+    return findRawType() ?: throw IllegalArgumentException("Cannot get raw type from $this")
+}
+
+private fun TypeName.findRawType(): ClassName? {
+    return when (this) {
+        is ClassName -> this
+        is ParameterizedTypeName -> rawType
+        is LambdaTypeName -> {
+            var count = parameters.size
+            if (receiver != null) {
+                count++
+            }
+            val functionSimpleName = if (count >= 23) {
+                "FunctionN"
+            } else {
+                "Function$count"
+            }
+            ClassName("kotlin.jvm.functions", functionSimpleName)
+        }
+        else -> null
+    }
+}
+
+private fun ClassName.withTypeArguments(arguments: List<TypeName>): TypeName {
+    return if (arguments.isEmpty()) {
+        this
+    } else {
+        this.parameterizedBy(arguments)
+    }
+}
+
+private fun KSDeclaration.toClassNameInternal(): ClassName {
+    require(!isLocal()) {
+        "Local/anonymous classes are not supported!"
+    }
+    val pkgName = packageName.asString()
+    val typesString = checkNotNull(qualifiedName).asString().removePrefix("$pkgName.")
+
+    val simpleNames = typesString
+        .split(".")
+    return ClassName(pkgName, simpleNames)
+}
+
+internal fun TypeVariableName.copy(name: String): TypeVariableName {
+    return TypeVariableName(
+        name,
+        bounds = this.bounds,
+        variance = this.variance,
+    ).copy(
+        reified = this.isReified,
+        tags = this.tags,
+        nullable = this.isNullable,
+        annotations = this.annotations,
+    )
+}
+
+internal fun WildcardTypeName.toTypeVariableName(): TypeVariableName {
+    val type = this.outTypes.first() as TypeVariableName
+
+    return TypeVariableName(
+        type.name,
+        bounds = type.bounds,
+    ).copy(
+        reified = type.isReified,
+        tags = type.tags,
+        annotations = type.annotations,
+        nullable = type.isNullable
+    )
+}
+
+private fun extractAliasTypeResolver(
+    declaration: KSTypeAlias,
+    typeParameterResolver: TypeParameterResolver
+): TypeParameterResolver {
+    return if (declaration.typeParameters.isEmpty()) {
+        typeParameterResolver
+    } else {
+        declaration.typeParameters.toTypeParameterResolver(typeParameterResolver)
+    }
+}
+
+private fun KSTypeAlias.abbreviateType(
+    typeParameterResolver: TypeParameterResolver,
+    isNullable: Boolean,
+    typeArguments: List<TypeName>
+): TypeName {
+    return this.type.resolve()
+        .toTypeName(typeParameterResolver)
+        .copy(nullable = isNullable)
+        .rawType()
+        .withTypeArguments(typeArguments)
+}
+
+private fun KSTypeAlias.parameterizedBy(
+    abbreviateType: TypeName,
+    typeArguments: List<TypeName>,
+): TypeName {
+    return this.toClassNameInternal()
+        .withTypeArguments(typeArguments)
+        .copy(tags = mapOf(TypeAliasTag::class to TypeAliasTag(abbreviateType)))
+}
+
+internal fun KSTypeReference.mapArgumentType(
+    typeParameterResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
+    mapping: Map<String, String>,
+): TypeName {
+    return resolve().mapArgumentType(
+        typeParameterResolver = typeParameterResolver,
+        mapping = mapping,
+        typeArguments = element?.typeArguments.orEmpty(),
+    )
+}
+
+private fun KSTypeArgument.mapArgumentType(
+    typeParameterResolver: TypeParameterResolver = TypeParameterResolver.EMPTY,
+    mapping: Map<String, String>,
+): TypeName {
+    val typeName = type?.mapArgumentType(
+        typeParameterResolver = typeParameterResolver,
+        mapping = mapping,
+    ) ?: return STAR
+    return when (variance) {
+        Variance.COVARIANT -> WildcardTypeName.producerOf(typeName)
+        Variance.CONTRAVARIANT -> WildcardTypeName.consumerOf(typeName)
+        Variance.STAR -> STAR
+        Variance.INVARIANT -> typeName
+    }
+}
+
+// see: https://github.com/square/kotlinpoet/blob/9af3f67bb4338f6f35fcd29cb9228227981ae1ce/interop/ksp/src/main/kotlin/com/squareup/kotlinpoet/ksp/ksTypes.kt#L60
+internal fun KSType.mapArgumentType(
+    typeParameterResolver: TypeParameterResolver,
+    mapping: Map<String, String>,
+    typeArguments: List<KSTypeArgument>,
+): TypeName {
+    require(!isError) {
+        "Error type '$this' is not resolvable in the current round of processing."
+    }
+
+    val type = when (val declaration = this.declaration) {
+        is KSTypeParameter -> {
+            val parameterType = typeParameterResolver[declaration.name.getShortName()]
+
+            if (parameterType.name in mapping) {
+                parameterType.copy(mapping[parameterType.name]!!)
+            } else {
+                parameterType
+            }
+        }
+        is KSClassDeclaration -> {
+            declaration.toClassName().withTypeArguments(
+                arguments.map { argument ->
+                    argument.mapArgumentType(
+                        typeParameterResolver = typeParameterResolver,
+                        mapping = mapping,
+                    )
+                }
+            )
+        }
+        is KSTypeAlias -> {
+            val extraResolver = extractAliasTypeResolver(declaration, typeParameterResolver)
+
+            val mappedArgs = arguments.map { argument ->
+                argument.mapArgumentType(
+                    typeParameterResolver = typeParameterResolver,
+                    mapping = mapping,
+                )
+            }
+
+            val abbreviatedType = declaration.abbreviateType(
+                typeParameterResolver = extraResolver,
+                isNullable = isMarkedNullable,
+                typeArguments = mappedArgs
+            )
+
+            val aliasArgs = typeArguments.map { argument ->
+                argument.mapArgumentType(
+                    typeParameterResolver = typeParameterResolver,
+                    mapping = mapping,
+                )
+            }
+
+            declaration.parameterizedBy(abbreviatedType, aliasArgs)
+        }
+        else -> error("Unsupported type: $declaration")
+    }
+
+    return type.copy(nullable = isMarkedNullable)
+}
+
+/* Workaround to overcome KSP misalignment on inherited types with function TypeParameter */
+// see: https://github.com/google/ksp/issues/958
+// TODO - Remove the following methods when KSP fixes this
+internal fun KSTypeArgument.toSecuredTypeName(
+    inheritedVarargArg: Boolean,
+    typeParameterResolver: TypeParameterResolver,
+    rootTypeArguments: List<KSTypeArgument>,
+): TypeName {
+    val typeName = type?.toSecuredTypeName(
+        inheritedVarargArg = inheritedVarargArg,
+        typeParameterResolver = typeParameterResolver,
+        rootTypeArguments = rootTypeArguments,
+    ) ?: return STAR
+    return when (variance) {
+        Variance.COVARIANT -> WildcardTypeName.producerOf(typeName)
+        Variance.CONTRAVARIANT -> WildcardTypeName.consumerOf(typeName)
+        Variance.STAR -> STAR
+        Variance.INVARIANT -> typeName
+    }
+}
+
+private fun KSClassDeclaration.isMisalignedVararg(
+    inheritedVarargArg: Boolean,
+    arguments: List<TypeName>,
+    rootTypeArguments: List<KSTypeArgument>
+): Boolean {
+    val resolved = rootTypeArguments.firstOrNull()?.type?.resolve()?.declaration?.simpleName?.getShortName()
+    val derived = arguments.firstOrNull()?.toString()
+
+    return this.simpleName.getShortName() == "Array" && inheritedVarargArg && derived != resolved
+}
+
+private fun KSType.toSecuredTypeName(
+    inheritedVarargArg: Boolean,
+    typeParameterResolver: TypeParameterResolver,
+    typeArguments: List<KSTypeArgument>,
+    rootTypeArguments: List<KSTypeArgument>,
+): TypeName {
+    require(!isError) {
+        "Error type '$this' is not resolvable in the current round of processing."
+    }
+
+    var overrideNullability = false
+    
+    val type = when (val declaration = this.declaration) {
+        is KSClassDeclaration -> {
+            val arguments = arguments.map { argument ->
+                argument.toSecuredTypeName(
+                    inheritedVarargArg = inheritedVarargArg,
+                    typeParameterResolver = typeParameterResolver,
+                    rootTypeArguments = rootTypeArguments,
+                )
+            }
+
+            if (declaration.isMisalignedVararg(inheritedVarargArg, arguments, rootTypeArguments)) {
+                (arguments.first() as WildcardTypeName).toTypeVariableName().also { resolved ->
+                    overrideNullability = resolved.isNullable
+                }
+            } else {
+                declaration.toClassName().withTypeArguments(arguments)
+            }
+        }
+        is KSTypeParameter -> {
+            typeParameterResolver[declaration.name.getShortName()]
+        }
+        is KSTypeAlias -> {
+            val extraResolver = extractAliasTypeResolver(declaration, typeParameterResolver) 
+                
+            val mappedArgs = arguments.map { argument ->
+                argument.toSecuredTypeName(
+                    inheritedVarargArg = inheritedVarargArg,
+                    typeParameterResolver = typeParameterResolver,
+                    rootTypeArguments = rootTypeArguments,
+                )
+            }
+
+            val abbreviatedType = declaration.abbreviateType(
+                typeParameterResolver = extraResolver,
+                isNullable = isMarkedNullable,
+                typeArguments = mappedArgs
+            )
+
+            val aliasArgs = typeArguments.map { argument ->
+                argument.toSecuredTypeName(
+                    inheritedVarargArg = inheritedVarargArg,
+                    typeParameterResolver = typeParameterResolver,
+                    rootTypeArguments = rootTypeArguments,
+                )
+            }
+
+            declaration.parameterizedBy(abbreviatedType, aliasArgs)
+        }
+        else -> error("Unsupported type: $declaration")
+    }
+
+    return type.copy(nullable = (isMarkedNullable || overrideNullability))
+}
+
+private fun KSTypeReference.toSecuredTypeName(
+    inheritedVarargArg: Boolean,
+    typeParameterResolver: TypeParameterResolver,
+    rootTypeArguments: List<KSTypeArgument>,
+): TypeName {
+    val typeElements = element?.typeArguments.orEmpty()
+
+    return resolve().toSecuredTypeName(
+        inheritedVarargArg = inheritedVarargArg,
+        typeParameterResolver = typeParameterResolver,
+        typeArguments = typeElements,
+        rootTypeArguments = rootTypeArguments,
+    )
+}
+
+internal fun KSTypeReference.toSecuredTypeName(
+    inheritedVarargArg: Boolean,
+    typeParameterResolver: TypeParameterResolver,
+): TypeName {
+    val typeElements = element?.typeArguments.orEmpty()
+    val type = resolve()
+
+    return type.toSecuredTypeName(
+        inheritedVarargArg = inheritedVarargArg,
+        typeParameterResolver = typeParameterResolver,
+        typeArguments = typeElements,
+        rootTypeArguments = typeElements,
+    )
+}

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/KotlinPoet.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/KotlinPoet.kt
@@ -264,7 +264,7 @@ private fun KSType.toSecuredTypeName(
     }
 
     var overrideNullability = false
-    
+
     val type = when (val declaration = this.declaration) {
         is KSClassDeclaration -> {
             val arguments = arguments.map { argument ->
@@ -287,8 +287,8 @@ private fun KSType.toSecuredTypeName(
             typeParameterResolver[declaration.name.getShortName()]
         }
         is KSTypeAlias -> {
-            val extraResolver = extractAliasTypeResolver(declaration, typeParameterResolver) 
-                
+            val extraResolver = extractAliasTypeResolver(declaration, typeParameterResolver)
+
             val mappedArgs = arguments.map { argument ->
                 argument.toSecuredTypeName(
                     inheritedVarargArg = inheritedVarargArg,

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
@@ -299,6 +299,26 @@ class KMockMocksSpec {
     }
 
     @Test
+    fun `Given a annotated Source for Generics for a Platform with a supertype is processed, it writes a mock`() {
+        // Given
+        val source = SourceFile.kotlin(
+            "Platform.kt",
+            loadResource("/template/generic/SuperTyped.kt")
+        )
+        val expected = loadResource("/expected/generic/SuperTyped.kt")
+
+        // When
+        val compilerResult = compile(provider, source, isKmp = false)
+        val actual = resolveGenerated("SuperTypedMock.kt")
+
+        // Then
+        compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK
+        actual isNot null
+
+        actual!!.readText().normalizeSource() mustBe expected.normalizeSource()
+    }
+
+    @Test
     fun `Given a annotated Source for Generics for Shared is processed, it writes a mock`() {
         // Given
         val source = SourceFile.kotlin(

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -284,8 +284,6 @@ class KMockMultiInterfaceMocksSpec {
         val actualActualMockFactory = resolveGenerated("ksp/sources/kotlin/$rootPackage/MockFactory.kt")
         val actualExpectMockFactory = resolveGenerated("kotlin/common/commonTest/kotlin/$rootPackage/MockFactory.kt")
 
-        println(actualIntermediateInterfaces!!.readText())
-
         // Then
         compilerResultRound1.exitCode mustBe KotlinCompilation.ExitCode.OK
         actualIntermediateInterfaces isNot null
@@ -301,12 +299,12 @@ class KMockMultiInterfaceMocksSpec {
 
         // Round2
         // Given
-        val provider = ShallowSymbolProcessorProvider(spyProvider.lastProcessor)
+        val provider = SymbolProcessorProviderSpy()
         val multiInterfaceInterface = SourceFile.kotlin(
             "KMockMultiInterfaceArtifacts.kt",
             actualIntermediateInterfaces.readText()
         )
-        val expectedMock = loadResource("/expected/common/GenericMock.kt")
+        val expectedMock = loadResource("/expected/commonGeneric/GenericMock.kt")
 
         // When
         val compilerResultRound2 = compile(
@@ -319,8 +317,6 @@ class KMockMultiInterfaceMocksSpec {
         // Then
         compilerResultRound2.exitCode mustBe KotlinCompilation.ExitCode.OK
         actualMock isNot null
-
-        println(actualMock!!.readText())
 
         actualMock!!.absolutePath.toString().endsWith(
             "ksp/sources/kotlin/common/commonTest/kotlin/multi/CommonGenericMultiMock.kt"

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -294,7 +294,7 @@ class KMockMultiInterfaceMocksSpec {
             "ksp/sources/kotlin/$rootPackage/KMockMultiInterfaceArtifacts.kt"
         ) mustBe true
         actualIntermediateInterfaces.readText().normalizeSource() mustBe expectedInterface.normalizeSource()
-        //actualActualMockFactory!!.readText().normalizeSource() mustBe expectedActualFactory.normalizeSource()
+        actualActualMockFactory!!.readText().normalizeSource() mustBe expectedActualFactory.normalizeSource()
         //actualExpectMockFactory!!.readText().normalizeSource() mustBe expectedExpectFactory.normalizeSource()
 
         // Round2

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -249,4 +249,82 @@ class KMockMultiInterfaceMocksSpec {
         ) mustBe true
         actualMock.readText().normalizeSource() mustBe expectedMock.normalizeSource()
     }
+
+    @Test
+    fun `Given a annotated Source for generic Common with multiple Interface it writes a mock`() {
+        // Round1
+        // Given
+        val spyProvider = SymbolProcessorProviderSpy()
+        val rootInterface = SourceFile.kotlin(
+            "Generic1.kt",
+            loadResource("/template/commonGeneric/Generic1.kt")
+        )
+        val nestedInterface = SourceFile.kotlin(
+            "Generic2.kt",
+            loadResource("/template/commonGeneric/nested/Generic2.kt")
+        )
+        val scopedInterface = SourceFile.kotlin(
+            "Generic3.kt",
+            loadResource("/template/commonGeneric/Generic3.kt")
+        )
+        val expectedInterface = loadResource("/expected/commonGeneric/GenericInterface.kt")
+        val expectedActualFactory = loadResource("/expected/commonGeneric/GenericActualFactory.kt")
+        val expectedExpectFactory = loadResource("/expected/commonGeneric/GenericExpectFactory.kt")
+
+        // When
+        val compilerResultRound1 = compile(
+            spyProvider,
+            isKmp = true,
+            kspArguments = mapOf(
+                "${KMOCK_PREFIX}allowInterfaces" to "true"
+            ),
+            sourceFiles = arrayOf(rootInterface, nestedInterface, scopedInterface)
+        )
+        val actualIntermediateInterfaces = resolveGenerated("KMockMultiInterfaceArtifacts.kt")
+        val actualActualMockFactory = resolveGenerated("ksp/sources/kotlin/$rootPackage/MockFactory.kt")
+        val actualExpectMockFactory = resolveGenerated("kotlin/common/commonTest/kotlin/$rootPackage/MockFactory.kt")
+
+        println(actualIntermediateInterfaces!!.readText())
+
+        // Then
+        compilerResultRound1.exitCode mustBe KotlinCompilation.ExitCode.OK
+        actualIntermediateInterfaces isNot null
+        actualActualMockFactory isNot null
+        actualExpectMockFactory isNot null
+
+        actualIntermediateInterfaces!!.absolutePath.toString().endsWith(
+            "ksp/sources/kotlin/$rootPackage/KMockMultiInterfaceArtifacts.kt"
+        ) mustBe true
+        actualIntermediateInterfaces.readText().normalizeSource() mustBe expectedInterface.normalizeSource()
+        //actualActualMockFactory!!.readText().normalizeSource() mustBe expectedActualFactory.normalizeSource()
+        //actualExpectMockFactory!!.readText().normalizeSource() mustBe expectedExpectFactory.normalizeSource()
+
+        // Round2
+        // Given
+        val provider = ShallowSymbolProcessorProvider(spyProvider.lastProcessor)
+        val multiInterfaceInterface = SourceFile.kotlin(
+            "KMockMultiInterfaceArtifacts.kt",
+            actualIntermediateInterfaces.readText()
+        )
+        val expectedMock = loadResource("/expected/common/GenericMock.kt")
+
+        // When
+        val compilerResultRound2 = compile(
+            provider,
+            isKmp = true,
+            sourceFiles = arrayOf(multiInterfaceInterface, rootInterface, nestedInterface, scopedInterface)
+        )
+        val actualMock = resolveGenerated("CommonGenericMultiMock.kt")
+
+        // Then
+        compilerResultRound2.exitCode mustBe KotlinCompilation.ExitCode.OK
+        actualMock isNot null
+
+        println(actualMock!!.readText())
+
+        actualMock!!.absolutePath.toString().endsWith(
+            "ksp/sources/kotlin/common/commonTest/kotlin/multi/CommonGenericMultiMock.kt"
+        ) mustBe true
+        actualMock.readText().normalizeSource() mustBe expectedMock.normalizeSource()
+    }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -295,7 +295,7 @@ class KMockMultiInterfaceMocksSpec {
         ) mustBe true
         actualIntermediateInterfaces.readText().normalizeSource() mustBe expectedInterface.normalizeSource()
         actualActualMockFactory!!.readText().normalizeSource() mustBe expectedActualFactory.normalizeSource()
-        //actualExpectMockFactory!!.readText().normalizeSource() mustBe expectedExpectFactory.normalizeSource()
+        actualExpectMockFactory!!.readText().normalizeSource() mustBe expectedExpectFactory.normalizeSource()
 
         // Round2
         // Given

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMultiInterfaceMocksSpec.kt
@@ -37,11 +37,11 @@ class KMockMultiInterfaceMocksSpec {
     }
 
     // Workaround for https://github.com/tschuchortdev/kotlin-compile-testing/issues/263
-    class SymbolProcessorProviderSpy : SymbolProcessorProvider {
+    class SymbolProcessorProviderSpy(private val useTestFlag: Boolean = false) : SymbolProcessorProvider {
         lateinit var lastProcessor: SymbolProcessor
 
         override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
-            val processor = KMockProcessorProvider().create(environment)
+            val processor = KMockProcessorProvider(useTestFlag).create(environment)
             lastProcessor = processor
 
             return processor
@@ -257,7 +257,7 @@ class KMockMultiInterfaceMocksSpec {
     fun `Given a annotated Source for generic Common with multiple Interface it writes a mock`() {
         // Round1
         // Given
-        val spyProvider = SymbolProcessorProviderSpy()
+        val spyProvider = SymbolProcessorProviderSpy(true)
         val rootInterface = SourceFile.kotlin(
             "Generic1.kt",
             loadResource("/template/commonGeneric/Generic1.kt")
@@ -302,7 +302,7 @@ class KMockMultiInterfaceMocksSpec {
 
         // Round2
         // Given
-        val provider = SymbolProcessorProviderSpy()
+        val provider = ShallowSymbolProcessorProvider(spyProvider.lastProcessor)
         val multiInterfaceInterface = SourceFile.kotlin(
             "KMockMultiInterfaceArtifacts.kt",
             actualIntermediateInterfaces.readText()
@@ -331,7 +331,7 @@ class KMockMultiInterfaceMocksSpec {
     fun `Given a annotated Source for generic Common while spied with multiple Interface it writes a mock`() {
         // Round1
         // Given
-        val spyProvider = SymbolProcessorProviderSpy()
+        val spyProvider = SymbolProcessorProviderSpy(true)
         val rootInterface = SourceFile.kotlin(
             "Generic1.kt",
             loadResource("/template/commonGeneric/Generic1.kt")
@@ -377,7 +377,7 @@ class KMockMultiInterfaceMocksSpec {
 
         // Round2
         // Given
-        val provider = SymbolProcessorProviderSpy()
+        val provider = ShallowSymbolProcessorProvider(spyProvider.lastProcessor)
         val multiInterfaceInterface = SourceFile.kotlin(
             "KMockMultiInterfaceArtifacts.kt",
             actualIntermediateInterfaces.readText()

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
@@ -278,7 +278,7 @@ class KMockProcessorSpec {
         verify(exactly = 1) {
             mockGenerator.writeCommonMocks(
                 interfacesCommon,
-                Aggregated(emptyList(), emptyList(), emptyList()),
+                emptyList(),
                 relaxer,
             )
         }
@@ -426,7 +426,7 @@ class KMockProcessorSpec {
         verify(exactly = 1) {
             mockGenerator.writeCommonMocks(
                 interfacesCommonRound1,
-                Aggregated(emptyList(), emptyList(), emptyList()),
+                emptyList(),
                 relaxer
             )
         }
@@ -434,7 +434,7 @@ class KMockProcessorSpec {
         verify(exactly = 1) {
             mockGenerator.writeCommonMocks(
                 interfacesCommonRound2,
-                Aggregated(illegal, multiInterfacesCommon, dependenciesMultiCommon),
+                multiInterfacesCommon,
                 relaxer
             )
         }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockProcessorSpec.kt
@@ -41,6 +41,7 @@ class KMockProcessorSpec {
         KMockProcessor(
             mockk(),
             fixture.fixture(),
+            fixture.fixture(),
             mockk(),
             mockk(),
             mockk(),
@@ -98,6 +99,7 @@ class KMockProcessorSpec {
         // When
         val actual = KMockProcessor(
             mockk(),
+            false,
             true,
             mockk(relaxed = true),
             mockk(relaxed = true),
@@ -171,6 +173,7 @@ class KMockProcessorSpec {
         // When
         val processor = KMockProcessor(
             mockk(),
+            false,
             true,
             mockk(relaxed = true),
             mockk(relaxed = true),
@@ -262,6 +265,7 @@ class KMockProcessorSpec {
         // When
         KMockProcessor(
             mockk(),
+            false,
             true,
             codeGenerator,
             mockk(relaxed = true),
@@ -408,6 +412,7 @@ class KMockProcessorSpec {
         // When
         val processor = KMockProcessor(
             mockk(),
+            false,
             true,
             codeGenerator,
             interfaceBinder,
@@ -546,6 +551,7 @@ class KMockProcessorSpec {
         // When
         KMockProcessor(
             mockk(),
+            false,
             false,
             codeGenerator,
             mockk(),

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/MultiInterfaceBinderSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/MultiInterfaceBinderSpec.kt
@@ -16,6 +16,7 @@ class MultiInterfaceBinderSpec {
     fun `It fulfils MultiInterfaceBinder`() {
         KMockMultiInterfaceBinder(
             mockk(),
+            mockk(),
             "any",
             mockk()
         ) fulfils ProcessorContract.MultiInterfaceBinder::class

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/ParentFinderSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/ParentFinderSpec.kt
@@ -6,11 +6,9 @@
 
 package tech.antibytes.kmock.processor.multi
 
-import com.google.devtools.ksp.symbol.KSFile
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import tech.antibytes.kmock.processor.ProcessorContract
-import tech.antibytes.kmock.processor.ProcessorContract.Aggregated
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.kmock.processor.ProcessorContract.TemplateSource
 import tech.antibytes.util.test.fixture.fixture
@@ -50,20 +48,14 @@ class ParentFinderSpec {
             dependencies = emptyList()
         )
 
-        val multiDependency: KSFile = mockk()
-
         // When
         val parents = KMockParentFinder.find(
             templateSource = templateSource,
-            templateMultiSources = Aggregated(
-                illFormed = emptyList(),
-                extractedTemplates = listOf(templateMultiSource),
-                totalDependencies = listOf(multiDependency)
-            ),
+            templateMultiSources = listOf(templateMultiSource),
         )
 
         // Then
-        parents mustBe emptyList()
+        parents mustBe null
     }
 
     @Test
@@ -90,20 +82,14 @@ class ParentFinderSpec {
             dependencies = emptyList()
         )
 
-        val multiDependency: KSFile = mockk()
-
         // When
         val parents = KMockParentFinder.find(
             templateSource = templateSource,
-            templateMultiSources = Aggregated(
-                illFormed = emptyList(),
-                extractedTemplates = listOf(templateMultiSource),
-                totalDependencies = listOf(multiDependency)
-            ),
+            templateMultiSources = listOf(templateMultiSource),
         )
 
         // Then
-        parents mustBe emptyList()
+        parents mustBe null
     }
 
     @Test
@@ -130,20 +116,14 @@ class ParentFinderSpec {
             dependencies = emptyList()
         )
 
-        val multiDependency: KSFile = mockk()
-
         // When
         val parents = KMockParentFinder.find(
             templateSource = templateSource,
-            templateMultiSources = Aggregated(
-                illFormed = emptyList(),
-                extractedTemplates = listOf(templateMultiSource),
-                totalDependencies = listOf(multiDependency)
-            ),
+            templateMultiSources = listOf(templateMultiSource),
         )
 
         // Then
-        parents mustBe emptyList()
+        parents mustBe null
     }
 
     @Test
@@ -171,19 +151,13 @@ class ParentFinderSpec {
             dependencies = emptyList()
         )
 
-        val multiDependency: KSFile = mockk()
-
         // When
         val parents = KMockParentFinder.find(
             templateSource = templateSource,
-            templateMultiSources = Aggregated(
-                illFormed = emptyList(),
-                extractedTemplates = listOf(templateMultiSource),
-                totalDependencies = listOf(multiDependency)
-            ),
+            templateMultiSources = listOf(templateMultiSource),
         )
 
         // Then
-        parents mustBe templateMultiSource.templates
+        parents mustBe templateMultiSource
     }
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/TemplateMultiSourceSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/TemplateMultiSourceSpec.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.multi
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
+import tech.antibytes.util.test.mustBe
+
+class TemplateMultiSourceSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    fun `Given hasGenerics is called, it returns false if no actual generics had been captured`() {
+        // Given
+        val source = TemplateMultiSource(
+            indicator = fixture.fixture(),
+            templateName = fixture.fixture(),
+            packageName = fixture.fixture(),
+            dependencies = emptyList(),
+            templates = emptyList(),
+            generics = listOf(null, null, null, null)
+        )
+
+        // When
+        val actual = source.hasGenerics()
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given hasGenerics is called, it returns true if at least one actual generics had been captured`() {
+        // Given
+        val source = TemplateMultiSource(
+            indicator = fixture.fixture(),
+            templateName = fixture.fixture(),
+            packageName = fixture.fixture(),
+            dependencies = emptyList(),
+            templates = emptyList(),
+            generics = listOf(null, null, mockk(), null)
+        )
+
+        // When
+        val actual = source.hasGenerics()
+
+        // Then
+        actual mustBe true
+    }
+}

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/TemplateMultiSourceSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/multi/TemplateMultiSourceSpec.kt
@@ -8,9 +8,9 @@ package tech.antibytes.kmock.processor.multi
 
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
-import tech.antibytes.kmock.processor.ProcessorContract.TemplateMultiSource
 import tech.antibytes.util.test.mustBe
 
 class TemplateMultiSourceSpec {

--- a/kmock-processor/src/test/resources/mock/expected/generic/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/Platform.kt
@@ -48,6 +48,10 @@ internal class PlatformMock<K : Any, L>(
         = ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithAnys", collector
     = verifier, freeze = freeze)
 
+    public val _lol: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Array<out kotlin.Any>>) ->
+    kotlin.Unit> = ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_lol",
+        collector = verifier, freeze = freeze)
+
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blaWithVoid", collector =
         verifier, freeze = freeze)
@@ -340,6 +344,10 @@ internal class PlatformMock<K : Any, L>(
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
+    public override fun lol(vararg payload: Array<out Any>): Unit = _lol.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
     @Suppress("UNCHECKED_CAST")
     public override fun <T : Int> bla(): T = _blaWithVoid.invoke() as T
 
@@ -590,6 +598,7 @@ internal class PlatformMock<K : Any, L>(
         _fooWithVoid.clear()
         _fooWithAny.clear()
         _fooWithAnys.clear()
+        _lol.clear()
         _blaWithVoid.clear()
         _blaWithInt.clear()
         _blaWithInts.clear()

--- a/kmock-processor/src/test/resources/mock/expected/generic/SuperTyped.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/SuperTyped.kt
@@ -1,0 +1,149 @@
+package mock.template.generic
+
+import kotlin.Any
+import kotlin.Array
+import kotlin.Boolean
+import kotlin.CharSequence
+import kotlin.Comparable
+import kotlin.Int
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+import tech.antibytes.kmock.proxy.ProxyFactory
+
+internal class SuperTypedMock<K : Any, L>(
+    verifier: KMockContract.Collector = NoopCollector,
+    @Suppress("UNUSED_PARAMETER")
+    spyOn: SuperTyped<K, L>? = null,
+    freeze: Boolean = true,
+    @Suppress("unused")
+    private val relaxUnitFun: Boolean = false,
+    @Suppress("unused")
+    private val relaxed: Boolean = false,
+) : SuperTyped<K, L> where L : Any, L : Comparable<L> {
+    public val _pptWithAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit>
+        = ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithAnys",
+        collector = verifier, freeze = freeze)
+
+    public val _pptWithCharSequenceComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Any>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithCharSequenceComparables",
+            collector = verifier, freeze = freeze)
+
+    public val _pptWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Comparable<Any?>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithComparables",
+            collector = verifier, freeze = freeze)
+
+    public val _pptWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithAny", collector
+        = verifier, freeze = freeze)
+
+    public val _pptWithCharSequenceComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithCharSequenceComparable",
+            collector = verifier, freeze = freeze)
+
+    public val _pptWithComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<Any?>) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithComparable",
+            collector = verifier, freeze = freeze)
+
+    public val _lolWithAnyComparables: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    kotlin.Comparable<Any?>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithAnyComparables",
+            collector = verifier, freeze = freeze)
+
+    public val _lolWithAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit>
+        = ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithAnys",
+        collector = verifier, freeze = freeze)
+
+    public val _lolWithAnyComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+        kotlin.Comparable<Any?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithAnyComparable",
+            collector = verifier, freeze = freeze)
+
+    public val _lolWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithAny", collector
+        = verifier, freeze = freeze)
+
+    public val _buzz: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_buzz", collector =
+        verifier, freeze = freeze)
+
+    public val _narv: KMockContract.SyncFunProxy<Unit, (Array<out L>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_narv", collector =
+        verifier, freeze = freeze)
+
+    public override fun <T> ppt(vararg x: T): Unit = _pptWithAnys.invoke(x) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T> ppt(vararg x: T): Unit where T : CharSequence, T : Comparable<T> =
+        _pptWithCharSequenceComparables.invoke(x) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : Comparable<T>> ppt(vararg x: T): Unit = _pptWithComparables.invoke(x) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T> ppt(x: T): Unit = _pptWithAny.invoke(x) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T> ppt(x: T): Unit where T : CharSequence, T : Comparable<T> =
+        _pptWithCharSequenceComparable.invoke(x) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : Comparable<T>> ppt(x: T): Unit = _pptWithComparable.invoke(x) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : Comparable<T>, K> lol(arg: K, vararg x: T): Unit =
+        _lolWithAnyComparables.invoke(arg, x) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : K, K> lol(vararg x: T): Unit = _lolWithAnys.invoke(x) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : Comparable<T>, K> lol(arg: K, x: T): Unit =
+        _lolWithAnyComparable.invoke(arg, x) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : K, K> lol(x: T): Unit = _lolWithAny.invoke(x) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <nulled : List<Array<Int>>> buzz(vararg payload: nulled?): Unit =
+        _buzz.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun narv(vararg x: L): Unit = _narv.invoke(x) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public fun _clearMock(): Unit {
+        _pptWithAnys.clear()
+        _pptWithCharSequenceComparables.clear()
+        _pptWithComparables.clear()
+        _pptWithAny.clear()
+        _pptWithCharSequenceComparable.clear()
+        _pptWithComparable.clear()
+        _lolWithAnyComparables.clear()
+        _lolWithAnys.clear()
+        _lolWithAnyComparable.clear()
+        _lolWithAny.clear()
+        _buzz.clear()
+        _narv.clear()
+    }
+}

--- a/kmock-processor/src/test/resources/mock/template/generic/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/template/generic/Platform.kt
@@ -19,6 +19,8 @@ interface Platform<K, L> where L : Any, L : Comparable<L>, K : Any {
     fun <T> foo(payload: T)
     fun <T> foo(vararg payload: T)
 
+    fun lol(vararg payload: Array<out Any>)
+
     fun <T : Int> bla(): T
     fun <T : Int> bla(payload: T)
     fun <T : Int> bla(vararg payload: T)

--- a/kmock-processor/src/test/resources/mock/template/generic/SuperTyped.kt
+++ b/kmock-processor/src/test/resources/mock/template/generic/SuperTyped.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package mock.template.generic
+
+import tech.antibytes.kmock.Mock
+
+@Mock(SuperTyped::class)
+interface SuperTyped<K, L> : Parent<K, L> where L : Any, L : Comparable<L>, K : Any
+
+interface Parent<K, L> where L : Any, L : Comparable<L>, K : Any {
+    fun <T> ppt(vararg x: T)
+    fun <T> ppt(vararg x: T) where T : CharSequence, T : Comparable<T>
+    fun <T> ppt(vararg x: T) where T : Comparable<T>
+    fun <T, K> lol(arg: K, vararg x: T) where T : Comparable<T>
+    fun <T, K> lol(vararg x: T) where T : K
+
+    fun <nulled : List<Array<Int>>> buzz(vararg payload: nulled?)
+
+    fun <T> ppt(x: T)
+    fun <T> ppt(x: T) where T : CharSequence, T : Comparable<T>
+    fun <T> ppt(x: T) where T : Comparable<T>
+    fun <T, K> lol(arg: K, x: T) where T : Comparable<T>
+    fun <T, K> lol(x: T) where T : K
+
+    fun narv(vararg x: L)
+}

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericActualFactory.kt
@@ -1,0 +1,33 @@
+@file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+
+package multi.expected.commonGeneric
+
+import kotlin.Boolean
+import kotlin.Suppress
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+
+private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+): Mock = when (Mock::class) {
+    multi.CommonMultiMock::class -> multi.CommonMultiMock<multi.CommonMultiMock<*>>(verifier =
+    verifier, relaxUnitFun = relaxUnitFun, freeze = freeze) as Mock
+    else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
+}
+
+internal actual inline fun <reified Mock> kmock(
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+): Mock = getMockInstance(
+    spyOn = null,
+    verifier = verifier,
+    relaxed = relaxed,
+    relaxUnitFun = relaxUnitFun,
+    freeze = freeze,
+)

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericActualFactory.kt
@@ -1,9 +1,14 @@
 @file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
 
-package multi.expected.commonGeneric
+package multi
 
+import kotlin.Any
 import kotlin.Boolean
+import kotlin.Comparable
 import kotlin.Suppress
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.nested.Generic2
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -14,8 +19,6 @@ private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
     relaxUnitFun: Boolean,
     freeze: Boolean,
 ): Mock = when (Mock::class) {
-    multi.CommonMultiMock::class -> multi.CommonMultiMock<multi.CommonMultiMock<*>>(verifier =
-    verifier, relaxUnitFun = relaxUnitFun, freeze = freeze) as Mock
     else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
 }
 
@@ -30,4 +33,56 @@ internal actual inline fun <reified Mock> kmock(
     relaxed = relaxed,
     relaxUnitFun = relaxUnitFun,
     freeze = freeze,
+)
+
+private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : Any,
+    KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4,
+    KMockTypeParameter5> getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
+        KMockTypeParameter1>>,
+    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
+        KMockTypeParameter3>>,
+    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
+        KMockTypeParameter5>>,
+): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
+              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
+              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
+    multi.CommonGenericMultiMock::class) {
+    multi.CommonGenericMultiMock(verifier = verifier, freeze = freeze, spyOn = spyOn as SpyOn?) as
+        Mock
+} else {
+    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+
+internal actual inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
+    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> kmock(
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
+        KMockTypeParameter1>>,
+    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
+        KMockTypeParameter3>>,
+    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
+        KMockTypeParameter5>>,
+): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, Mock :
+              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
+              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = getMockInstance(
+    spyOn = null,
+    verifier = verifier,
+    relaxed = relaxed,
+    relaxUnitFun = relaxUnitFun,
+    freeze = freeze,
+    templateType0 = templateType0,
+    templateType1 = templateType1,
+    templateType2 = templateType2,
 )

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericExpectFactory.kt
@@ -1,0 +1,16 @@
+@file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+
+package multi.expected.commonGeneric
+
+import kotlin.Boolean
+import kotlin.Suppress
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+
+internal expect inline fun <reified Mock> kmock(
+    verifier: KMockContract.Collector = NoopCollector,
+    relaxed: Boolean = false,
+    relaxUnitFun: Boolean = false,
+    freeze: Boolean = true,
+): Mock

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericExpectFactory.kt
@@ -1,9 +1,14 @@
 @file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
 
-package multi.expected.commonGeneric
+package multi
 
+import kotlin.Any
 import kotlin.Boolean
+import kotlin.Comparable
 import kotlin.Suppress
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.nested.Generic2
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -14,3 +19,21 @@ internal expect inline fun <reified Mock> kmock(
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
 ): Mock
+
+internal expect inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
+    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> kmock(
+    verifier: KMockContract.Collector = NoopCollector,
+    relaxed: Boolean = false,
+    relaxUnitFun: Boolean = false,
+    freeze: Boolean = true,
+    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
+        KMockTypeParameter1>>,
+    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
+        KMockTypeParameter3>>,
+    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
+        KMockTypeParameter5>>,
+): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, Mock :
+              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
+              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3>

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericInterface.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericInterface.kt
@@ -1,0 +1,13 @@
+package multi
+
+import kotlin.Any
+import kotlin.Comparable
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.nested.Generic2
+import tech.antibytes.kmock.MockCommon
+
+@MockCommon(CommonGenericMulti::class)
+private interface CommonGenericMulti<T0 : Any, T1, T3 : Any, T4, T6, T7> : Generic1<T0, T1>,
+    Generic2<T3, T4>, GenericCommonContract.Generic3<T6, T7> where T1 : Any, T1 : Comparable<T1>, T4
+: Any, T4 : Comparable<T4>

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericInterface.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericInterface.kt
@@ -8,6 +8,10 @@ import multi.template.commonGeneric.nested.Generic2
 import tech.antibytes.kmock.MockCommon
 
 @MockCommon(CommonGenericMulti::class)
-private interface CommonGenericMulti<T0 : Any, T1, T3 : Any, T4, T6, T7> : Generic1<T0, T1>,
-    Generic2<T3, T4>, GenericCommonContract.Generic3<T6, T7> where T1 : Any, T1 : Comparable<T1>, T4
-: Any, T4 : Comparable<T4>
+private interface CommonGenericMulti<KMockTypeParameter0 : Any, KMockTypeParameter1,
+    KMockTypeParameter3 : Any, KMockTypeParameter4, KMockTypeParameter6, KMockTypeParameter7> :
+    Generic1<KMockTypeParameter0, KMockTypeParameter1>,
+    Generic2<KMockTypeParameter3, KMockTypeParameter4>,
+    GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> where
+KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+KMockTypeParameter4 : Any, KMockTypeParameter4 : Comparable<KMockTypeParameter4>

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericInterface.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericInterface.kt
@@ -9,9 +9,9 @@ import tech.antibytes.kmock.MockCommon
 
 @MockCommon(CommonGenericMulti::class)
 private interface CommonGenericMulti<KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter3 : Any, KMockTypeParameter4, KMockTypeParameter6, KMockTypeParameter7> :
+    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> :
     Generic1<KMockTypeParameter0, KMockTypeParameter1>,
-    Generic2<KMockTypeParameter3, KMockTypeParameter4>,
-    GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> where
+    Generic2<KMockTypeParameter2, KMockTypeParameter3>,
+    GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> where
 KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
-KMockTypeParameter4 : Any, KMockTypeParameter4 : Comparable<KMockTypeParameter4>
+KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3>

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
@@ -1,0 +1,75 @@
+package multi.expected.commonGeneric
+
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import multi.template.common.CommonContractRegular
+import multi.template.common.Regular1
+import multi.template.common.nested.Regular3
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+import tech.antibytes.kmock.proxy.ProxyFactory
+
+internal class CommonMultiMock<MultiMock>(
+    verifier: KMockContract.Collector = NoopCollector,
+    @Suppress("UNUSED_PARAMETER")
+    spyOn: MultiMock? = null,
+    freeze: Boolean = true,
+    @Suppress("unused")
+    private val relaxUnitFun: Boolean = false,
+    @Suppress("unused")
+    private val relaxed: Boolean = false,
+) : Regular1, CommonContractRegular.Regular2, Regular3 where MultiMock : Regular1, MultiMock :
+CommonContractRegular.Regular2, MultiMock : Regular3 {
+    public override val something: Int
+        get() = _something.onGet()
+
+    public val _something: KMockContract.PropertyProxy<Int> =
+        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_something", collector = verifier,
+            freeze = freeze)
+
+    public override val anything: Any
+        get() = _anything.onGet()
+
+    public val _anything: KMockContract.PropertyProxy<Any> =
+        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_anything", collector = verifier,
+            freeze = freeze)
+
+    public override val somethingElse: String
+        get() = _somethingElse.onGet()
+
+    public val _somethingElse: KMockContract.PropertyProxy<String> =
+        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_somethingElse", collector = verifier,
+            freeze = freeze)
+
+    public val _doSomething: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doSomething", collector = verifier,
+            freeze = freeze)
+
+    public val _doAnything: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doAnything", collector = verifier,
+            freeze = freeze)
+
+    public val _doSomethingElse: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
+        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doSomethingElse", collector =
+        verifier, freeze = freeze)
+
+    public override fun doSomething(): Int = _doSomething.invoke()
+
+    public override fun doAnything(): Any = _doAnything.invoke()
+
+    public override fun doSomethingElse(): String = _doSomethingElse.invoke()
+
+    public fun _clearMock(): Unit {
+        _something.clear()
+        _anything.clear()
+        _somethingElse.clear()
+        _doSomething.clear()
+        _doAnything.clear()
+        _doSomethingElse.clear()
+    }
+}

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
@@ -1,20 +1,30 @@
-package multi.expected.commonGeneric
+package multi
 
 import kotlin.Any
+import kotlin.Array
 import kotlin.Boolean
+import kotlin.Char
+import kotlin.CharSequence
+import kotlin.Comparable
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
-import multi.template.common.CommonContractRegular
-import multi.template.common.Regular1
-import multi.template.common.nested.Regular3
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.sequences.Sequence
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.SomeGeneric
+import multi.template.commonGeneric.nested.Generic2
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
 
-internal class CommonMultiMock<MultiMock>(
+internal class CommonGenericMultiMock<KMockTypeParameter0 : Any, KMockTypeParameter1,
+    KMockTypeParameter3 : Any, KMockTypeParameter4, KMockTypeParameter6, KMockTypeParameter7,
+    MultiMock>(
     verifier: KMockContract.Collector = NoopCollector,
     @Suppress("UNUSED_PARAMETER")
     spyOn: MultiMock? = null,
@@ -23,53 +33,513 @@ internal class CommonMultiMock<MultiMock>(
     private val relaxUnitFun: Boolean = false,
     @Suppress("unused")
     private val relaxed: Boolean = false,
-) : Regular1, CommonContractRegular.Regular2, Regular3 where MultiMock : Regular1, MultiMock :
-CommonContractRegular.Regular2, MultiMock : Regular3 {
-    public override val something: Int
-        get() = _something.onGet()
+) : Generic1<KMockTypeParameter0, KMockTypeParameter1>,
+    Generic2<KMockTypeParameter3, KMockTypeParameter4>,
+    GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> where
+KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+KMockTypeParameter4 : Any, KMockTypeParameter4 : Comparable<KMockTypeParameter4>, MultiMock :
+Generic1<KMockTypeParameter0, KMockTypeParameter1>, MultiMock :
+Generic2<KMockTypeParameter3, KMockTypeParameter4>, MultiMock :
+GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
+    public override var template: KMockTypeParameter1
+        get() = _template.onGet()
+        set(`value`) = _template.onSet(value)
 
-    public val _something: KMockContract.PropertyProxy<Int> =
-        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_something", collector = verifier,
-            freeze = freeze)
-
-    public override val anything: Any
-        get() = _anything.onGet()
-
-    public val _anything: KMockContract.PropertyProxy<Any> =
-        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_anything", collector = verifier,
-            freeze = freeze)
-
-    public override val somethingElse: String
-        get() = _somethingElse.onGet()
-
-    public val _somethingElse: KMockContract.PropertyProxy<String> =
-        ProxyFactory.createPropertyProxy("multi.CommonMultiMock#_somethingElse", collector = verifier,
-            freeze = freeze)
-
-    public val _doSomething: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
-        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doSomething", collector = verifier,
-            freeze = freeze)
-
-    public val _doAnything: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doAnything", collector = verifier,
-            freeze = freeze)
-
-    public val _doSomethingElse: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("multi.CommonMultiMock#_doSomethingElse", collector =
+    public val _template: KMockContract.PropertyProxy<KMockTypeParameter1> =
+        ProxyFactory.createPropertyProxy("multi.CommonGenericMultiMock#_template", collector =
         verifier, freeze = freeze)
 
-    public override fun doSomething(): Int = _doSomething.invoke()
+    public override val lol: KMockTypeParameter3
+        get() = _lol.onGet()
 
-    public override fun doAnything(): Any = _doAnything.invoke()
+    public val _lol: KMockContract.PropertyProxy<KMockTypeParameter3> =
+        ProxyFactory.createPropertyProxy("multi.CommonGenericMultiMock#_lol", collector = verifier,
+            freeze = freeze)
 
-    public override fun doSomethingElse(): String = _doSomethingElse.invoke()
+    public val _fooWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _fooWithAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit>
+        = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithAnys", collector =
+    verifier, freeze = freeze)
+
+    public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blaWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _blaWithInt: KMockContract.SyncFunProxy<Unit, (kotlin.Int) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blaWithInt", collector =
+        verifier, freeze = freeze)
+
+    public val _blaWithInts: KMockContract.SyncFunProxy<Unit, (kotlin.IntArray) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blaWithInts", collector =
+        verifier, freeze = freeze)
+
+    public val _barWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String>>, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.String>>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_barWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _barWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String>>) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_barWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _barWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_barWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _blubbWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String?>>, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.String?>>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blubbWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _blubbWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String?>>) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blubbWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _blubbWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blubbWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _bussWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _bussWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _bussWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _bossWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>?>, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.Int>?>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bossWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _bossWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>?>) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bossWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _bossWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bossWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _buzzWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_buzzWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _buzzWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_buzzWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _buzzWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_buzzWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _ozzWithVoid: KMockContract.SyncFunProxy<KMockTypeParameter1, () ->
+    KMockTypeParameter1> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _ozzWithKMockTypeParameter4: KMockContract.SyncFunProxy<Unit, (KMockTypeParameter4) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter4",
+            collector = verifier, freeze = freeze)
+
+    public val _ozzWithKMockTypeParameter4s: KMockContract.SyncFunProxy<Unit, (Array<out
+    KMockTypeParameter4>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter4s",
+            collector = verifier, freeze = freeze)
+
+    public val _brassWithVoid:
+        KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>, () ->
+        kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_brassWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _brassWithComparable:
+        KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>) ->
+        kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_brassWithComparable", collector
+        = verifier, freeze = freeze)
+
+    public val _brassWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_brassWithComparables",
+            collector = verifier, freeze = freeze)
+
+    public val _blissWithVoid:
+        KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?, () ->
+        kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _blissWithComparable:
+        KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
+        kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithComparable", collector
+        = verifier, freeze = freeze)
+
+    public val _blissWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithComparables",
+            collector = verifier, freeze = freeze)
+
+    public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
+        kotlin.String>, () -> kotlin.collections.Map<kotlin.String, kotlin.String>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lossWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _lossWithMap: KMockContract.SyncFunProxy<Unit, (kotlin.collections.Map<kotlin.String,
+        kotlin.String>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lossWithMap", collector =
+        verifier, freeze = freeze)
+
+    public val _lossWithMaps: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lossWithMaps", collector =
+        verifier, freeze = freeze)
+
+    public val _uzz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_uzz", collector = verifier,
+            freeze = freeze)
+
+    public val _lzz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lzz", collector = verifier,
+            freeze = freeze)
+
+    public val _tzz: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_tzz", collector = verifier,
+            freeze = freeze)
+
+    public val _rzz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_rzz", collector = verifier,
+            freeze = freeze)
+
+    public val _izz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_izz", collector = verifier,
+            freeze = freeze)
+
+    public val _ossWithAny: KMockContract.SyncFunProxy<Any?, (kotlin.Any?) -> kotlin.Any?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _ossWithAnyAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithAnyAny",
+        collector = verifier, freeze = freeze)
+
+    public val _ossWithAnyAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    kotlin.Any?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithAnyAnys", collector =
+        verifier, freeze = freeze)
+
+    public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_kss", collector = verifier,
+            freeze = freeze)
+
+    public val _iss: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_iss", collector = verifier,
+            freeze = freeze)
+
+    public val _pss:
+        KMockContract.SyncFunProxy<multi.template.commonGeneric.SomeGeneric<kotlin.String>, (multi.template.commonGeneric.SomeGeneric<kotlin.String>) ->
+        multi.template.commonGeneric.SomeGeneric<kotlin.String>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_pss", collector = verifier,
+            freeze = freeze)
+
+    public val _xssWithAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _xssWithAnySequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+        kotlin.Any) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithAnySequenceCharSequence",
+            collector = verifier, freeze = freeze)
+
+    public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter7, (KMockTypeParameter6) ->
+    KMockTypeParameter7> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_doSomething", collector =
+        verifier, freeze = freeze)
+
+    public val _compareTo:
+        KMockContract.SyncFunProxy<Int, (multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter7,
+            KMockTypeParameter6>) -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_compareTo", collector =
+        verifier, freeze = freeze)
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> foo(): T = _fooWithVoid.invoke() as T
+
+    public override fun <T> foo(payload: T): Unit = _fooWithAny.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithAnys.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Int> bla(): T = _blaWithVoid.invoke() as T
+
+    public override fun <T : Int> bla(payload: T): Unit = _blaWithInt.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : Int> bla(vararg payload: T): Unit = _blaWithInts.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<String>>> bar(): T = _barWithVoid.invoke() as T
+
+    public override fun <T : List<Array<String>>> bar(payload: T): Unit = _barWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : List<Array<String>>> bar(vararg payload: T): Unit =
+        _barWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<String?>>> blubb(): T = _blubbWithVoid.invoke() as T
+
+    public override fun <T : List<Array<String?>>> blubb(payload: T): Unit =
+        _blubbWithList.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : List<Array<String?>>> blubb(vararg payload: T): Unit =
+        _blubbWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() as T
+
+    public override fun <T : List<Array<Int>>?> buss(payload: T): Unit = _bussWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
+        _bussWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<Int>?>> boss(): T = _bossWithVoid.invoke() as T
+
+    public override fun <T : List<Array<Int>?>> boss(payload: T): Unit = _bossWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : List<Array<Int>?>> boss(vararg payload: T): Unit =
+        _bossWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<Int>>> buzz(): T? = _buzzWithVoid.invoke() as T?
+
+    public override fun <T : List<Array<Int>>> buzz(payload: T?): Unit = _buzzWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : List<Array<Int>>> buzz(vararg payload: T?): Unit =
+        _buzzWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : KMockTypeParameter1> ozz(): T = _ozzWithVoid.invoke() as T
+
+    public override fun <T : KMockTypeParameter4> ozz(payload: T): Unit =
+        _ozzWithKMockTypeParameter4.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : KMockTypeParameter4> ozz(vararg payload: T): Unit =
+        _ozzWithKMockTypeParameter4s.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Comparable<List<Array<T>>>> brass(): T = _brassWithVoid.invoke() as T
+
+    public override fun <T : Comparable<List<Array<T>>>> brass(payload: T): Unit =
+        _brassWithComparable.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : Comparable<List<Array<T>>>> brass(vararg payload: T): Unit =
+        _brassWithComparables.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() as T
+
+    public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
+        _blissWithComparable.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
+        _blissWithComparables.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Map<String, String>> loss(): T = _lossWithVoid.invoke() as T
+
+    public override fun <T : Map<String, String>> loss(payload: T): Unit =
+        _lossWithMap.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : Map<String, String>> loss(vararg payload: T): Unit =
+        _lossWithMaps.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> uzz(): T where T : SomeGeneric<String>, T : List<String> = _uzz.invoke()
+        as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> lzz(): T where T : SomeGeneric<String>, T : List<String>? = _lzz.invoke()
+        as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> tzz(): T where T : SomeGeneric<String>?, T : List<String>? = _tzz.invoke()
+        as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> rzz(): T where T : SomeGeneric<String>, T : Map<String, String> =
+        _rzz.invoke() as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> izz(): T where T : SomeGeneric<String>, T : Comparable<List<Array<T>>> =
+        _izz.invoke() as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : R, R> oss(arg0: T): R = _ossWithAny.invoke(arg0) as R
+
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithAnyAny.invoke(arg0, arg1) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithAnyAnys.invoke(arg0,
+        arg1) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
+    Comparable<List<Array<R>>> = _kss.invoke(arg0) as R
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
+    Comparable<List<Array<T>>> = _iss.invoke(arg0) as R
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <R : T, T : X, X : SomeGeneric<String>> pss(arg0: T): R = _pss.invoke(arg0) as
+        R
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
+        _xssWithAny.invoke(arg0) as R
+
+    public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
+        = _xssWithAnySequenceCharSequence.invoke(arg0, arg1) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun doSomething(arg: KMockTypeParameter6): KMockTypeParameter7 =
+        _doSomething.invoke(arg)
+
+    public override
+    fun compareTo(other: GenericCommonContract.Generic3<KMockTypeParameter7, KMockTypeParameter6>):
+        Int = _compareTo.invoke(other)
 
     public fun _clearMock(): Unit {
-        _something.clear()
-        _anything.clear()
-        _somethingElse.clear()
+        _template.clear()
+        _lol.clear()
+        _fooWithVoid.clear()
+        _fooWithAny.clear()
+        _fooWithAnys.clear()
+        _blaWithVoid.clear()
+        _blaWithInt.clear()
+        _blaWithInts.clear()
+        _barWithVoid.clear()
+        _barWithList.clear()
+        _barWithLists.clear()
+        _blubbWithVoid.clear()
+        _blubbWithList.clear()
+        _blubbWithLists.clear()
+        _bussWithVoid.clear()
+        _bussWithList.clear()
+        _bussWithLists.clear()
+        _bossWithVoid.clear()
+        _bossWithList.clear()
+        _bossWithLists.clear()
+        _buzzWithVoid.clear()
+        _buzzWithList.clear()
+        _buzzWithLists.clear()
+        _ozzWithVoid.clear()
+        _ozzWithKMockTypeParameter4.clear()
+        _ozzWithKMockTypeParameter4s.clear()
+        _brassWithVoid.clear()
+        _brassWithComparable.clear()
+        _brassWithComparables.clear()
+        _blissWithVoid.clear()
+        _blissWithComparable.clear()
+        _blissWithComparables.clear()
+        _lossWithVoid.clear()
+        _lossWithMap.clear()
+        _lossWithMaps.clear()
+        _uzz.clear()
+        _lzz.clear()
+        _tzz.clear()
+        _rzz.clear()
+        _izz.clear()
+        _ossWithAny.clear()
+        _ossWithAnyAny.clear()
+        _ossWithAnyAnys.clear()
+        _kss.clear()
+        _iss.clear()
+        _pss.clear()
+        _xssWithAny.clear()
+        _xssWithAnySequenceCharSequence.clear()
         _doSomething.clear()
-        _doAnything.clear()
-        _doSomethingElse.clear()
+        _compareTo.clear()
     }
 }

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
@@ -23,7 +23,7 @@ import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
 
 internal class CommonGenericMultiMock<KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter3 : Any, KMockTypeParameter4, KMockTypeParameter6, KMockTypeParameter7,
+    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5,
     MultiMock>(
     verifier: KMockContract.Collector = NoopCollector,
     @Suppress("UNUSED_PARAMETER")
@@ -34,13 +34,13 @@ internal class CommonGenericMultiMock<KMockTypeParameter0 : Any, KMockTypeParame
     @Suppress("unused")
     private val relaxed: Boolean = false,
 ) : Generic1<KMockTypeParameter0, KMockTypeParameter1>,
-    Generic2<KMockTypeParameter3, KMockTypeParameter4>,
-    GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> where
+    Generic2<KMockTypeParameter2, KMockTypeParameter3>,
+    GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> where
 KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
-KMockTypeParameter4 : Any, KMockTypeParameter4 : Comparable<KMockTypeParameter4>, MultiMock :
+KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3>, MultiMock :
 Generic1<KMockTypeParameter0, KMockTypeParameter1>, MultiMock :
-Generic2<KMockTypeParameter3, KMockTypeParameter4>, MultiMock :
-GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, MultiMock :
+GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     public override var template: KMockTypeParameter1
         get() = _template.onGet()
         set(`value`) = _template.onSet(value)
@@ -49,10 +49,10 @@ GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
         ProxyFactory.createPropertyProxy("multi.CommonGenericMultiMock#_template", collector =
         verifier, freeze = freeze)
 
-    public override val lol: KMockTypeParameter3
+    public override val lol: KMockTypeParameter2
         get() = _lol.onGet()
 
-    public val _lol: KMockContract.PropertyProxy<KMockTypeParameter3> =
+    public val _lol: KMockContract.PropertyProxy<KMockTypeParameter2> =
         ProxyFactory.createPropertyProxy("multi.CommonGenericMultiMock#_lol", collector = verifier,
             freeze = freeze)
 
@@ -165,14 +165,14 @@ GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _ozzWithKMockTypeParameter4: KMockContract.SyncFunProxy<Unit, (KMockTypeParameter4) ->
+    public val _ozzWithKMockTypeParameter3: KMockContract.SyncFunProxy<Unit, (KMockTypeParameter3) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter4",
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter3",
             collector = verifier, freeze = freeze)
 
-    public val _ozzWithKMockTypeParameter4s: KMockContract.SyncFunProxy<Unit, (Array<out
-    KMockTypeParameter4>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter4s",
+    public val _ozzWithKMockTypeParameter3s: KMockContract.SyncFunProxy<Unit, (Array<out
+    KMockTypeParameter3>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter3s",
             collector = verifier, freeze = freeze)
 
     public val _brassWithVoid:
@@ -280,14 +280,14 @@ GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithAnySequenceCharSequence",
             collector = verifier, freeze = freeze)
 
-    public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter7, (KMockTypeParameter6) ->
-    KMockTypeParameter7> =
+    public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
+    KMockTypeParameter5> =
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_doSomething", collector =
         verifier, freeze = freeze)
 
     public val _compareTo:
-        KMockContract.SyncFunProxy<Int, (multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter7,
-            KMockTypeParameter6>) -> kotlin.Int> =
+        KMockContract.SyncFunProxy<Int, (multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter5,
+            KMockTypeParameter4>) -> kotlin.Int> =
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_compareTo", collector =
         verifier, freeze = freeze)
 
@@ -381,13 +381,13 @@ GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T : KMockTypeParameter1> ozz(): T = _ozzWithVoid.invoke() as T
 
-    public override fun <T : KMockTypeParameter4> ozz(payload: T): Unit =
-        _ozzWithKMockTypeParameter4.invoke(payload) {
+    public override fun <T : KMockTypeParameter3> ozz(payload: T): Unit =
+        _ozzWithKMockTypeParameter3.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
-    public override fun <T : KMockTypeParameter4> ozz(vararg payload: T): Unit =
-        _ozzWithKMockTypeParameter4s.invoke(payload) {
+    public override fun <T : KMockTypeParameter3> ozz(vararg payload: T): Unit =
+        _ozzWithKMockTypeParameter3s.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -483,11 +483,11 @@ GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun doSomething(arg: KMockTypeParameter6): KMockTypeParameter7 =
+    public override fun doSomething(arg: KMockTypeParameter4): KMockTypeParameter5 =
         _doSomething.invoke(arg)
 
     public override
-    fun compareTo(other: GenericCommonContract.Generic3<KMockTypeParameter7, KMockTypeParameter6>):
+    fun compareTo(other: GenericCommonContract.Generic3<KMockTypeParameter5, KMockTypeParameter4>):
         Int = _compareTo.invoke(other)
 
     public fun _clearMock(): Unit {
@@ -515,8 +515,8 @@ GenericCommonContract.Generic3<KMockTypeParameter6, KMockTypeParameter7> {
         _buzzWithList.clear()
         _buzzWithLists.clear()
         _ozzWithVoid.clear()
-        _ozzWithKMockTypeParameter4.clear()
-        _ozzWithKMockTypeParameter4s.clear()
+        _ozzWithKMockTypeParameter3.clear()
+        _ozzWithKMockTypeParameter3s.clear()
         _brassWithVoid.clear()
         _brassWithComparable.clear()
         _brassWithComparables.clear()

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericActualFactory.kt
@@ -1,0 +1,87 @@
+@file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+
+package multi
+
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Comparable
+import kotlin.Suppress
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.nested.Generic2
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+
+private inline fun <reified Mock : SpyOn, reified SpyOn> getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+): Mock = when (Mock::class) {
+    else -> throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")
+}
+
+internal actual inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector,
+    freeze: Boolean,
+): Mock = getMockInstance(
+    spyOn = spyOn,
+    verifier = verifier,
+    relaxed = false,
+    relaxUnitFun = false,
+    freeze = freeze,
+)
+
+private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : Any,
+    KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4,
+    KMockTypeParameter5> getMockInstance(
+    spyOn: SpyOn?,
+    verifier: KMockContract.Collector,
+    relaxed: Boolean,
+    relaxUnitFun: Boolean,
+    freeze: Boolean,
+    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
+        KMockTypeParameter1>>,
+    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
+        KMockTypeParameter3>>,
+    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
+        KMockTypeParameter5>>,
+): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
+              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
+              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
+    multi.CommonGenericMultiMock::class) {
+    multi.CommonGenericMultiMock(verifier = verifier, freeze = freeze, spyOn = spyOn as SpyOn?) as
+        Mock
+} else {
+    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+
+internal actual inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : Any,
+    KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4,
+    KMockTypeParameter5> kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector,
+    freeze: Boolean,
+    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
+        KMockTypeParameter1>>,
+    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
+        KMockTypeParameter3>>,
+    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
+        KMockTypeParameter5>>,
+): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
+              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
+              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = getMockInstance(
+    spyOn = spyOn,
+    verifier = verifier,
+    relaxed = false,
+    relaxUnitFun = false,
+    freeze = freeze,
+    templateType0 = templateType0,
+    templateType1 = templateType1,
+    templateType2 = templateType2,
+)

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericExpectFactory.kt
@@ -1,0 +1,38 @@
+@file:Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION")
+
+package multi
+
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Comparable
+import kotlin.Suppress
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.nested.Generic2
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+
+internal expect inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector = NoopCollector,
+    freeze: Boolean = true,
+): Mock
+
+internal expect inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : Any,
+    KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4,
+    KMockTypeParameter5> kspy(
+    spyOn: SpyOn,
+    verifier: KMockContract.Collector = NoopCollector,
+    freeze: Boolean = true,
+    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
+        KMockTypeParameter1>>,
+    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
+        KMockTypeParameter3>>,
+    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
+        KMockTypeParameter5>>,
+): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
+              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
+              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3>

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericInterface.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericInterface.kt
@@ -1,0 +1,17 @@
+package multi
+
+import kotlin.Any
+import kotlin.Comparable
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.nested.Generic2
+import tech.antibytes.kmock.MockCommon
+
+@MockCommon(CommonGenericMulti::class)
+private interface CommonGenericMulti<KMockTypeParameter0 : Any, KMockTypeParameter1,
+    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> :
+    Generic1<KMockTypeParameter0, KMockTypeParameter1>,
+    Generic2<KMockTypeParameter2, KMockTypeParameter3>,
+    GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> where
+KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3>

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericMock.kt
@@ -1,0 +1,657 @@
+package multi
+
+import kotlin.Any
+import kotlin.Array
+import kotlin.Boolean
+import kotlin.Char
+import kotlin.CharSequence
+import kotlin.Comparable
+import kotlin.Int
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.sequences.Sequence
+import multi.template.commonGeneric.Generic1
+import multi.template.commonGeneric.GenericCommonContract
+import multi.template.commonGeneric.SomeGeneric
+import multi.template.commonGeneric.nested.Generic2
+import tech.antibytes.kmock.KMockContract
+import tech.antibytes.kmock.KMockContract.Collector
+import tech.antibytes.kmock.proxy.NoopCollector
+import tech.antibytes.kmock.proxy.ProxyFactory
+
+internal class CommonGenericMultiMock<KMockTypeParameter0 : Any, KMockTypeParameter1,
+    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5,
+    MultiMock>(
+    verifier: KMockContract.Collector = NoopCollector,
+    @Suppress("UNUSED_PARAMETER")
+    spyOn: MultiMock? = null,
+    freeze: Boolean = true,
+    @Suppress("unused")
+    private val relaxUnitFun: Boolean = false,
+    @Suppress("unused")
+    private val relaxed: Boolean = false,
+) : Generic1<KMockTypeParameter0, KMockTypeParameter1>,
+    Generic2<KMockTypeParameter2, KMockTypeParameter3>,
+    GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> where
+KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3>, MultiMock :
+Generic1<KMockTypeParameter0, KMockTypeParameter1>, MultiMock :
+Generic2<KMockTypeParameter2, KMockTypeParameter3>, MultiMock :
+GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
+    private val __spyOn: MultiMock? = spyOn
+
+    public override var template: KMockTypeParameter1
+        get() = _template.onGet {
+            useSpyIf(__spyOn) { __spyOn!!.template }
+        }
+        set(`value`) = _template.onSet(value) {
+            useSpyIf(__spyOn) { __spyOn!!.template = value }
+        }
+
+    public val _template: KMockContract.PropertyProxy<KMockTypeParameter1> =
+        ProxyFactory.createPropertyProxy("multi.CommonGenericMultiMock#_template", collector =
+        verifier, freeze = freeze)
+
+    public override val lol: KMockTypeParameter2
+        get() = _lol.onGet {
+            useSpyIf(__spyOn) { __spyOn!!.lol }
+        }
+
+    public val _lol: KMockContract.PropertyProxy<KMockTypeParameter2> =
+        ProxyFactory.createPropertyProxy("multi.CommonGenericMultiMock#_lol", collector = verifier,
+            freeze = freeze)
+
+    public val _fooWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _fooWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _fooWithAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit>
+        = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithAnys", collector =
+    verifier, freeze = freeze)
+
+    public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blaWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _blaWithInt: KMockContract.SyncFunProxy<Unit, (kotlin.Int) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blaWithInt", collector =
+        verifier, freeze = freeze)
+
+    public val _blaWithInts: KMockContract.SyncFunProxy<Unit, (kotlin.IntArray) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blaWithInts", collector =
+        verifier, freeze = freeze)
+
+    public val _barWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String>>, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.String>>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_barWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _barWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String>>) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_barWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _barWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_barWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _blubbWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.String?>>, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.String?>>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blubbWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _blubbWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String?>>) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blubbWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _blubbWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blubbWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _bussWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _bussWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _bussWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _bossWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>?>, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.Int>?>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bossWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _bossWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>?>) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bossWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _bossWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bossWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _buzzWithVoid:
+        KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
+        kotlin.collections.List<kotlin.Array<kotlin.Int>>?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_buzzWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _buzzWithList:
+        KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_buzzWithList",
+        collector = verifier, freeze = freeze)
+
+    public val _buzzWithLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_buzzWithLists", collector =
+        verifier, freeze = freeze)
+
+    public val _ozzWithVoid: KMockContract.SyncFunProxy<KMockTypeParameter1, () ->
+    KMockTypeParameter1> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _ozzWithKMockTypeParameter3: KMockContract.SyncFunProxy<Unit, (KMockTypeParameter3) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter3",
+            collector = verifier, freeze = freeze)
+
+    public val _ozzWithKMockTypeParameter3s: KMockContract.SyncFunProxy<Unit, (Array<out
+    KMockTypeParameter3>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ozzWithKMockTypeParameter3s",
+            collector = verifier, freeze = freeze)
+
+    public val _brassWithVoid:
+        KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>, () ->
+        kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_brassWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _brassWithComparable:
+        KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>) ->
+        kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_brassWithComparable", collector
+        = verifier, freeze = freeze)
+
+    public val _brassWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_brassWithComparables",
+            collector = verifier, freeze = freeze)
+
+    public val _blissWithVoid:
+        KMockContract.SyncFunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?, () ->
+        kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _blissWithComparable:
+        KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
+        kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithComparable", collector
+        = verifier, freeze = freeze)
+
+    public val _blissWithComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithComparables",
+            collector = verifier, freeze = freeze)
+
+    public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
+        kotlin.String>, () -> kotlin.collections.Map<kotlin.String, kotlin.String>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lossWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _lossWithMap: KMockContract.SyncFunProxy<Unit, (kotlin.collections.Map<kotlin.String,
+        kotlin.String>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lossWithMap", collector =
+        verifier, freeze = freeze)
+
+    public val _lossWithMaps: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lossWithMaps", collector =
+        verifier, freeze = freeze)
+
+    public val _uzz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_uzz", collector = verifier,
+            freeze = freeze)
+
+    public val _lzz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_lzz", collector = verifier,
+            freeze = freeze)
+
+    public val _tzz: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_tzz", collector = verifier,
+            freeze = freeze)
+
+    public val _rzz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_rzz", collector = verifier,
+            freeze = freeze)
+
+    public val _izz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_izz", collector = verifier,
+            freeze = freeze)
+
+    public val _ossWithAny: KMockContract.SyncFunProxy<Any?, (kotlin.Any?) -> kotlin.Any?> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _ossWithAnyAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithAnyAny",
+        collector = verifier, freeze = freeze)
+
+    public val _ossWithAnyAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    kotlin.Any?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithAnyAnys", collector =
+        verifier, freeze = freeze)
+
+    public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_kss", collector = verifier,
+            freeze = freeze)
+
+    public val _iss: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_iss", collector = verifier,
+            freeze = freeze)
+
+    public val _pss:
+        KMockContract.SyncFunProxy<multi.template.commonGeneric.SomeGeneric<kotlin.String>, (multi.template.commonGeneric.SomeGeneric<kotlin.String>) ->
+        multi.template.commonGeneric.SomeGeneric<kotlin.String>> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_pss", collector = verifier,
+            freeze = freeze)
+
+    public val _xssWithAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _xssWithAnySequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+        kotlin.Any) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithAnySequenceCharSequence",
+            collector = verifier, freeze = freeze)
+
+    public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
+    KMockTypeParameter5> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_doSomething", collector =
+        verifier, freeze = freeze)
+
+    public val _compareTo:
+        KMockContract.SyncFunProxy<Int, (multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter5,
+            KMockTypeParameter4>) -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_compareTo", collector =
+        verifier, freeze = freeze)
+
+    public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_toString", collector =
+        verifier, freeze = freeze, ignorableForVerification = true)
+
+    public val _equals: KMockContract.SyncFunProxy<Boolean, (kotlin.Any?) -> kotlin.Boolean> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_equals", collector = verifier,
+            freeze = freeze, ignorableForVerification = true)
+
+    public val _hashCode: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_hashCode", collector =
+        verifier, freeze = freeze, ignorableForVerification = true)
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> foo(): T = _fooWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.foo() }
+    } as T
+
+    public override fun <T> foo(payload: T): Unit = _fooWithAny.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.foo(payload) }
+    }
+
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithAnys.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.foo(*payload) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Int> bla(): T = _blaWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.bla() }
+    } as T
+
+    public override fun <T : Int> bla(payload: T): Unit = _blaWithInt.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.bla(payload) }
+    }
+
+    public override fun <T : Int> bla(vararg payload: T): Unit = _blaWithInts.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.bla(*payload) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<String>>> bar(): T = _barWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.bar() }
+    } as T
+
+    public override fun <T : List<Array<String>>> bar(payload: T): Unit = _barWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.bar(payload) }
+    }
+
+    public override fun <T : List<Array<String>>> bar(vararg payload: T): Unit =
+        _barWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.bar(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<String?>>> blubb(): T = _blubbWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.blubb() }
+    } as T
+
+    public override fun <T : List<Array<String?>>> blubb(payload: T): Unit =
+        _blubbWithList.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.blubb(payload) }
+        }
+
+    public override fun <T : List<Array<String?>>> blubb(vararg payload: T): Unit =
+        _blubbWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.blubb(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.buss() }
+    } as T
+
+    public override fun <T : List<Array<Int>>?> buss(payload: T): Unit = _bussWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.buss(payload) }
+    }
+
+    public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
+        _bussWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.buss(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<Int>?>> boss(): T = _bossWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.boss() }
+    } as T
+
+    public override fun <T : List<Array<Int>?>> boss(payload: T): Unit = _bossWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.boss(payload) }
+    }
+
+    public override fun <T : List<Array<Int>?>> boss(vararg payload: T): Unit =
+        _bossWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.boss(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : List<Array<Int>>> buzz(): T? = _buzzWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.buzz() }
+    } as T?
+
+    public override fun <T : List<Array<Int>>> buzz(payload: T?): Unit = _buzzWithList.invoke(payload)
+    {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.buzz(payload) }
+    }
+
+    public override fun <T : List<Array<Int>>> buzz(vararg payload: T?): Unit =
+        _buzzWithLists.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.buzz(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : KMockTypeParameter1> ozz(): T = _ozzWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.ozz() }
+    } as T
+
+    public override fun <T : KMockTypeParameter3> ozz(payload: T): Unit =
+        _ozzWithKMockTypeParameter3.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.ozz(payload) }
+        }
+
+    public override fun <T : KMockTypeParameter3> ozz(vararg payload: T): Unit =
+        _ozzWithKMockTypeParameter3s.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.ozz(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Comparable<List<Array<T>>>> brass(): T = _brassWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.brass() }
+    } as T
+
+    public override fun <T : Comparable<List<Array<T>>>> brass(payload: T): Unit =
+        _brassWithComparable.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.brass(payload) }
+        }
+
+    public override fun <T : Comparable<List<Array<T>>>> brass(vararg payload: T): Unit =
+        _brassWithComparables.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.brass(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.bliss() }
+    } as T
+
+    public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
+        _blissWithComparable.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.bliss(payload) }
+        }
+
+    public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
+        _blissWithComparables.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.bliss(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Map<String, String>> loss(): T = _lossWithVoid.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.loss() }
+    } as T
+
+    public override fun <T : Map<String, String>> loss(payload: T): Unit =
+        _lossWithMap.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.loss(payload) }
+        }
+
+    public override fun <T : Map<String, String>> loss(vararg payload: T): Unit =
+        _lossWithMaps.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.loss(*payload) }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> uzz(): T where T : SomeGeneric<String>, T : List<String> = _uzz.invoke() {
+        useSpyIf(__spyOn) { __spyOn!!.uzz() }
+    } as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> lzz(): T where T : SomeGeneric<String>, T : List<String>? = _lzz.invoke()
+    {
+        useSpyIf(__spyOn) { __spyOn!!.lzz() }
+    } as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> tzz(): T where T : SomeGeneric<String>?, T : List<String>? = _tzz.invoke()
+    {
+        useSpyIf(__spyOn) { __spyOn!!.tzz() }
+    } as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> rzz(): T where T : SomeGeneric<String>, T : Map<String, String> =
+        _rzz.invoke() {
+            useSpyIf(__spyOn) { __spyOn!!.rzz() }
+        } as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> izz(): T where T : SomeGeneric<String>, T : Comparable<List<Array<T>>> =
+        _izz.invoke() {
+            useSpyIf(__spyOn) { __spyOn!!.izz() }
+        } as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : R, R> oss(arg0: T): R = _ossWithAny.invoke(arg0) {
+        useSpyIf(__spyOn) { __spyOn!!.oss(arg0) }
+    } as R
+
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithAnyAny.invoke(arg0, arg1) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.oss(arg0, arg1) }
+    }
+
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithAnyAnys.invoke(arg0,
+        arg1) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.oss(arg0, *arg1) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
+    Comparable<List<Array<R>>> = _kss.invoke(arg0) {
+        useSpyIf(__spyOn) { __spyOn!!.kss(arg0) }
+    } as R
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
+    Comparable<List<Array<T>>> = _iss.invoke(arg0) {
+        useSpyIf(__spyOn) { __spyOn!!.iss(arg0) }
+    } as R
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <R : T, T : X, X : SomeGeneric<String>> pss(arg0: T): R = _pss.invoke(arg0) {
+        useSpyIf(__spyOn) { __spyOn!!.pss(arg0) }
+    } as R
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
+        _xssWithAny.invoke(arg0) {
+            useSpyIf(__spyOn) { __spyOn!!.xss(arg0) }
+        } as R
+
+    public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
+        = _xssWithAnySequenceCharSequence.invoke(arg0, arg1) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        useSpyIf(__spyOn) { __spyOn!!.xss(arg0, arg1) }
+    }
+
+    public override fun doSomething(arg: KMockTypeParameter4): KMockTypeParameter5 =
+        _doSomething.invoke(arg) {
+            useSpyIf(__spyOn) { __spyOn!!.doSomething(arg) }
+        }
+
+    public override
+    fun compareTo(other: GenericCommonContract.Generic3<KMockTypeParameter5, KMockTypeParameter4>):
+        Int = _compareTo.invoke(other) {
+        useSpyIf(__spyOn) { __spyOn!!.compareTo(other) }
+    }
+
+    public override fun toString(): String = _toString.invoke() {
+        useRelaxerIf(true) { super.toString() }
+        useSpyIf(__spyOn) { __spyOn!!.toString() }
+    }
+
+    public override fun equals(other: Any?): Boolean = _equals.invoke(other) {
+        useRelaxerIf(true) { super.equals(other) }
+        useSpyOnEqualsIf(
+            spyTarget = __spyOn,
+            other = other,
+            spyOn = { super.equals(other) },
+            mockKlass = CommonGenericMultiMock::class
+        )
+    }
+
+    public override fun hashCode(): Int = _hashCode.invoke() {
+        useRelaxerIf(true) { super.hashCode() }
+        useSpyIf(__spyOn) { __spyOn!!.hashCode() }
+    }
+
+    public fun _clearMock(): Unit {
+        _template.clear()
+        _lol.clear()
+        _fooWithVoid.clear()
+        _fooWithAny.clear()
+        _fooWithAnys.clear()
+        _blaWithVoid.clear()
+        _blaWithInt.clear()
+        _blaWithInts.clear()
+        _barWithVoid.clear()
+        _barWithList.clear()
+        _barWithLists.clear()
+        _blubbWithVoid.clear()
+        _blubbWithList.clear()
+        _blubbWithLists.clear()
+        _bussWithVoid.clear()
+        _bussWithList.clear()
+        _bussWithLists.clear()
+        _bossWithVoid.clear()
+        _bossWithList.clear()
+        _bossWithLists.clear()
+        _buzzWithVoid.clear()
+        _buzzWithList.clear()
+        _buzzWithLists.clear()
+        _ozzWithVoid.clear()
+        _ozzWithKMockTypeParameter3.clear()
+        _ozzWithKMockTypeParameter3s.clear()
+        _brassWithVoid.clear()
+        _brassWithComparable.clear()
+        _brassWithComparables.clear()
+        _blissWithVoid.clear()
+        _blissWithComparable.clear()
+        _blissWithComparables.clear()
+        _lossWithVoid.clear()
+        _lossWithMap.clear()
+        _lossWithMaps.clear()
+        _uzz.clear()
+        _lzz.clear()
+        _tzz.clear()
+        _rzz.clear()
+        _izz.clear()
+        _ossWithAny.clear()
+        _ossWithAnyAny.clear()
+        _ossWithAnyAnys.clear()
+        _kss.clear()
+        _iss.clear()
+        _pss.clear()
+        _xssWithAny.clear()
+        _xssWithAnySequenceCharSequence.clear()
+        _doSomething.clear()
+        _compareTo.clear()
+        _toString.clear()
+        _equals.clear()
+        _hashCode.clear()
+    }
+}

--- a/kmock-processor/src/test/resources/multi/template/commonGeneric/Generic1.kt
+++ b/kmock-processor/src/test/resources/multi/template/commonGeneric/Generic1.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package multi.template.commonGeneric
+
+import multi.template.commonGeneric.nested.Generic2
+import tech.antibytes.kmock.MultiMockCommon
+
+interface SomeGeneric<T>
+
+@MultiMockCommon(
+    "CommonGenericMulti",
+    Generic1::class,
+    Generic2::class,
+    GenericCommonContract.Generic3::class
+)
+interface Generic1<K, L> where L : Any, L : Comparable<L>, K : Any {
+    var template: L
+
+    fun <T> foo(): T
+
+    fun <T : Int> bla(): T
+
+    fun <T : List<Array<String>>> bar(): T
+
+    fun <T : List<Array<String?>>> blubb(): T
+
+    fun <T : List<Array<Int>>?> buss(): T
+
+    fun <T : List<Array<Int>?>> boss(): T
+
+    fun <T : List<Array<Int>>> buzz(): T?
+
+    fun <T : L> ozz(): T
+
+    fun <T> brass(): T where T : Comparable<List<Array<T>>>
+
+    fun <T> bliss(): T where T : Comparable<List<Array<T>>>?
+
+    fun <T> loss(): T where T : Map<String, String>
+
+    fun <T> uzz(): T where T : SomeGeneric<String>, T : List<String>
+
+    fun <T> lzz(): T where T : SomeGeneric<String>, T : List<String>?
+
+    fun <T> tzz(): T where T : SomeGeneric<String>?, T : List<String>?
+
+    fun <T> rzz(): T where T : SomeGeneric<String>, T : Map<String, String>
+
+    fun <T> izz(): T where T : SomeGeneric<String>, T : Comparable<List<Array<T>>>
+
+    fun <T : R, R> oss(arg0: T): R
+
+    fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R : Comparable<List<Array<R>>>
+
+    fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R : Comparable<List<Array<T>>>
+
+    fun <R, T : X, X : SomeGeneric<String>> pss(arg0: T): R where R : T
+
+    fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence
+}

--- a/kmock-processor/src/test/resources/multi/template/commonGeneric/Generic3.kt
+++ b/kmock-processor/src/test/resources/multi/template/commonGeneric/Generic3.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package multi.template.commonGeneric
+
+interface GenericCommonContract {
+    interface Generic3<K, L> : Comparable<Generic3<L, K>> {
+        fun doSomething(arg: K): L
+    }
+}

--- a/kmock-processor/src/test/resources/multi/template/commonGeneric/nested/Generic2.kt
+++ b/kmock-processor/src/test/resources/multi/template/commonGeneric/nested/Generic2.kt
@@ -7,6 +7,8 @@
 package multi.template.commonGeneric.nested
 
 interface Generic2<K, L> where L : Any, L : Comparable<L>, K : Any {
+    val lol: K
+
     fun <T> foo(payload: T)
     fun <T> foo(vararg payload: T)
 

--- a/kmock-processor/src/test/resources/multi/template/commonGeneric/nested/Generic2.kt
+++ b/kmock-processor/src/test/resources/multi/template/commonGeneric/nested/Generic2.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package multi.template.commonGeneric.nested
+
+interface Generic2<K, L> where L : Any, L : Comparable<L>, K : Any {
+    fun <T> foo(payload: T)
+    fun <T> foo(vararg payload: T)
+
+    fun <T : Int> bla(payload: T)
+    fun <T : Int> bla(vararg payload: T)
+
+    fun <T : List<Array<String>>> bar(payload: T)
+    fun <T : List<Array<String>>> bar(vararg payload: T)
+
+    fun <T : List<Array<String?>>> blubb(payload: T)
+    fun <T : List<Array<String?>>> blubb(vararg payload: T)
+
+    fun <T : List<Array<Int>>?> buss(payload: T)
+    fun <T : List<Array<Int>>?> buss(vararg payload: T)
+
+    fun <T : List<Array<Int>?>> boss(payload: T)
+    fun <T : List<Array<Int>?>> boss(vararg payload: T)
+
+    fun <T : List<Array<Int>>> buzz(payload: T?)
+    fun <T : List<Array<Int>>> buzz(vararg payload: T?)
+
+    fun <T : L> ozz(payload: T)
+    fun <T : L> ozz(vararg payload: T)
+
+    fun <T> brass(payload: T) where T : Comparable<List<Array<T>>>
+    fun <T> brass(vararg payload: T) where T : Comparable<List<Array<T>>>
+
+    fun <T> bliss(payload: T) where T : Comparable<List<Array<T>>>?
+    fun <T> bliss(vararg payload: T) where T : Comparable<List<Array<T>>>?
+
+    fun <T> loss(payload: T) where T : Map<String, String>
+    fun <T> loss(vararg payload: T) where T : Map<String, String>
+
+    fun <T : R, R> oss(arg0: T, arg1: R)
+    fun <T : R, R> oss(arg0: R, vararg arg1: T)
+
+    fun <R, T> xss(arg0: T, arg1: R) where R : Sequence<Char>, R : CharSequence
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #102, #138

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This adds the support for generics in a multi-interface context. Since it depends on inheritance it also overcomes the current [KSP issue](https://github.com/google/ksp/issues/958) with varargs by porting KotlinPoet KSP interop into KMock and makes some needed modification.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [ ] My changes are reflected in the changelog.
