### PR TITLE
Change relaxation to support generics

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -57,6 +57,7 @@ toc::[]
 * Android MinSDK 23 -> 21
 * `spyOn` is now capable of picking up KMock defined Aliases
 * `kspy` in terms of generics not longer exposed if not declared via `spyOn` or `spiesOnly`
+* relaxation method gets now the return type boundaries delegated, if generic in order to resolve type conflicts
 
 === Deprecated
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
@@ -448,4 +448,17 @@ internal object KMockGenerics : GenericResolver {
 
         return TypeVariableName(name, bounds = listOf(boundary)).copy(reified = true)
     }
+
+    private fun List<KSTypeReference>.toTypeNames(
+        resolver: TypeParameterResolver
+    ): List<TypeName> = this.map { rawType -> rawType.toTypeName(resolver) }
+
+    override fun mapClassScopeGenerics(
+        generics: Map<String, List<KSTypeReference>>?,
+        resolver: TypeParameterResolver,
+    ): Map<String, List<TypeName>>? {
+        return generics?.map { (key, rawTypes) ->
+            key to rawTypes.toTypeNames(resolver)
+        }?.toMap()
+    }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -180,6 +180,11 @@ internal interface ProcessorContract {
             resolver: TypeParameterResolver
         ): Map<String, List<KSTypeReference>>?
 
+        fun mapClassScopeGenerics(
+            generics: Map<String, List<KSTypeReference>>?,
+            resolver: TypeParameterResolver,
+        ): Map<String, List<TypeName>>?
+
         fun resolveMockClassType(
             template: KSClassDeclaration,
             resolver: TypeParameterResolver
@@ -230,7 +235,8 @@ internal interface ProcessorContract {
 
     data class MethodReturnTypeInfo(
         val typeName: TypeName,
-        val generic: GenericDeclaration?
+        val generic: GenericDeclaration?,
+        val classScope: Map<String, List<TypeName>>?
     )
 
     interface ProxyNameCollector {
@@ -258,11 +264,14 @@ internal interface ProcessorContract {
     }
 
     interface RelaxerGenerator {
-        fun buildPropertyRelaxation(relaxer: Relaxer?): String
+        fun buildPropertyRelaxation(
+            propertyType: MethodReturnTypeInfo,
+            relaxer: Relaxer?,
+        ): String
 
         fun buildMethodRelaxation(
-            relaxer: Relaxer?,
             methodReturnType: MethodReturnTypeInfo,
+            relaxer: Relaxer?,
         ): String
 
         fun buildBuildInRelaxation(
@@ -287,6 +296,7 @@ internal interface ProcessorContract {
         fun buildGetterNonIntrusiveInvocation(
             enableSpy: Boolean,
             propertyName: String,
+            propertyType: MethodReturnTypeInfo,
             relaxer: Relaxer?
         ): String
 
@@ -314,6 +324,7 @@ internal interface ProcessorContract {
     interface PropertyGenerator {
         fun buildPropertyBundle(
             qualifier: String,
+            classScopeGenerics: Map<String, List<TypeName>>?,
             ksProperty: KSPropertyDeclaration,
             typeResolver: TypeParameterResolver,
             enableSpy: Boolean,
@@ -325,6 +336,7 @@ internal interface ProcessorContract {
         fun buildMethodBundle(
             methodScope: TypeName?,
             qualifier: String,
+            classScopeGenerics: Map<String, List<TypeName>>?,
             ksFunction: KSFunctionDeclaration,
             typeResolver: TypeParameterResolver,
             enableSpy: Boolean,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockGenerator.kt
@@ -157,6 +157,7 @@ internal class KMockGenerator(
             typeResolver = typeResolver,
         )
         val proxyNameCollector: MutableList<String> = mutableListOf()
+        val classScopeGenerics = genericsResolver.mapClassScopeGenerics(generics, typeResolver)
 
         mock.addSuperinterfaces(superTypes)
         mock.addModifiers(KModifier.INTERNAL)
@@ -207,6 +208,7 @@ internal class KMockGenerator(
             if (ksProperty.isPublicOpen()) {
                 val (proxy, property) = propertyGenerator.buildPropertyBundle(
                     qualifier = qualifier,
+                    classScopeGenerics = classScopeGenerics,
                     ksProperty = ksProperty,
                     typeResolver = typeResolver,
                     enableSpy = enableSpy,
@@ -230,6 +232,7 @@ internal class KMockGenerator(
                 val (proxy, method) = methodGenerator.buildMethodBundle(
                     methodScope = scope,
                     qualifier = qualifier,
+                    classScopeGenerics = classScopeGenerics,
                     ksFunction = ksFunction,
                     typeResolver = typeResolver,
                     enableSpy = enableSpy,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockNonIntrusiveInvocationGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockNonIntrusiveInvocationGenerator.kt
@@ -38,10 +38,11 @@ internal class KMockNonIntrusiveInvocationGenerator(
     override fun buildGetterNonIntrusiveInvocation(
         enableSpy: Boolean,
         propertyName: String,
+        propertyType: MethodReturnTypeInfo,
         relaxer: Relaxer?
     ): String = buildInvocation { nonIntrusiveInvocation ->
         nonIntrusiveInvocation.append(
-            relaxerGenerator.buildPropertyRelaxation(relaxer)
+            relaxerGenerator.buildPropertyRelaxation(propertyType, relaxer)
         )
         if (enableSpy) {
             nonIntrusiveInvocation.append(

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockFactoriesSpec.kt
@@ -64,7 +64,6 @@ class KMockFactoriesSpec {
     private fun findGeneratedSource(filter: (File) -> Boolean): List<File> {
         return buildDir.walkBottomUp()
             .toList()
-            .onEach { println(it) }
             .filter(filter)
     }
 

--- a/kmock-processor/src/test/resources/mock/expected/relaxed/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/relaxed/Common.kt
@@ -2,6 +2,7 @@ package mock.template.relaxed
 
 import kotlin.Any
 import kotlin.Boolean
+import kotlin.Comparable
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -11,28 +12,56 @@ import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
 import tech.antibytes.kmock.proxy.ProxyFactory
 
-internal class CommonMock(
+internal class CommonMock<K : Any, L>(
     verifier: KMockContract.Collector = NoopCollector,
     @Suppress("UNUSED_PARAMETER")
-    spyOn: Common? = null,
+    spyOn: Common<K, L>? = null,
     freeze: Boolean = true,
     @Suppress("unused")
     private val relaxUnitFun: Boolean = false,
     @Suppress("unused")
     private val relaxed: Boolean = false,
-) : Common {
+) : Common<K, L> where L : Any, L : Comparable<L> {
+    public override var template: L
+        get() = _template.onGet {
+            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
+                type0 = kotlin.Any::class,
+                type1 = kotlin.Comparable::class,) }
+        }
+        set(`value`) = _template.onSet(value)
+
+    public val _template: KMockContract.PropertyProxy<L> =
+        ProxyFactory.createPropertyProxy("mock.template.relaxed.CommonMock#_template", collector =
+        verifier, freeze = freeze)
+
     public override val buzz: String
         get() = _buzz.onGet {
-            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
         }
 
     public val _buzz: KMockContract.PropertyProxy<String> =
         ProxyFactory.createPropertyProxy("mock.template.relaxed.CommonMock#_buzz", collector =
         verifier, freeze = freeze)
 
-    public val _foo: KMockContract.SyncFunProxy<String, (kotlin.Any) -> kotlin.String> =
-        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_foo", collector = verifier,
-            freeze = freeze)
+    public val _fooWithAny: KMockContract.SyncFunProxy<String, (kotlin.Any) -> kotlin.String> =
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_fooWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _fooWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_fooWithVoid", collector =
+        verifier, freeze = freeze)
+
+    public val _fooWithString: KMockContract.SyncFunProxy<L, (kotlin.String) -> L> =
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_fooWithString", collector =
+        verifier, freeze = freeze)
+
+    public val _fooBarWithAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_fooBarWithAny", collector =
+        verifier, freeze = freeze)
+
+    public val _fooBarWithVoid: KMockContract.SyncFunProxy<K?, () -> K?> =
+        ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_fooBarWithVoid", collector
+        = verifier, freeze = freeze)
 
     public val _oo: KMockContract.SyncFunProxy<String, (Array<out kotlin.Any>) -> kotlin.String> =
         ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_oo", collector = verifier,
@@ -50,20 +79,42 @@ internal class CommonMock(
         ProxyFactory.createSyncFunProxy("mock.template.relaxed.CommonMock#_buzzWithVoid", collector =
         verifier, freeze = freeze)
 
-    public override fun foo(payload: Any): String = _foo.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+    public override fun foo(payload: Any): String = _fooWithAny.invoke(payload) {
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> foo(): T = _fooWithVoid.invoke() {
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
+            type0 = kotlin.Any::class,) }
+    } as T
+
+    public override fun foo(payload: String): L = _fooWithString.invoke(payload) {
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
+            type0 = kotlin.Any::class,
+            type1 = kotlin.Comparable::class,) }
+    }
+
+    public override fun <T : Any> fooBar(payload: T): Unit = _fooBarWithAny.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : K?> fooBar(): T = _fooBarWithVoid.invoke() {
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
+            type0 = kotlin.Any::class,) }
+    } as T
+
     public override fun oo(vararg payload: Any): String = _oo.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override suspend fun bar(payload: Any): String = _bar.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override suspend fun ar(vararg payload: Any): String = _ar.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override fun buzz(): Unit = _buzzWithVoid.invoke() {
@@ -71,8 +122,13 @@ internal class CommonMock(
     }
 
     public fun _clearMock(): Unit {
+        _template.clear()
         _buzz.clear()
-        _foo.clear()
+        _fooWithAny.clear()
+        _fooWithVoid.clear()
+        _fooWithString.clear()
+        _fooBarWithAny.clear()
+        _fooBarWithVoid.clear()
         _oo.clear()
         _bar.clear()
         _ar.clear()

--- a/kmock-processor/src/test/resources/mock/expected/relaxed/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/relaxed/Platform.kt
@@ -23,7 +23,7 @@ internal class PlatformMock(
 ) : Platform {
     public override val buzz: String
         get() = _buzz.onGet {
-            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
         }
 
     public val _buzz: KMockContract.PropertyProxy<String> =
@@ -51,19 +51,19 @@ internal class PlatformMock(
         = verifier, freeze = freeze)
 
     public override fun foo(payload: Any): String = _foo.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override fun oo(vararg payload: Any): String = _oo.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override suspend fun bar(payload: Any): String = _bar.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override suspend fun ar(vararg payload: Any): String = _ar.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override fun buzz(): Unit = _buzzWithVoid.invoke() {

--- a/kmock-processor/src/test/resources/mock/expected/relaxed/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/relaxed/Shared.kt
@@ -23,7 +23,7 @@ internal class SharedMock(
 ) : Shared {
     public override val buzz: String
         get() = _buzz.onGet {
-            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
         }
 
     public val _buzz: KMockContract.PropertyProxy<String> =
@@ -43,11 +43,11 @@ internal class SharedMock(
         verifier, freeze = freeze)
 
     public override fun foo(payload: Any): String = _foo.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override suspend fun bar(payload: Any): String = _bar.invoke(payload) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
     }
 
     public override fun buzz(): Unit = _buzzWithVoid.invoke() {

--- a/kmock-processor/src/test/resources/mock/expected/spy/Relaxed.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Relaxed.kt
@@ -27,7 +27,9 @@ internal class RelaxedMock<K : Any, L>(
 
     public override var template: L
         get() = _template.onGet {
-            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
+                type0 = kotlin.Any::class,
+                type1 = kotlin.Comparable::class,) }
             useSpyIf(__spyOn) { __spyOn!!.template }
         }
         set(`value`) = _template.onSet(value) {
@@ -40,7 +42,7 @@ internal class RelaxedMock<K : Any, L>(
 
     public override val ozz: Int
         get() = _ozz.onGet {
-            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
             useSpyIf(__spyOn) { __spyOn!!.ozz }
         }
 
@@ -78,12 +80,14 @@ internal class RelaxedMock<K : Any, L>(
     }
 
     public override fun bar(arg0: Int): Any = _bar.invoke(arg0) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,) }
         useSpyIf(__spyOn) { __spyOn!!.bar(arg0) }
     }
 
     public override suspend fun buzz(arg0: String): L = _buzz.invoke(arg0) {
-        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId) }
+        useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
+            type0 = kotlin.Any::class,
+            type1 = kotlin.Comparable::class,) }
         useSpyIf(__spyOn) { __spyOn!!.buzz(arg0) }
     }
 

--- a/kmock-processor/src/test/resources/mock/template/relaxed/Common.kt
+++ b/kmock-processor/src/test/resources/mock/template/relaxed/Common.kt
@@ -15,10 +15,15 @@ internal inline fun <reified T> relaxed(id: String): T {
 }
 
 @MockCommon(Common::class)
-interface Common {
+interface Common<K, L> where L : Any, L : Comparable<L>, K : Any {
+    var template: L
     val buzz: String
 
     fun foo(payload: Any): String
+    fun <T> foo(): T
+    fun foo(payload: String): L
+    fun <T: Any> fooBar(payload: T)
+    fun <T> fooBar(): T where T : K?
     fun oo(vararg payload: Any): String
     suspend fun bar(payload: Any): String
     suspend fun ar(vararg payload: Any): String


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #125

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This deals with the Relaxation issue when using generics. It is solved by delegating the types to the relaxation method if it needs a generic return value.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
