### PR TITLE
Fix misaligned returns for Relaxer and Spies

### DIFF
--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -235,6 +235,7 @@ internal interface ProcessorContract {
 
     data class MethodReturnTypeInfo(
         val typeName: TypeName,
+        val actualTypeName: TypeName,
         val generic: GenericDeclaration?,
         val classScope: Map<String, List<TypeName>>?
     )
@@ -286,7 +287,9 @@ internal interface ProcessorContract {
 
         fun buildMethodSpy(
             methodName: String,
-            arguments: Array<MethodTypeInfo>
+            parameter: List<TypeName>,
+            arguments: Array<MethodTypeInfo>,
+            methodReturnType: MethodReturnTypeInfo,
         ): String
 
         fun buildEqualsSpy(mockName: String): String
@@ -308,6 +311,7 @@ internal interface ProcessorContract {
         fun buildMethodNonIntrusiveInvocation(
             enableSpy: Boolean,
             methodName: String,
+            parameter: List<TypeName>,
             arguments: Array<MethodTypeInfo>,
             methodReturnType: MethodReturnTypeInfo,
             relaxer: Relaxer?,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockNonIntrusiveInvocationGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockNonIntrusiveInvocationGenerator.kt
@@ -6,6 +6,8 @@
 
 package tech.antibytes.kmock.processor.mock
 
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeVariableName
 import tech.antibytes.kmock.processor.ProcessorContract.MethodReturnTypeInfo
 import tech.antibytes.kmock.processor.ProcessorContract.MethodTypeInfo
 import tech.antibytes.kmock.processor.ProcessorContract.NonIntrusiveInvocationGenerator
@@ -18,6 +20,7 @@ internal class KMockNonIntrusiveInvocationGenerator(
     private val spyGenerator: SpyGenerator
 ) : NonIntrusiveInvocationGenerator {
     private val noArguments: Array<MethodTypeInfo> = arrayOf()
+    private val illegal = MethodReturnTypeInfo(TypeVariableName(""), TypeVariableName(""), null, null)
 
     private fun buildInvocation(hook: (StringBuilder) -> Unit): String {
         val nonIntrusiveInvocation = StringBuilder(4)
@@ -65,6 +68,7 @@ internal class KMockNonIntrusiveInvocationGenerator(
     override fun buildMethodNonIntrusiveInvocation(
         enableSpy: Boolean,
         methodName: String,
+        parameter: List<TypeName>,
         arguments: Array<MethodTypeInfo>,
         methodReturnType: MethodReturnTypeInfo,
         relaxer: Relaxer?
@@ -80,7 +84,9 @@ internal class KMockNonIntrusiveInvocationGenerator(
             nonIntrusiveInvocation.append(
                 spyGenerator.buildMethodSpy(
                     methodName = methodName,
-                    arguments = arguments
+                    arguments = arguments,
+                    parameter = parameter,
+                    methodReturnType = methodReturnType
                 )
             )
         }
@@ -92,7 +98,7 @@ internal class KMockNonIntrusiveInvocationGenerator(
 
     private fun buildBuildInSpy(
         methodName: String
-    ): String = spyGenerator.buildMethodSpy(methodName, noArguments)
+    ): String = spyGenerator.buildMethodSpy(methodName, emptyList(), noArguments, illegal)
 
     private fun buildEqualsRelaxer(
         argument: MethodTypeInfo?

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockPropertyGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockPropertyGenerator.kt
@@ -253,6 +253,7 @@ internal class KMockPropertyGenerator(
         )
         val returnType = MethodReturnTypeInfo(
             typeName = propertyType,
+            actualTypeName = propertyType,
             generic = null,
             classScope = classScopeGenerics
         )

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockSpyGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockSpyGenerator.kt
@@ -6,6 +6,8 @@
 
 package tech.antibytes.kmock.processor.mock
 
+import com.squareup.kotlinpoet.TypeName
+import tech.antibytes.kmock.processor.ProcessorContract.MethodReturnTypeInfo
 import tech.antibytes.kmock.processor.ProcessorContract.MethodTypeInfo
 import tech.antibytes.kmock.processor.ProcessorContract.SpyGenerator
 
@@ -32,16 +34,27 @@ internal object KMockSpyGenerator : SpyGenerator {
         }
     }
 
+    private fun resolveTypes(parameter: List<TypeName>): String {
+        return if (parameter.isEmpty()) {
+            ""
+        } else {
+            "<${parameter.joinToString(", ")}>"
+        }
+    }
+
     override fun buildMethodSpy(
         methodName: String,
-        arguments: Array<MethodTypeInfo>
+        parameter: List<TypeName>,
+        arguments: Array<MethodTypeInfo>,
+        methodReturnType: MethodReturnTypeInfo,
     ): String {
         val invocationArguments = arguments.joinToString(
             separator = ", ",
             transform = ::determineSpyInvocationArgument
         )
+        val typesParameter = resolveTypes(parameter)
 
-        return buildSpy("__spyOn!!.$methodName($invocationArguments)")
+        return buildSpy("__spyOn!!.$methodName$typesParameter($invocationArguments)")
     }
 
     override fun buildEqualsSpy(mockName: String): String {

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/MethodReturnTypeInfoExtensions.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/MethodReturnTypeInfoExtensions.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.mock
+
+import com.squareup.kotlinpoet.TypeName
+import tech.antibytes.kmock.processor.ProcessorContract.MethodReturnTypeInfo
+import tech.antibytes.kmock.processor.ProcessorContract.Relaxer
+
+internal fun MethodReturnTypeInfo.resolveClassScope(): List<TypeName>? {
+    return this.classScope?.get(this.actualTypeName.toString().trimEnd('?'))
+}
+
+private fun MethodReturnTypeInfo.needsCastOnReturn(): Boolean = this.typeName != this.actualTypeName
+
+private fun MethodReturnTypeInfo.needsCastForRelaxer(relaxer: Relaxer?): Boolean {
+    return relaxer != null &&
+        ((this.generic != null && this.generic.types.isNotEmpty()) || this.resolveClassScope() != null)
+}
+
+internal fun MethodReturnTypeInfo.needsCastAnnotation(
+    relaxer: Relaxer?,
+): Boolean = this.needsCastOnReturn() || this.needsCastForRelaxer(relaxer)
+
+private fun MethodReturnTypeInfo.resolveCast(condition: Boolean): String {
+    return if (condition) {
+        " as ${this.typeName}"
+    } else {
+        ""
+    }
+}
+
+internal fun MethodReturnTypeInfo.resolveCastOnReturn(): String = resolveCast(this.needsCastOnReturn())
+
+internal fun MethodReturnTypeInfo.resolveCastForRelaxer(
+    relaxer: Relaxer?
+): String = resolveCast(this.needsCastForRelaxer(relaxer))
+
+internal fun MethodReturnTypeInfo.hasGenerics(): Boolean = this.generic != null || this.classScope != null

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/mock/MethodReturnTypeInfoExtensionsSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/mock/MethodReturnTypeInfoExtensionsSpec.kt
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.kmock.processor.mock
+
+import com.squareup.kotlinpoet.TypeName
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import tech.antibytes.kmock.processor.ProcessorContract.GenericDeclaration
+import tech.antibytes.kmock.processor.ProcessorContract.MethodReturnTypeInfo
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.mustBe
+
+class MethodReturnTypeInfoExtensionsSpec {
+    private val fixture = kotlinFixture()
+
+    @Test
+    fun `Given resolveClassScope is called it returns null if no class scope was delegated`() {
+        // Given
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = mockk(),
+            actualTypeName = mockk(),
+            generic = null,
+            classScope = null
+        )
+
+        // When
+        val actual = typeInfo.resolveClassScope()
+
+        // Then
+        actual mustBe null
+    }
+
+    @Test
+    fun `Given resolveClassScope is called it returns null if no matching types were found`() {
+        // Given
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = mockk(),
+            actualTypeName = mockk(),
+            generic = null,
+            classScope = mapOf(
+                "any" to mockk()
+            )
+        )
+
+        // When
+        val actual = typeInfo.resolveClassScope()
+
+        // Then
+        actual mustBe null
+    }
+
+    @Test
+    fun `Given resolveClassScope is called it returns the resolved types`() {
+        // Given
+        val actualTypeName: TypeName = mockk()
+        val actualTypeNameStr = "${fixture.fixture<String>()}?"
+        val types: List<TypeName> = mockk()
+        val classScope: Map<String, List<TypeName>> = mapOf(
+            actualTypeNameStr.dropLast(1) to types
+        )
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = mockk(),
+            actualTypeName = actualTypeName,
+            generic = null,
+            classScope = classScope
+        )
+
+        every { actualTypeName.toString() } returns actualTypeNameStr
+
+        // When
+        val actual = typeInfo.resolveClassScope()
+
+        // Then
+        actual mustBe types
+    }
+
+    @Test
+    fun `Given needsCastAnnotation returns true if the typeName and actualTypeName differ`() {
+        // Given
+        val actualTypeName: TypeName = mockk()
+        val typeName: TypeName = mockk()
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = typeName,
+            actualTypeName = actualTypeName,
+            generic = null,
+            classScope = null
+        )
+
+        every { actualTypeName.toString() } returns fixture.fixture()
+        every { typeName.toString() } returns fixture.fixture()
+
+        // When
+        val actual = typeInfo.needsCastAnnotation(null)
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given needsCastAnnotation returns true if the relaxer is not null and it has generics types`() {
+        // Given
+        val generics: GenericDeclaration = mockk()
+        val typeName: TypeName = mockk()
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = typeName,
+            actualTypeName = typeName,
+            generic = generics,
+            classScope = null
+        )
+
+        every { generics.types } returns listOf(mockk())
+
+        // When
+        val actual = typeInfo.needsCastAnnotation(
+            relaxer = mockk()
+        )
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given needsCastAnnotation returns true if the relaxer is not null and it has a resolve ClassScope`() {
+        // Given
+        val actualTypeName: TypeName = mockk()
+        val actualTypeNameStr = "${fixture.fixture<String>()}?"
+        val types: List<TypeName> = mockk()
+        val classScope: Map<String, List<TypeName>> = mapOf(
+            actualTypeNameStr.dropLast(1) to types
+        )
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = actualTypeName,
+            actualTypeName = actualTypeName,
+            generic = null,
+            classScope = classScope
+        )
+
+        every { actualTypeName.toString() } returns actualTypeNameStr
+
+        // When
+        val actual = typeInfo.needsCastAnnotation(
+            relaxer = mockk()
+        )
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given hasGenerics returns false if neither a class scope nor a generic were given`() {
+        // Given
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = mockk(),
+            actualTypeName = mockk(),
+            generic = null,
+            classScope = null
+        )
+
+        // When
+        val actual = typeInfo.hasGenerics()
+
+        // Then
+        actual mustBe false
+    }
+
+    @Test
+    fun `Given hasGenerics returns true if a class scope was given`() {
+        // Given
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = mockk(),
+            actualTypeName = mockk(),
+            generic = null,
+            classScope = mockk()
+        )
+
+        // When
+        val actual = typeInfo.hasGenerics()
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given hasGenerics returns true if a generics was given`() {
+        // Given
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = mockk(),
+            actualTypeName = mockk(),
+            generic = mockk(),
+            classScope = null
+        )
+
+        // When
+        val actual = typeInfo.hasGenerics()
+
+        // Then
+        actual mustBe true
+    }
+
+    @Test
+    fun `Given resolveCastOnReturn returns a string if the typeName and actualTypeName differ`() {
+        // Given
+        val actualTypeName: TypeName = mockk()
+        val typeName: TypeName = mockk()
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = typeName,
+            actualTypeName = actualTypeName,
+            generic = null,
+            classScope = null
+        )
+
+        // When
+        val actual = typeInfo.resolveCastOnReturn()
+
+        // Then
+        actual mustBe " as $typeName"
+    }
+
+    @Test
+    fun `Given resolveCastForRelaxer returns an empty string if the relaxer is null`() {
+        // Given
+        val typeName: TypeName = mockk()
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = typeName,
+            actualTypeName = typeName,
+            generic = null,
+            classScope = null
+        )
+
+        // When
+        val actual = typeInfo.resolveCastForRelaxer(null)
+
+        // Then
+        actual mustBe ""
+    }
+
+    @Test
+    fun `Given resolveCastForRelaxer returns an empty string if the relaxer is not null but it has no generics types`() {
+        // Given
+        val generics: GenericDeclaration = mockk()
+        val typeName: TypeName = mockk()
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = typeName,
+            actualTypeName = typeName,
+            generic = null,
+            classScope = null
+        )
+
+        every { generics.types } returns listOf(mockk())
+
+        // When
+        val actual = typeInfo.resolveCastForRelaxer(mockk())
+
+        // Then
+        actual mustBe ""
+    }
+
+    @Test
+    fun `Given resolveCastForRelaxer returns a string if the relaxer is not null and it has generics types`() {
+        // Given
+        val generics: GenericDeclaration = mockk()
+        val typeName: TypeName = mockk()
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = typeName,
+            actualTypeName = typeName,
+            generic = generics,
+            classScope = null
+        )
+
+        every { generics.types } returns listOf(mockk())
+
+        // When
+        val actual = typeInfo.resolveCastForRelaxer(mockk())
+
+        // Then
+        actual mustBe " as $typeName"
+    }
+
+    @Test
+    fun `Given resolveCastForRelaxer returns a string if the relaxer is not null and it has a resolve ClassScope`() {
+        // Given
+        val actualTypeName: TypeName = mockk()
+        val actualTypeNameStr = "${fixture.fixture<String>()}?"
+        val types: List<TypeName> = mockk()
+        val classScope: Map<String, List<TypeName>> = mapOf(
+            actualTypeNameStr.dropLast(1) to types
+        )
+
+        val typeInfo = MethodReturnTypeInfo(
+            typeName = actualTypeName,
+            actualTypeName = actualTypeName,
+            generic = null,
+            classScope = classScope
+        )
+
+        every { actualTypeName.toString() } returns actualTypeNameStr
+
+        // When
+        val actual = typeInfo.resolveCastForRelaxer(mockk())
+
+        // Then
+        actual mustBe " as $actualTypeNameStr"
+    }
+}

--- a/kmock-processor/src/test/resources/mock/expected/relaxed/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/relaxed/Common.kt
@@ -26,7 +26,7 @@ internal class CommonMock<K : Any, L>(
         get() = _template.onGet {
             useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
                 type0 = kotlin.Any::class,
-                type1 = kotlin.Comparable::class,) }
+                type1 = kotlin.Comparable::class,) as L }
         }
         set(`value`) = _template.onSet(value)
 
@@ -86,13 +86,14 @@ internal class CommonMock<K : Any, L>(
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() {
         useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
-            type0 = kotlin.Any::class,) }
+            type0 = kotlin.Any::class,) as T }
     } as T
 
+    @Suppress("UNCHECKED_CAST")
     public override fun foo(payload: String): L = _fooWithString.invoke(payload) {
         useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
             type0 = kotlin.Any::class,
-            type1 = kotlin.Comparable::class,) }
+            type1 = kotlin.Comparable::class,) as L }
     }
 
     public override fun <T : Any> fooBar(payload: T): Unit = _fooBarWithTAny.invoke(payload) {
@@ -102,7 +103,7 @@ internal class CommonMock<K : Any, L>(
     @Suppress("UNCHECKED_CAST")
     public override fun <T : K?> fooBar(): T = _fooBarWithVoid.invoke() {
         useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
-            type0 = kotlin.Any::class,) }
+            type0 = kotlin.Any::class,) as T }
     } as T
 
     public override fun oo(vararg payload: Any): String = _oo.invoke(payload) {

--- a/kmock-processor/src/test/resources/mock/expected/spy/Alias.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Alias.kt
@@ -1,12 +1,15 @@
 package mock.template.spy
 
 import kotlin.Any
+import kotlin.Array
 import kotlin.Boolean
+import kotlin.CharSequence
 import kotlin.Comparable
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
+import kotlin.collections.List
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -70,6 +73,10 @@ internal class AliasPlatformMock<K : Any, L>(
     L> = ProxyFactory.createAsyncFunProxy("mock.template.spy.AliasPlatformMock#_buzzWithStrings",
         collector = verifier, freeze = freeze)
 
+    public val _izz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_izz", collector =
+        verifier, freeze = freeze)
+
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
         ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_toString", collector =
         verifier, freeze = freeze, ignorableForVerification = true)
@@ -108,6 +115,12 @@ internal class AliasPlatformMock<K : Any, L>(
         useSpyIf(__spyOn) { __spyOn!!.buzz(*arg0) }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> izz(): T where T : CharSequence, T : Comparable<List<Array<T>>> =
+        _izz.invoke() {
+            useSpyIf(__spyOn) { __spyOn!!.izz<T>() }
+        } as T
+
     public override fun toString(): String = _toString.invoke() {
         useRelaxerIf(true) { super.toString() }
         useSpyIf(__spyOn) { __spyOn!!.toString() }
@@ -137,6 +150,7 @@ internal class AliasPlatformMock<K : Any, L>(
         _barWithInts.clear()
         _buzzWithString.clear()
         _buzzWithStrings.clear()
+        _izz.clear()
         _toString.clear()
         _equals.clear()
         _hashCode.clear()

--- a/kmock-processor/src/test/resources/mock/expected/spy/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Common.kt
@@ -1,12 +1,15 @@
 package mock.template.spy
 
 import kotlin.Any
+import kotlin.Array
 import kotlin.Boolean
+import kotlin.CharSequence
 import kotlin.Comparable
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
+import kotlin.collections.List
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -69,6 +72,10 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createAsyncFunProxy("mock.template.spy.CommonMock#_uzz", collector = verifier,
             freeze = freeze)
 
+    public val _izz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_izz", collector = verifier,
+            freeze = freeze)
+
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
         ProxyFactory.createSyncFunProxy("mock.template.spy.CommonMock#_toString", collector =
         verifier, freeze = freeze, ignorableForVerification = true)
@@ -107,6 +114,12 @@ internal class CommonMock<K : Any, L>(
         useSpyIf(__spyOn) { __spyOn!!.uzz(*arg0) }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> izz(): T where T : CharSequence, T : Comparable<List<Array<T>>> =
+        _izz.invoke() {
+            useSpyIf(__spyOn) { __spyOn!!.izz<T>() }
+        } as T
+
     public override fun toString(): String = _toString.invoke() {
         useRelaxerIf(true) { super.toString() }
         useSpyIf(__spyOn) { __spyOn!!.toString() }
@@ -136,6 +149,7 @@ internal class CommonMock<K : Any, L>(
         _ar.clear()
         _buzz.clear()
         _uzz.clear()
+        _izz.clear()
         _toString.clear()
         _equals.clear()
         _hashCode.clear()

--- a/kmock-processor/src/test/resources/mock/expected/spy/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Platform.kt
@@ -1,12 +1,15 @@
 package mock.template.spy
 
 import kotlin.Any
+import kotlin.Array
 import kotlin.Boolean
+import kotlin.CharSequence
 import kotlin.Comparable
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
+import kotlin.collections.List
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -69,6 +72,10 @@ internal class PlatformMock<K : Any, L>(
     L> = ProxyFactory.createAsyncFunProxy("mock.template.spy.PlatformMock#_buzzWithStrings",
         collector = verifier, freeze = freeze)
 
+    public val _izz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_izz", collector = verifier,
+            freeze = freeze)
+
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
         ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_toString", collector =
         verifier, freeze = freeze, ignorableForVerification = true)
@@ -107,6 +114,12 @@ internal class PlatformMock<K : Any, L>(
         useSpyIf(__spyOn) { __spyOn!!.buzz(*arg0) }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> izz(): T where T : CharSequence, T : Comparable<List<Array<T>>> =
+        _izz.invoke() {
+            useSpyIf(__spyOn) { __spyOn!!.izz<T>() }
+        } as T
+
     public override fun toString(): String = _toString.invoke() {
         useRelaxerIf(true) { super.toString() }
         useSpyIf(__spyOn) { __spyOn!!.toString() }
@@ -136,6 +149,7 @@ internal class PlatformMock<K : Any, L>(
         _barWithInts.clear()
         _buzzWithString.clear()
         _buzzWithStrings.clear()
+        _izz.clear()
         _toString.clear()
         _equals.clear()
         _hashCode.clear()

--- a/kmock-processor/src/test/resources/mock/expected/spy/Relaxed.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Relaxed.kt
@@ -1,12 +1,15 @@
 package mock.template.spy
 
 import kotlin.Any
+import kotlin.Array
 import kotlin.Boolean
+import kotlin.CharSequence
 import kotlin.Comparable
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
+import kotlin.collections.List
 import mock.template.spy.relaxed
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
@@ -29,7 +32,7 @@ internal class RelaxedMock<K : Any, L>(
         get() = _template.onGet {
             useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
                 type0 = kotlin.Any::class,
-                type1 = kotlin.Comparable::class,) }
+                type1 = kotlin.Comparable::class,) as L }
             useSpyIf(__spyOn) { __spyOn!!.template }
         }
         set(`value`) = _template.onSet(value) {
@@ -62,6 +65,10 @@ internal class RelaxedMock<K : Any, L>(
         ProxyFactory.createAsyncFunProxy("mock.template.spy.RelaxedMock#_buzz", collector = verifier,
             freeze = freeze)
 
+    public val _izz: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_izz", collector = verifier,
+            freeze = freeze)
+
     public val _toString: KMockContract.SyncFunProxy<String, () -> kotlin.String> =
         ProxyFactory.createSyncFunProxy("mock.template.spy.RelaxedMock#_toString", collector =
         verifier, freeze = freeze, ignorableForVerification = true)
@@ -84,12 +91,22 @@ internal class RelaxedMock<K : Any, L>(
         useSpyIf(__spyOn) { __spyOn!!.bar(arg0) }
     }
 
+    @Suppress("UNCHECKED_CAST")
     public override suspend fun buzz(arg0: String): L = _buzz.invoke(arg0) {
         useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
             type0 = kotlin.Any::class,
-            type1 = kotlin.Comparable::class,) }
+            type1 = kotlin.Comparable::class,) as L }
         useSpyIf(__spyOn) { __spyOn!!.buzz(arg0) }
     }
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T> izz(): T where T : CharSequence, T : Comparable<List<Array<T>>> =
+        _izz.invoke() {
+            useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
+                type0 = kotlin.CharSequence::class,
+                type1 = kotlin.Comparable::class,) as T }
+            useSpyIf(__spyOn) { __spyOn!!.izz<T>() }
+        } as T
 
     public override fun toString(): String = _toString.invoke() {
         useRelaxerIf(true) { super.toString() }
@@ -117,6 +134,7 @@ internal class RelaxedMock<K : Any, L>(
         _foo.clear()
         _bar.clear()
         _buzz.clear()
+        _izz.clear()
         _toString.clear()
         _equals.clear()
         _hashCode.clear()

--- a/kmock-processor/src/test/resources/mock/template/spy/Common.kt
+++ b/kmock-processor/src/test/resources/mock/template/spy/Common.kt
@@ -19,4 +19,5 @@ interface Common<K, L> where L : Any, L : Comparable<L>, K : Any {
     fun ar(vararg arg0: Int): Any
     suspend fun buzz(arg0: String): L
     suspend fun uzz(vararg arg0: String): L
+    fun <T> izz(): T where T : CharSequence, T : Comparable<List<Array<T>>>
 }

--- a/kmock-processor/src/test/resources/mock/template/spy/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/template/spy/Platform.kt
@@ -19,4 +19,5 @@ interface Platform<K, L> where L : Any, L : Comparable<L>, K : Any {
     fun bar(vararg arg0: Int): Any
     suspend fun buzz(arg0: String): L
     suspend fun buzz(vararg arg0: String): L
+    fun <T> izz(): T where T : CharSequence, T : Comparable<List<Array<T>>>
 }

--- a/kmock-processor/src/test/resources/mock/template/spy/Relaxed.kt
+++ b/kmock-processor/src/test/resources/mock/template/spy/Relaxed.kt
@@ -22,4 +22,5 @@ interface Relaxed<K, L> where L : Any, L : Comparable<L>, K : Any {
     fun <T> foo(payload: T)
     fun bar(arg0: Int): Any
     suspend fun buzz(arg0: String): L
+    fun <T> izz(): T where T : CharSequence, T : Comparable<List<Array<T>>>
 }

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericMock.kt
@@ -497,31 +497,31 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> uzz(): T where T : SomeGeneric<String>, T : List<String> = _uzz.invoke() {
-        useSpyIf(__spyOn) { __spyOn!!.uzz() }
+        useSpyIf(__spyOn) { __spyOn!!.uzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> lzz(): T where T : SomeGeneric<String>, T : List<String>? = _lzz.invoke()
     {
-        useSpyIf(__spyOn) { __spyOn!!.lzz() }
+        useSpyIf(__spyOn) { __spyOn!!.lzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> tzz(): T where T : SomeGeneric<String>?, T : List<String>? = _tzz.invoke()
     {
-        useSpyIf(__spyOn) { __spyOn!!.tzz() }
+        useSpyIf(__spyOn) { __spyOn!!.tzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> rzz(): T where T : SomeGeneric<String>, T : Map<String, String> =
         _rzz.invoke() {
-            useSpyIf(__spyOn) { __spyOn!!.rzz() }
+            useSpyIf(__spyOn) { __spyOn!!.rzz<T>() }
         } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> izz(): T where T : SomeGeneric<String>, T : Comparable<List<Array<T>>> =
         _izz.invoke() {
-            useSpyIf(__spyOn) { __spyOn!!.izz() }
+            useSpyIf(__spyOn) { __spyOn!!.izz<T>() }
         } as T
 
     @Suppress("UNCHECKED_CAST")
@@ -543,13 +543,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
     Comparable<List<Array<R>>> = _kss.invoke(arg0) {
-        useSpyIf(__spyOn) { __spyOn!!.kss(arg0) }
+        useSpyIf(__spyOn) { __spyOn!!.kss<T, R>(arg0) }
     } as R
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
     Comparable<List<Array<T>>> = _iss.invoke(arg0) {
-        useSpyIf(__spyOn) { __spyOn!!.iss(arg0) }
+        useSpyIf(__spyOn) { __spyOn!!.iss<R, T>(arg0) }
     } as R
 
     @Suppress("UNCHECKED_CAST")
@@ -560,13 +560,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
         _xssWithTAny.invoke(arg0) {
-            useSpyIf(__spyOn) { __spyOn!!.xss(arg0) }
+            useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0) }
         } as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
         = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-        useSpyIf(__spyOn) { __spyOn!!.xss(arg0, arg1) }
+        useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0, arg1) }
     }
 
     public override fun doSomething(arg: KMockTypeParameter4): KMockTypeParameter5 =

--- a/kmock-processor/src/test/resources/multi/expected/platformGeneric/SpiedGenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/platformGeneric/SpiedGenericMock.kt
@@ -501,31 +501,31 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> uzz(): T where T : SomeGeneric<String>, T : List<String> = _uzz.invoke() {
-        useSpyIf(__spyOn) { __spyOn!!.uzz() }
+        useSpyIf(__spyOn) { __spyOn!!.uzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> lzz(): T where T : SomeGeneric<String>, T : List<String>? = _lzz.invoke()
     {
-        useSpyIf(__spyOn) { __spyOn!!.lzz() }
+        useSpyIf(__spyOn) { __spyOn!!.lzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> tzz(): T where T : SomeGeneric<String>?, T : List<String>? = _tzz.invoke()
     {
-        useSpyIf(__spyOn) { __spyOn!!.tzz() }
+        useSpyIf(__spyOn) { __spyOn!!.tzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> rzz(): T where T : SomeGeneric<String>, T : Map<String, String> =
         _rzz.invoke() {
-            useSpyIf(__spyOn) { __spyOn!!.rzz() }
+            useSpyIf(__spyOn) { __spyOn!!.rzz<T>() }
         } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> izz(): T where T : SomeGeneric<String>, T : Comparable<List<Array<T>>> =
         _izz.invoke() {
-            useSpyIf(__spyOn) { __spyOn!!.izz() }
+            useSpyIf(__spyOn) { __spyOn!!.izz<T>() }
         } as T
 
     @Suppress("UNCHECKED_CAST")
@@ -547,13 +547,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
     Comparable<List<Array<R>>> = _kss.invoke(arg0) {
-        useSpyIf(__spyOn) { __spyOn!!.kss(arg0) }
+        useSpyIf(__spyOn) { __spyOn!!.kss<T, R>(arg0) }
     } as R
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
     Comparable<List<Array<T>>> = _iss.invoke(arg0) {
-        useSpyIf(__spyOn) { __spyOn!!.iss(arg0) }
+        useSpyIf(__spyOn) { __spyOn!!.iss<R, T>(arg0) }
     } as R
 
     @Suppress("UNCHECKED_CAST")
@@ -564,13 +564,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
         _xssWithTAny.invoke(arg0) {
-            useSpyIf(__spyOn) { __spyOn!!.xss(arg0) }
+            useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0) }
         } as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
         = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-        useSpyIf(__spyOn) { __spyOn!!.xss(arg0, arg1) }
+        useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0, arg1) }
     }
 
     public override fun doSomething(arg: KMockTypeParameter4): KMockTypeParameter5 =

--- a/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericMock.kt
@@ -497,31 +497,31 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> uzz(): T where T : SomeGeneric<String>, T : List<String> = _uzz.invoke() {
-        useSpyIf(__spyOn) { __spyOn!!.uzz() }
+        useSpyIf(__spyOn) { __spyOn!!.uzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> lzz(): T where T : SomeGeneric<String>, T : List<String>? = _lzz.invoke()
     {
-        useSpyIf(__spyOn) { __spyOn!!.lzz() }
+        useSpyIf(__spyOn) { __spyOn!!.lzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> tzz(): T where T : SomeGeneric<String>?, T : List<String>? = _tzz.invoke()
     {
-        useSpyIf(__spyOn) { __spyOn!!.tzz() }
+        useSpyIf(__spyOn) { __spyOn!!.tzz<T>() }
     } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> rzz(): T where T : SomeGeneric<String>, T : Map<String, String> =
         _rzz.invoke() {
-            useSpyIf(__spyOn) { __spyOn!!.rzz() }
+            useSpyIf(__spyOn) { __spyOn!!.rzz<T>() }
         } as T
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> izz(): T where T : SomeGeneric<String>, T : Comparable<List<Array<T>>> =
         _izz.invoke() {
-            useSpyIf(__spyOn) { __spyOn!!.izz() }
+            useSpyIf(__spyOn) { __spyOn!!.izz<T>() }
         } as T
 
     @Suppress("UNCHECKED_CAST")
@@ -543,13 +543,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
     Comparable<List<Array<R>>> = _kss.invoke(arg0) {
-        useSpyIf(__spyOn) { __spyOn!!.kss(arg0) }
+        useSpyIf(__spyOn) { __spyOn!!.kss<T, R>(arg0) }
     } as R
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
     Comparable<List<Array<T>>> = _iss.invoke(arg0) {
-        useSpyIf(__spyOn) { __spyOn!!.iss(arg0) }
+        useSpyIf(__spyOn) { __spyOn!!.iss<R, T>(arg0) }
     } as R
 
     @Suppress("UNCHECKED_CAST")
@@ -560,13 +560,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
         _xssWithTAny.invoke(arg0) {
-            useSpyIf(__spyOn) { __spyOn!!.xss(arg0) }
+            useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0) }
         } as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
         = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-        useSpyIf(__spyOn) { __spyOn!!.xss(arg0, arg1) }
+        useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0, arg1) }
     }
 
     public override fun doSomething(arg: KMockTypeParameter4): KMockTypeParameter5 =


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #125

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This fixes the issue that spied methods or relaxer causes compiler errors if they use generics as return values.
In terms of the spy this caused by multi bounded return value types

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [ ] My changes are reflected in the changelog.
