### PR TITLE
Add spy all flag

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,7 @@ toc::[]
 * `or` ArgumentConstraint
 * `not` ArgumentConstraint
 * `spiesOnly` in the Gradle extension, in order to tell the processor to only create `kspy`. Also `spyOn` is not needed in this configuration
+* `spyAll` in the Gradle extension, in order to tell the processor to create for al given interfaces also a spy entryPoint
 * `vararg` is now supported by Mocks
 * `freezeOnDefault` in the Gradle extension, which sets a default freeze value for `kspy` and `kmock`
 * `enableNewOverloadingNames` and `useTypePrefixFor` for overloaded names in order to ease them
@@ -42,9 +43,9 @@ toc::[]
 * `assertOrder` in order to make the names more consistent and preserves the old behaviour of `verifyStrictOrder`
 * `assertProxy` as alternative to `verify`
 * iosSimulatorArm64 support
-* support for instrumented Android tests (aka androidAndroidTest) on KMP
+* Support for instrumented Android tests (aka androidAndroidTest) on KMP
 * Multi-Interface Mocks support
-* interface receiver members are full supported
+* Interface receiver members are full supported
 * `run` for FunProxies to mitigate the strict assignment policy in terms of a single SideEffect
 * `runs` for FunProxies to mitigate the strict assignment policy in terms of SideEffects
 
@@ -60,8 +61,8 @@ toc::[]
 * Android MinSDK 23 -> 21
 * `spyOn` is now capable of picking up KMock defined Aliases
 * `kspy` in terms of generics not longer exposed if not declared via `spyOn` or `spiesOnly`
-* relaxation method gets now the return type boundaries delegated, if generic in order to resolve type conflicts
-* generic methods names get prefixed by the generic type name, if overloaded to avoid name collisions
+* Relaxation method gets now the return type boundaries delegated, if generic in order to resolve type conflicts
+* Generic methods names get prefixed by the generic type name, if overloaded to avoid name collisions
 
 === Deprecated
 
@@ -72,7 +73,7 @@ toc::[]
 * `allowedRecursiveTypes`, since it is no longer needed due to the new spy invocation
 * `allowInterfacesOnKmock`, use allowInterfaces instead
 * `allowInterfacesOnKspy`, use allowInterfaces instead
-* old experimental ProxyAssertion family, use `assertProxy` or `verify` instead
+* Old experimental ProxyAssertion family, use `assertProxy` or `verify` instead
 
 === Fixed
 

--- a/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockExtension.kt
+++ b/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockExtension.kt
@@ -19,6 +19,7 @@ import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.KSP_DIR
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.OVERLOAD_NAME_FEATURE_FLAG
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.ROOT_PACKAGE
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.SPIES_ONLY
+import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.SPY_ALL
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.SPY_ON
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.TYPE_PREFIXES
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.USELESS_PREFIXES
@@ -55,6 +56,7 @@ abstract class KMockExtension(
     private var _allowInterfaces = false
 
     private var _spyOn: Set<String> = emptySet()
+    private var _spyAll = false
     private var _spiesOnly = false
 
     private var _disableFactories = false
@@ -188,6 +190,13 @@ abstract class KMockExtension(
         set(value) {
             propagateValue(SPIES_ONLY, value.toString())
             _spiesOnly = value
+        }
+
+    override var spyAll: Boolean
+        get() = _spyAll
+        set(value) {
+            propagateValue(SPY_ALL, value.toString())
+            _spyAll = value
         }
 
     override var disableFactories: Boolean

--- a/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockPluginContract.kt
+++ b/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockPluginContract.kt
@@ -74,8 +74,17 @@ internal interface KMockPluginContract {
         /**
          * Switch which will KMock tell generate only `kspy` instead of `kmock`.
          * `kspy` will automatically reference all generated spies an additional invocation of `spyOn` is not needed.
+         *
+         * Default is false
          */
         var spiesOnly: Boolean
+
+        /**
+         * Enables spies for all given Interfaces.
+         *
+         * Default is false
+         */
+        var spyAll: Boolean
 
         /**
          * Enable factory functions to reference Mocks by their interfaces.
@@ -123,6 +132,7 @@ internal interface KMockPluginContract {
         const val ALIASES = "${KMOCK_PREFIX}alias_"
         const val USE_BUILD_IN = "${KMOCK_PREFIX}buildIn_"
         const val SPY_ON = "${KMOCK_PREFIX}spyOn_"
+        const val SPY_ALL = "${KMOCK_PREFIX}spyAll"
         const val SPIES_ONLY = "${KMOCK_PREFIX}spiesOnly"
         const val OVERLOAD_NAME_FEATURE_FLAG = "${KMOCK_PREFIX}useNewOverloadedNames"
         const val USELESS_PREFIXES = "${KMOCK_PREFIX}oldNamePrefix_"

--- a/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/ExtensionSpec.kt
+++ b/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/ExtensionSpec.kt
@@ -552,6 +552,35 @@ class ExtensionSpec {
     }
 
     @Test
+    fun `Its spyAll is false by default`() {
+        val project: Project = mockk(relaxed = true)
+        val kspExtension: KspExtension = mockk()
+
+        every { project.extensions.getByType(KspExtension::class.java) } returns kspExtension
+
+        val extension = createExtension<KMockExtension>(project)
+
+        extension.spyAll mustBe false
+    }
+
+    @Test
+    fun `It propagates spyAll changes to Ksp`() {
+        // Given
+        val project: Project = mockk(relaxed = true)
+        val kspExtension: KspExtension = mockk(relaxed = true)
+        val expected: Boolean = fixture.fixture()
+
+        every { project.extensions.getByType(KspExtension::class.java) } returns kspExtension
+
+        // When
+        val extension = createExtension<KMockExtension>(project)
+        extension.spyAll = expected
+
+        extension.spyAll mustBe expected
+        verify(exactly = 1) { kspExtension.arg("kmock_spyAll", expected.toString()) }
+    }
+
+    @Test
     fun `Its disableFactories is false by default`() {
         val project: Project = mockk(relaxed = true)
         val kspExtension: KspExtension = mockk()

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockOptionExtractor.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockOptionExtractor.kt
@@ -18,6 +18,7 @@ import tech.antibytes.kmock.processor.ProcessorContract.Companion.OVERLOAD_NAME_
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.PRECEDENCE
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.ROOT_PACKAGE
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.SPIES_ONLY
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.SPY_ALL
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.SPY_ON
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.TYPE_PREFIXES
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.USELESS_PREFIXES
@@ -53,6 +54,7 @@ internal object KMockOptionExtractor : OptionExtractor {
         var freezeOnDefault = true
         var allowInterfaces = false
         var spiesOnly = false
+        var spyAll = false
         var disableFactories = false
         var enableNewOverloadingNames = true
         val uselessPrefixes: MutableSet<String> = mutableSetOf()
@@ -68,6 +70,7 @@ internal object KMockOptionExtractor : OptionExtractor {
                 key == FREEZE -> freezeOnDefault = value.toBoolean()
                 key == INTERFACES -> allowInterfaces = value.toBoolean()
                 key == SPIES_ONLY -> spiesOnly = value.toBoolean()
+                key == SPY_ALL -> spyAll = value.toBoolean()
                 key == DISABLE_FACTORIES -> disableFactories = value.toBoolean()
                 key.startsWith(PRECEDENCE) -> extractMappedValue(PRECEDENCE, key, value) { sourceSet, precedence ->
                     precedences[sourceSet] = precedence.toInt()
@@ -120,6 +123,7 @@ internal object KMockOptionExtractor : OptionExtractor {
             aliases = aliases,
             useBuildInProxiesOn = useBuildInProxiesOn,
             spyOn = spyOn,
+            spyAll = spyAll,
             enableNewOverloadingNames = enableNewOverloadingNames,
             useTypePrefixFor = useTypePrefixFor,
             customMethodNames = customMethodNames,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockProcessorProvider.kt
@@ -106,8 +106,9 @@ class KMockProcessorProvider(
         val options = KMockOptionExtractor.convertOptions(environment.options)
 
         val spyContainer = SpyContainer(
+            spyOn = options.spyOn,
+            spyAll = options.spyAll,
             spiesOnly = options.spiesOnly,
-            spyOn = options.spyOn
         )
 
         val codeGenerator = KMockCodeGenerator(

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -52,6 +52,7 @@ internal interface ProcessorContract {
         val freezeOnDefault: Boolean,
         val allowInterfaces: Boolean,
         val spiesOnly: Boolean,
+        val spyAll: Boolean,
         val disableFactories: Boolean,
         val rootPackage: String,
         val knownSharedSourceSets: Set<String>,
@@ -657,6 +658,7 @@ internal interface ProcessorContract {
         const val USE_BUILD_IN = "${KMOCK_PREFIX}buildIn_"
         const val SPY_ON = "${KMOCK_PREFIX}spyOn_"
         const val SPIES_ONLY = "${KMOCK_PREFIX}spiesOnly"
+        const val SPY_ALL = "${KMOCK_PREFIX}spyAll"
         const val OVERLOAD_NAME_FEATURE_FLAG = "${KMOCK_PREFIX}useNewOverloadedNames"
         const val USELESS_PREFIXES = "${KMOCK_PREFIX}oldNamePrefix_"
         const val TYPE_PREFIXES = "${KMOCK_PREFIX}namePrefix_"

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/mock/KMockGenerator.kt
@@ -325,7 +325,7 @@ internal class KMockGenerator(
             }
         }
 
-        if (templateName in useBuildInProxiesOn || enableSpy) {
+        if (enableSpy || templateName in useBuildInProxiesOn) {
             val (proxies, functions) = buildInGenerator.buildMethodBundles(
                 mockName = mockName,
                 qualifier = qualifier,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SpyContainer.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/utils/SpyContainer.kt
@@ -11,17 +11,19 @@ import tech.antibytes.kmock.processor.ProcessorContract
 import tech.antibytes.kmock.processor.ProcessorContract.Source
 
 internal class SpyContainer(
-    private val spiesOnly: Boolean,
     private val spyOn: Set<String>,
+    private val spiesOnly: Boolean,
+    private val spyAll: Boolean
 ) : ProcessorContract.SpyContainer {
     override fun isSpyable(
         template: KSClassDeclaration?,
         packageName: String,
         templateName: String
     ): Boolean {
-        return template?.qualifiedName?.asString() in spyOn ||
-            "$packageName.$templateName" in spyOn ||
-            spiesOnly
+        return spiesOnly ||
+            spyAll ||
+            template?.qualifiedName?.asString() in spyOn ||
+            "$packageName.$templateName" in spyOn
     }
 
     private fun List<Source>.deriveQualifiedNames(): List<String> {
@@ -33,5 +35,5 @@ internal class SpyContainer(
         return this.filter { qualifiedName -> qualifiedName !in filter }
     }
 
-    override fun hasSpies(filter: List<Source>): Boolean = spyOn.filterSpies(filter).isNotEmpty() || spiesOnly
+    override fun hasSpies(filter: List<Source>): Boolean = spiesOnly || spyAll || spyOn.filterSpies(filter).isNotEmpty()
 }

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockOptionExtractorSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/processor/KMockOptionExtractorSpec.kt
@@ -415,6 +415,48 @@ class KMockOptionExtractorSpec {
     }
 
     @Test
+    fun `Given convertOptions it returns false for spyAll if no value was propagated`() {
+        // Given
+        val rootPackage: String = fixture.fixture()
+        val isKmp: Boolean = fixture.fixture()
+        val kspDir: String = fixture.fixture()
+
+        val delegateKSP = mutableMapOf(
+            "kmock_kspDir" to kspDir,
+            "kmock_rootPackage" to rootPackage,
+            "kmock_isKmp" to isKmp.toString()
+        )
+
+        // When
+        val actual = KMockOptionExtractor.convertOptions(delegateKSP)
+
+        // Then
+        actual.spyAll mustBe false
+    }
+
+    @Test
+    fun `Given convertOptions it returns the propagated value for spyAll`() {
+        // Given
+        val rootPackage: String = fixture.fixture()
+        val isKmp: Boolean = fixture.fixture()
+        val kspDir: String = fixture.fixture()
+        val expected = true
+
+        val delegateKSP = mutableMapOf(
+            "kmock_kspDir" to kspDir,
+            "kmock_rootPackage" to rootPackage,
+            "kmock_isKmp" to isKmp.toString(),
+            "kmock_spyAll" to expected.toString()
+        )
+
+        // When
+        val actual = KMockOptionExtractor.convertOptions(delegateKSP)
+
+        // Then
+        actual.spyAll mustBe expected
+    }
+
+    @Test
     fun `Given convertOptions it returns false for disableFactories if no value was propagated`() {
         // Given
         val rootPackage: String = fixture.fixture()


### PR DESCRIPTION
### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This adds a new flag (`spyAll`) to make it possible to generate for all interfaces spies.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [x] My changes update the documentation.
- [x] My changes are reflected in the changelog.
