### PR TITLE
Fix nullable generics methods

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -64,6 +64,7 @@ toc::[]
 * `kspy` in terms of generics not longer exposed if not declared via `spyOn` or `spiesOnly`
 * Relaxation method gets now the return type boundaries delegated, if generic in order to resolve type conflicts
 * Generic methods names get prefixed by the generic type name, if overloaded to avoid name collisions
+* Generic methods names get prefixed by the generic type name and a nullable, if overloaded and nullable to avoid name collisions
 * Meta/Shared Source Annotation are now supporting platform references (e.g. instead of metaTest you can write meta)
 * Custom Source Annotation are now supporting platform references (e.g. instead of sharedTest you can write shared)
 

--- a/kmock-processor/src/test/resources/mock/expected/compatibility/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/compatibility/Common.kt
@@ -66,8 +66,8 @@ internal class CommonMock(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.CommonMock#_fooWithFunction1",
             collector = verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.CommonMock#_fooWithTAny",
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.CommonMock#_fooWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _fooWithTMockTemplateCompatibilityCommon:
@@ -97,7 +97,7 @@ internal class CommonMock(
 
     public override fun foo(fuzz: Function1<Any, Unit>): Any = _fooWithFunction1.invoke(fuzz)
 
-    public override fun <T> foo(fuzz: T): Unit = _fooWithTAny.invoke(fuzz) {
+    public override fun <T> foo(fuzz: T): Unit = _fooWithZTAny.invoke(fuzz) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -122,7 +122,7 @@ internal class CommonMock(
         _fooWithStringAny.clear()
         _fooWithStringMockTemplateCompatibilityAbc.clear()
         _fooWithFunction1.clear()
-        _fooWithTAny.clear()
+        _fooWithZTAny.clear()
         _fooWithTMockTemplateCompatibilityCommon.clear()
         _fooWithTMockTemplateCompatibilityLPG.clear()
         _fooWithAnys.clear()

--- a/kmock-processor/src/test/resources/mock/expected/compatibility/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/compatibility/Platform.kt
@@ -40,13 +40,13 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_fooWithVoid",
             collector = verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_fooWithTAny",
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_fooWithZTAny",
             collector = verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_fooWithTAnys",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_fooWithZTAnys",
             collector = verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
@@ -101,15 +101,15 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_bussWithVoid",
             collector = verifier, freeze = freeze)
 
-    public val _bussWithTCollectionsList:
+    public val _bussWithZTCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_bussWithTCollectionsList",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_bussWithZTCollectionsList",
             collector = verifier, freeze = freeze)
 
-    public val _bussWithTCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTCollectionsLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_bussWithTCollectionsLists",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_bussWithZTCollectionsLists",
             collector = verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -181,15 +181,15 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_blissWithVoid",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -240,14 +240,14 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_tzzWithVoid",
             collector = verifier, freeze = freeze)
 
-    public val _tzzWithTMockTemplateCompatibilitySomeGenericCollectionsList:
+    public val _tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsList:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_tzzWithTMockTemplateCompatibilitySomeGenericCollectionsList",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsList",
             collector = verifier, freeze = freeze)
 
-    public val _tzzWithTMockTemplateCompatibilitySomeGenericCollectionsLists:
+    public val _tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsLists:
         KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_tzzWithTMockTemplateCompatibilitySomeGenericCollectionsLists",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsLists",
             collector = verifier, freeze = freeze)
 
     public val _rzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
@@ -282,14 +282,14 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_ossWithTAny",
             collector = verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_ossWithTAnyRAny",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_ossWithTAnyZRAny",
             collector = verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_ossWithRAnyTAnys",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_ossWithZRAnyTAnys",
             collector = verifier, freeze = freeze)
 
     public val _kssWithTMockTemplateCompatibilitySomeGenericComparable:
@@ -303,13 +303,13 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_kssWithTMockTemplateCompatibilitySomeGenericComparableRMockTemplateCompatibilitySomeGenericComparable",
             collector = verifier, freeze = freeze)
 
-    public val _issWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_issWithTAny",
+    public val _issWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_issWithZTAny",
             collector = verifier, freeze = freeze)
 
-    public val _issWithTAnyRMockTemplateCompatibilitySomeGenericComparable:
+    public val _issWithZTAnyRMockTemplateCompatibilitySomeGenericComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_issWithTAnyRMockTemplateCompatibilitySomeGenericComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_issWithZTAnyRMockTemplateCompatibilitySomeGenericComparable",
             collector = verifier, freeze = freeze)
 
     public val _pssWithTMockTemplateCompatibilitySomeGeneric:
@@ -324,23 +324,23 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_pssWithTMockTemplateCompatibilitySomeGenericRMockTemplateCompatibilitySomeGeneric",
             collector = verifier, freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_xssWithTAny",
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_xssWithZTAny",
             collector = verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequencesSequenceCharSequence:
+    public val _xssWithZTAnyRSequencesSequenceCharSequence:
         KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_xssWithTAnyRSequencesSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("mock.template.compatibility.PlatformMock#_xssWithZTAnyRSequencesSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -385,12 +385,12 @@ internal class PlatformMock<K : Any, L>(
     public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTCollectionsList.invoke(payload) {
+        _bussWithZTCollectionsList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTCollectionsLists.invoke(payload) {
+        _bussWithZTCollectionsLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -448,12 +448,12 @@ internal class PlatformMock<K : Any, L>(
     public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -504,12 +504,12 @@ internal class PlatformMock<K : Any, L>(
         _tzzWithVoid.invoke() as T
 
     public override fun <T> tzz(payload: T): Unit where T : SomeGeneric<String>?, T : List<String>? =
-        _tzzWithTMockTemplateCompatibilitySomeGenericCollectionsList.invoke(payload) {
+        _tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T> tzz(vararg payload: T): Unit where T : SomeGeneric<String>?, T :
-    List<String>? = _tzzWithTMockTemplateCompatibilitySomeGenericCollectionsLists.invoke(payload)
+    List<String>? = _tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsLists.invoke(payload)
     {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
@@ -549,14 +549,15 @@ internal class PlatformMock<K : Any, L>(
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> oss(arg0: T): R = _ossWithTAny.invoke(arg0) as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -572,11 +573,11 @@ internal class PlatformMock<K : Any, L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
-    Comparable<List<Array<T>>> = _issWithTAny.invoke(arg0) as R
+    Comparable<List<Array<T>>> = _issWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> iss(arg0: T, arg1: R): Unit where R : SomeGeneric<String>, R :
     Comparable<List<Array<T>>> =
-        _issWithTAnyRMockTemplateCompatibilitySomeGenericComparable.invoke(arg0, arg1) {
+        _issWithZTAnyRMockTemplateCompatibilitySomeGenericComparable.invoke(arg0, arg1) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -592,18 +593,18 @@ internal class PlatformMock<K : Any, L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) as R
+        _xssWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequencesSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequencesSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
     public fun _clearMock(): Unit {
         _template.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -614,8 +615,8 @@ internal class PlatformMock<K : Any, L>(
         _blubbWithTCollectionsList.clear()
         _blubbWithTCollectionsLists.clear()
         _bussWithVoid.clear()
-        _bussWithTCollectionsList.clear()
-        _bussWithTCollectionsLists.clear()
+        _bussWithZTCollectionsList.clear()
+        _bussWithZTCollectionsLists.clear()
         _bossWithVoid.clear()
         _bossWithTCollectionsList.clear()
         _bossWithTCollectionsLists.clear()
@@ -629,8 +630,8 @@ internal class PlatformMock<K : Any, L>(
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTCollectionsMap.clear()
         _lossWithTCollectionsMaps.clear()
@@ -641,8 +642,8 @@ internal class PlatformMock<K : Any, L>(
         _lzzWithTMockTemplateCompatibilitySomeGenericCollectionsList.clear()
         _lzzWithTMockTemplateCompatibilitySomeGenericCollectionsLists.clear()
         _tzzWithVoid.clear()
-        _tzzWithTMockTemplateCompatibilitySomeGenericCollectionsList.clear()
-        _tzzWithTMockTemplateCompatibilitySomeGenericCollectionsLists.clear()
+        _tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsList.clear()
+        _tzzWithZTMockTemplateCompatibilitySomeGenericCollectionsLists.clear()
         _rzzWithVoid.clear()
         _rzzWithTMockTemplateCompatibilitySomeGenericCollectionsMap.clear()
         _rzzWithTMockTemplateCompatibilitySomeGenericCollectionsMaps.clear()
@@ -650,15 +651,15 @@ internal class PlatformMock<K : Any, L>(
         _izzWithTMockTemplateCompatibilitySomeGenericComparable.clear()
         _izzWithTMockTemplateCompatibilitySomeGenericComparables.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kssWithTMockTemplateCompatibilitySomeGenericComparable.clear()
         _kssWithTMockTemplateCompatibilitySomeGenericComparableRMockTemplateCompatibilitySomeGenericComparable.clear()
-        _issWithTAny.clear()
-        _issWithTAnyRMockTemplateCompatibilitySomeGenericComparable.clear()
+        _issWithZTAny.clear()
+        _issWithZTAnyRMockTemplateCompatibilitySomeGenericComparable.clear()
         _pssWithTMockTemplateCompatibilitySomeGeneric.clear()
         _pssWithTMockTemplateCompatibilitySomeGenericRMockTemplateCompatibilitySomeGeneric.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequencesSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequencesSequenceCharSequence.clear()
     }
 }

--- a/kmock-processor/src/test/resources/mock/expected/generic/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/Common.kt
@@ -40,8 +40,8 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
@@ -96,15 +96,15 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithTList", collector =
-        verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithZTList", collector
+        = verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithTLists", collector
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_bussWithZTLists", collector
         = verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -176,15 +176,15 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -232,14 +232,14 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _tzzWithTSomeGenericList: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) ->
+    public val _tzzWithZTSomeGenericList: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithTSomeGenericList",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithZTSomeGenericList",
             collector = verifier, freeze = freeze)
 
-    public val _tzzWithTSomeGenericLists: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithTSomeGenericLists",
+    public val _tzzWithZTSomeGenericLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Any?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_tzzWithZTSomeGenericLists",
             collector = verifier, freeze = freeze)
 
     public val _rzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
@@ -273,14 +273,14 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithTAnyRAny", collector
-        = verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithTAnyZRAny",
+            collector = verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithRAnyTAnys",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_ossWithZRAnyTAnys",
             collector = verifier, freeze = freeze)
 
     public val _kssWithTSomeGenericComparable: KMockContract.SyncFunProxy<Any, (kotlin.Any) ->
@@ -293,13 +293,13 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_kssWithTSomeGenericComparableRSomeGenericComparable",
             collector = verifier, freeze = freeze)
 
-    public val _issWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_issWithTAny", collector =
+    public val _issWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_issWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _issWithTAnyRSomeGenericComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _issWithZTAnyRSomeGenericComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_issWithTAnyRSomeGenericComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_issWithZTAnyRSomeGenericComparable",
             collector = verifier, freeze = freeze)
 
     public val _pssWithTSomeGeneric:
@@ -314,19 +314,19 @@ internal class CommonMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_pssWithTSomeGenericRSomeGeneric",
             collector = verifier, freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.CommonMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -371,12 +371,12 @@ internal class CommonMock<K : Any, L>(
     public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -434,12 +434,12 @@ internal class CommonMock<K : Any, L>(
     public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -489,12 +489,12 @@ internal class CommonMock<K : Any, L>(
         _tzzWithVoid.invoke() as T
 
     public override fun <T> tzz(payload: T): Unit where T : SomeGeneric<String>?, T : List<String>? =
-        _tzzWithTSomeGenericList.invoke(payload) {
+        _tzzWithZTSomeGenericList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T> tzz(vararg payload: T): Unit where T : SomeGeneric<String>?, T :
-    List<String>? = _tzzWithTSomeGenericLists.invoke(payload) {
+    List<String>? = _tzzWithZTSomeGenericLists.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -529,14 +529,15 @@ internal class CommonMock<K : Any, L>(
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> oss(arg0: T): R = _ossWithTAny.invoke(arg0) as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -550,10 +551,10 @@ internal class CommonMock<K : Any, L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
-    Comparable<List<Array<T>>> = _issWithTAny.invoke(arg0) as R
+    Comparable<List<Array<T>>> = _issWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> iss(arg0: T, arg1: R): Unit where R : SomeGeneric<String>, R :
-    Comparable<List<Array<T>>> = _issWithTAnyRSomeGenericComparable.invoke(arg0, arg1) {
+    Comparable<List<Array<T>>> = _issWithZTAnyRSomeGenericComparable.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -568,17 +569,17 @@ internal class CommonMock<K : Any, L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) as R
+        _xssWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
     public fun _clearMock(): Unit {
         _template.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
+        _fooWithZTAny.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -589,8 +590,8 @@ internal class CommonMock<K : Any, L>(
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -604,8 +605,8 @@ internal class CommonMock<K : Any, L>(
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -616,8 +617,8 @@ internal class CommonMock<K : Any, L>(
         _lzzWithTSomeGenericList.clear()
         _lzzWithTSomeGenericLists.clear()
         _tzzWithVoid.clear()
-        _tzzWithTSomeGenericList.clear()
-        _tzzWithTSomeGenericLists.clear()
+        _tzzWithZTSomeGenericList.clear()
+        _tzzWithZTSomeGenericLists.clear()
         _rzzWithVoid.clear()
         _rzzWithTSomeGenericMap.clear()
         _rzzWithTSomeGenericMaps.clear()
@@ -625,15 +626,15 @@ internal class CommonMock<K : Any, L>(
         _izzWithTSomeGenericComparable.clear()
         _izzWithTSomeGenericComparables.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kssWithTSomeGenericComparable.clear()
         _kssWithTSomeGenericComparableRSomeGenericComparable.clear()
-        _issWithTAny.clear()
-        _issWithTAnyRSomeGenericComparable.clear()
+        _issWithZTAny.clear()
+        _issWithZTAnyRSomeGenericComparable.clear()
         _pssWithTSomeGeneric.clear()
         _pssWithTSomeGenericRSomeGeneric.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
     }
 }

--- a/kmock-processor/src/test/resources/mock/expected/generic/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/Platform.kt
@@ -44,13 +44,13 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithTAny", collector =
-        verifier, freeze = freeze)
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithZTAny", collector
+        = verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithTAnys", collector
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_fooWithZTAnys", collector
         = verifier, freeze = freeze)
 
     public val _lol: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Array<out kotlin.Any>>) ->
@@ -109,15 +109,15 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithVoid", collector
         = verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithTList", collector
-        = verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithZTList",
+            collector = verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithTLists",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_bussWithZTLists",
             collector = verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -189,15 +189,15 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithVoid", collector
         = verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -247,14 +247,14 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _tzzWithTSomeGenericList: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) ->
+    public val _tzzWithZTSomeGenericList: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithTSomeGenericList",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithZTSomeGenericList",
             collector = verifier, freeze = freeze)
 
-    public val _tzzWithTSomeGenericLists: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithTSomeGenericLists",
+    public val _tzzWithZTSomeGenericLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    kotlin.Any?>) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_tzzWithZTSomeGenericLists",
             collector = verifier, freeze = freeze)
 
     public val _rzzWithVoid: KMockContract.SyncFunProxy<Any, () -> kotlin.Any> =
@@ -289,14 +289,14 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithTAnyRAny",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithTAnyZRAny",
             collector = verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithRAnyTAnys",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_ossWithZRAnyTAnys",
             collector = verifier, freeze = freeze)
 
     public val _kssWithTSomeGenericComparable: KMockContract.SyncFunProxy<Any, (kotlin.Any) ->
@@ -309,13 +309,13 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_kssWithTSomeGenericComparableRSomeGenericComparable",
             collector = verifier, freeze = freeze)
 
-    public val _issWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_issWithTAny", collector =
-        verifier, freeze = freeze)
+    public val _issWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_issWithZTAny", collector
+        = verifier, freeze = freeze)
 
-    public val _issWithTAnyRSomeGenericComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _issWithZTAnyRSomeGenericComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_issWithTAnyRSomeGenericComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_issWithZTAnyRSomeGenericComparable",
             collector = verifier, freeze = freeze)
 
     public val _pssWithTSomeGeneric:
@@ -330,13 +330,13 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_pssWithTSomeGenericRSomeGeneric",
             collector = verifier, freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_xssWithTAny", collector =
-        verifier, freeze = freeze)
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_xssWithZTAny", collector
+        = verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.PlatformMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     public override fun foo(payload: Any): String = _fooWithAny.invoke(payload)
@@ -344,11 +344,11 @@ internal class PlatformMock<K : Any, L>(
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -397,12 +397,12 @@ internal class PlatformMock<K : Any, L>(
     public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -460,12 +460,12 @@ internal class PlatformMock<K : Any, L>(
     public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -515,12 +515,12 @@ internal class PlatformMock<K : Any, L>(
         _tzzWithVoid.invoke() as T
 
     public override fun <T> tzz(payload: T): Unit where T : SomeGeneric<String>?, T : List<String>? =
-        _tzzWithTSomeGenericList.invoke(payload) {
+        _tzzWithZTSomeGenericList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T> tzz(vararg payload: T): Unit where T : SomeGeneric<String>?, T :
-    List<String>? = _tzzWithTSomeGenericLists.invoke(payload) {
+    List<String>? = _tzzWithZTSomeGenericLists.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -555,14 +555,15 @@ internal class PlatformMock<K : Any, L>(
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> oss(arg0: T): R = _ossWithTAny.invoke(arg0) as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -576,10 +577,10 @@ internal class PlatformMock<K : Any, L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
-    Comparable<List<Array<T>>> = _issWithTAny.invoke(arg0) as R
+    Comparable<List<Array<T>>> = _issWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> iss(arg0: T, arg1: R): Unit where R : SomeGeneric<String>, R :
-    Comparable<List<Array<T>>> = _issWithTAnyRSomeGenericComparable.invoke(arg0, arg1) {
+    Comparable<List<Array<T>>> = _issWithZTAnyRSomeGenericComparable.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -594,10 +595,10 @@ internal class PlatformMock<K : Any, L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) as R
+        _xssWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -605,8 +606,8 @@ internal class PlatformMock<K : Any, L>(
         _template.clear()
         _fooWithAny.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _lol.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
@@ -618,8 +619,8 @@ internal class PlatformMock<K : Any, L>(
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -633,8 +634,8 @@ internal class PlatformMock<K : Any, L>(
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -645,8 +646,8 @@ internal class PlatformMock<K : Any, L>(
         _lzzWithTSomeGenericList.clear()
         _lzzWithTSomeGenericLists.clear()
         _tzzWithVoid.clear()
-        _tzzWithTSomeGenericList.clear()
-        _tzzWithTSomeGenericLists.clear()
+        _tzzWithZTSomeGenericList.clear()
+        _tzzWithZTSomeGenericLists.clear()
         _rzzWithVoid.clear()
         _rzzWithTSomeGenericMap.clear()
         _rzzWithTSomeGenericMaps.clear()
@@ -654,15 +655,15 @@ internal class PlatformMock<K : Any, L>(
         _izzWithTSomeGenericComparable.clear()
         _izzWithTSomeGenericComparables.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kssWithTSomeGenericComparable.clear()
         _kssWithTSomeGenericComparableRSomeGenericComparable.clear()
-        _issWithTAny.clear()
-        _issWithTAnyRSomeGenericComparable.clear()
+        _issWithZTAny.clear()
+        _issWithZTAnyRSomeGenericComparable.clear()
         _pssWithTSomeGeneric.clear()
         _pssWithTSomeGenericRSomeGeneric.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
     }
 }

--- a/kmock-processor/src/test/resources/mock/expected/generic/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/Shared.kt
@@ -40,8 +40,8 @@ internal class SharedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
@@ -51,6 +51,20 @@ internal class SharedMock<K : Any, L>(
     public val _blaWithTInt: KMockContract.SyncFunProxy<Unit, (kotlin.Int) -> kotlin.Unit> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithTInt", collector =
         verifier, freeze = freeze)
+
+    public val _blaWithZTInt: KMockContract.SyncFunProxy<Unit, (kotlin.Int?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithZTInt", collector =
+        verifier, freeze = freeze)
+
+    public val _blaWithTCharSequenceComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithTCharSequenceComparable",
+            collector = verifier, freeze = freeze)
+
+    public val _blaWithTCharSequenceComparableKCharSequenceComparable:
+        KMockContract.SyncFunProxy<Unit, (kotlin.Any, kotlin.Any) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blaWithTCharSequenceComparableKCharSequenceComparable",
+            collector = verifier, freeze = freeze)
 
     public val _barWithTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.String>>) ->
@@ -76,11 +90,11 @@ internal class SharedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blubbWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bussWithTList", collector =
-        verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_bussWithZTList", collector
+        = verifier, freeze = freeze)
 
     public val _bussWithVoid:
         KMockContract.SyncFunProxy<kotlin.collections.List<kotlin.Array<kotlin.Int>>?, () ->
@@ -132,10 +146,10 @@ internal class SharedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_brassWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
     public val _blissWithVoid:
@@ -170,9 +184,9 @@ internal class SharedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_lzzWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _tzzWithTSomeGenericList: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) ->
+    public val _tzzWithZTSomeGenericList: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_tzzWithTSomeGenericList",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_tzzWithZTSomeGenericList",
             collector = verifier, freeze = freeze)
 
     public val _tzzWithVoid: KMockContract.SyncFunProxy<Any?, () -> kotlin.Any?> =
@@ -196,10 +210,10 @@ internal class SharedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_izzWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ossWithTAnyRAny", collector
-        = verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ossWithTAnyZRAny",
+            collector = verifier, freeze = freeze)
 
     public val _ossWithTAny: KMockContract.SyncFunProxy<Any?, (kotlin.Any?) -> kotlin.Any?> =
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_ossWithTAny", collector =
@@ -215,13 +229,13 @@ internal class SharedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_kssWithTSomeGenericComparable",
             collector = verifier, freeze = freeze)
 
-    public val _issWithTAnyRSomeGenericComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _issWithZTAnyRSomeGenericComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_issWithTAnyRSomeGenericComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_issWithZTAnyRSomeGenericComparable",
             collector = verifier, freeze = freeze)
 
-    public val _issWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_issWithTAny", collector =
+    public val _issWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_issWithZTAny", collector =
         verifier, freeze = freeze)
 
     public val _pssWithTSomeGeneric:
@@ -236,19 +250,19 @@ internal class SharedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_pssWithTSomeGenericRSomeGeneric",
             collector = verifier, freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SharedMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -256,6 +270,20 @@ internal class SharedMock<K : Any, L>(
     public override fun <T : Int> bla(): T = _blaWithVoid.invoke() as T
 
     public override fun <T : Int> bla(payload: T): Unit = _blaWithTInt.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T : Int?> bla(payload: T): Unit = _blaWithZTInt.invoke(payload) {
+        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+    }
+
+    public override fun <T> bla(payload: T): Unit where T : CharSequence, T : Comparable<T>? =
+        _blaWithTCharSequenceComparable.invoke(payload) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
+
+    public override fun <T : K, K> bla(arg0: T, arg1: K): Unit where K : CharSequence, K :
+    Comparable<K>? = _blaWithTCharSequenceComparableKCharSequenceComparable.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -276,7 +304,7 @@ internal class SharedMock<K : Any, L>(
     public override fun <T : List<Array<String?>>> blubb(): T = _blubbWithVoid.invoke() as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -315,7 +343,7 @@ internal class SharedMock<K : Any, L>(
     public override fun <T : Comparable<List<Array<T>>>> brass(): T = _brassWithVoid.invoke() as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -349,7 +377,7 @@ internal class SharedMock<K : Any, L>(
         _lzzWithVoid.invoke() as T
 
     public override fun <T> tzz(payload: T): Unit where T : SomeGeneric<String>?, T : List<String>? =
-        _tzzWithTSomeGenericList.invoke(payload) {
+        _tzzWithZTSomeGenericList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -375,7 +403,8 @@ internal class SharedMock<K : Any, L>(
     public override fun <T> izz(): T where T : SomeGeneric<String>, T : Comparable<List<Array<T>>> =
         _izzWithVoid.invoke() as T
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -393,13 +422,13 @@ internal class SharedMock<K : Any, L>(
     Comparable<List<Array<R>>> = _kssWithTSomeGenericComparable.invoke(arg0) as R
 
     public override fun <R, T> iss(arg0: T, arg1: R): Unit where R : SomeGeneric<String>, R :
-    Comparable<List<Array<T>>> = _issWithTAnyRSomeGenericComparable.invoke(arg0, arg1) {
+    Comparable<List<Array<T>>> = _issWithZTAnyRSomeGenericComparable.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> iss(arg0: T): R where R : SomeGeneric<String>, R :
-    Comparable<List<Array<T>>> = _issWithTAny.invoke(arg0) as R
+    Comparable<List<Array<T>>> = _issWithZTAny.invoke(arg0) as R
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R : T, T : X, X : SomeGeneric<String>> pss(arg0: T): R =
@@ -412,24 +441,27 @@ internal class SharedMock<K : Any, L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) as R
+        _xssWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
     public fun _clearMock(): Unit {
         _template.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
+        _fooWithZTAny.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
+        _blaWithZTInt.clear()
+        _blaWithTCharSequenceComparable.clear()
+        _blaWithTCharSequenceComparableKCharSequenceComparable.clear()
         _barWithTList.clear()
         _barWithVoid.clear()
         _blubbWithTList.clear()
         _blubbWithVoid.clear()
-        _bussWithTList.clear()
+        _bussWithZTList.clear()
         _bussWithVoid.clear()
         _bossWithTList.clear()
         _bossWithVoid.clear()
@@ -439,7 +471,7 @@ internal class SharedMock<K : Any, L>(
         _ozzWithVoid.clear()
         _brassWithTComparable.clear()
         _brassWithVoid.clear()
-        _blissWithTComparable.clear()
+        _blissWithZTComparable.clear()
         _blissWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithVoid.clear()
@@ -447,21 +479,21 @@ internal class SharedMock<K : Any, L>(
         _uzzWithVoid.clear()
         _lzzWithTSomeGenericList.clear()
         _lzzWithVoid.clear()
-        _tzzWithTSomeGenericList.clear()
+        _tzzWithZTSomeGenericList.clear()
         _tzzWithVoid.clear()
         _rzzWithTSomeGenericMap.clear()
         _rzzWithVoid.clear()
         _izzWithTSomeGenericComparable.clear()
         _izzWithVoid.clear()
-        _ossWithTAnyRAny.clear()
+        _ossWithTAnyZRAny.clear()
         _ossWithTAny.clear()
         _kssWithTSomeGenericComparableRSomeGenericComparable.clear()
         _kssWithTSomeGenericComparable.clear()
-        _issWithTAnyRSomeGenericComparable.clear()
-        _issWithTAny.clear()
+        _issWithZTAnyRSomeGenericComparable.clear()
+        _issWithZTAny.clear()
         _pssWithTSomeGeneric.clear()
         _pssWithTSomeGenericRSomeGeneric.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
     }
 }

--- a/kmock-processor/src/test/resources/mock/expected/generic/SuperTyped.kt
+++ b/kmock-processor/src/test/resources/mock/expected/generic/SuperTyped.kt
@@ -24,9 +24,9 @@ internal class SuperTypedMock<K : Any, L>(
     @Suppress("unused")
     private val relaxed: Boolean = false,
 ) : SuperTyped<K, L> where L : Any, L : Comparable<L> {
-    public val _pptWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    public val _pptWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithTAnys",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithZTAnys",
             collector = verifier, freeze = freeze)
 
     public val _pptWithTCharSequenceComparables: KMockContract.SyncFunProxy<Unit, (Array<out
@@ -39,9 +39,9 @@ internal class SuperTypedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithTComparables",
             collector = verifier, freeze = freeze)
 
-    public val _pptWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithTAny", collector
-        = verifier, freeze = freeze)
+    public val _pptWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithZTAny",
+            collector = verifier, freeze = freeze)
 
     public val _pptWithTCharSequenceComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any) ->
     kotlin.Unit> =
@@ -53,9 +53,9 @@ internal class SuperTypedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_pptWithTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _lolWithKAnyTComparables: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _lolWithZKAnyTComparables: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Comparable<Any?>>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithKAnyTComparables",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithZKAnyTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lolWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
@@ -63,9 +63,9 @@ internal class SuperTypedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithTAnys",
             collector = verifier, freeze = freeze)
 
-    public val _lolWithKAnyTComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _lolWithZKAnyTComparable: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Comparable<Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithKAnyTComparable",
+        ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_lolWithZKAnyTComparable",
             collector = verifier, freeze = freeze)
 
     public val _lolWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
@@ -81,7 +81,7 @@ internal class SuperTypedMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.generic.SuperTypedMock#_narv", collector =
         verifier, freeze = freeze)
 
-    public override fun <T> ppt(vararg x: T): Unit = _pptWithTAnys.invoke(x) {
+    public override fun <T> ppt(vararg x: T): Unit = _pptWithZTAnys.invoke(x) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -94,7 +94,7 @@ internal class SuperTypedMock<K : Any, L>(
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T> ppt(x: T): Unit = _pptWithTAny.invoke(x) {
+    public override fun <T> ppt(x: T): Unit = _pptWithZTAny.invoke(x) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -108,7 +108,7 @@ internal class SuperTypedMock<K : Any, L>(
     }
 
     public override fun <T : Comparable<T>, K> lol(arg: K, vararg x: T): Unit =
-        _lolWithKAnyTComparables.invoke(arg, x) {
+        _lolWithZKAnyTComparables.invoke(arg, x) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -117,7 +117,7 @@ internal class SuperTypedMock<K : Any, L>(
     }
 
     public override fun <T : Comparable<T>, K> lol(arg: K, x: T): Unit =
-        _lolWithKAnyTComparable.invoke(arg, x) {
+        _lolWithZKAnyTComparable.invoke(arg, x) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -135,15 +135,15 @@ internal class SuperTypedMock<K : Any, L>(
     }
 
     public fun _clearMock(): Unit {
-        _pptWithTAnys.clear()
+        _pptWithZTAnys.clear()
         _pptWithTCharSequenceComparables.clear()
         _pptWithTComparables.clear()
-        _pptWithTAny.clear()
+        _pptWithZTAny.clear()
         _pptWithTCharSequenceComparable.clear()
         _pptWithTComparable.clear()
-        _lolWithKAnyTComparables.clear()
+        _lolWithZKAnyTComparables.clear()
         _lolWithTAnys.clear()
-        _lolWithKAnyTComparable.clear()
+        _lolWithZKAnyTComparable.clear()
         _lolWithTAny.clear()
         _buzz.clear()
         _narv.clear()

--- a/kmock-processor/src/test/resources/mock/expected/methodreceiver/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/methodreceiver/Platform.kt
@@ -38,8 +38,8 @@ internal class PlatformMock<L>(
         ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.PlatformMock#_doSomethingElseReceiverWithSomethingElse",
             collector = verifier, freeze = freeze)
 
-    public val _doSomethingElseReceiverWithTAny: KMockContract.SyncFunProxy<L, (kotlin.Any?) -> L> =
-        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.PlatformMock#_doSomethingElseReceiverWithTAny",
+    public val _doSomethingElseReceiverWithZTAny: KMockContract.SyncFunProxy<L, (kotlin.Any?) -> L> =
+        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.PlatformMock#_doSomethingElseReceiverWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _doSomethingElse:
@@ -95,7 +95,7 @@ internal class PlatformMock<L>(
         _doSomethingElseReceiverWithSomethingElse.invoke(this@doSomethingElse,)
 
     public override fun <T> T.doSomethingElse(): L =
-        _doSomethingElseReceiverWithTAny.invoke(this@doSomethingElse,)
+        _doSomethingElseReceiverWithZTAny.invoke(this@doSomethingElse,)
 
     public override fun doSomethingElse(x: SomethingElse<Any>): Unit = _doSomethingElse.invoke(x) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
@@ -135,7 +135,7 @@ internal class PlatformMock<L>(
         _equalsReceiver.clear()
         _doSomethingReceiver.clear()
         _doSomethingElseReceiverWithSomethingElse.clear()
-        _doSomethingElseReceiverWithTAny.clear()
+        _doSomethingElseReceiverWithZTAny.clear()
         _doSomethingElse.clear()
         _mutaborReceiver.clear()
         _mutabor.clear()

--- a/kmock-processor/src/test/resources/mock/expected/methodreceiver/Relaxed.kt
+++ b/kmock-processor/src/test/resources/mock/expected/methodreceiver/Relaxed.kt
@@ -39,8 +39,8 @@ internal class RelaxedMock<L>(
         ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.RelaxedMock#_doSomethingElseReceiverWithSomethingElse",
             collector = verifier, freeze = freeze)
 
-    public val _doSomethingElseReceiverWithTAny: KMockContract.SyncFunProxy<L, (kotlin.Any?) -> L> =
-        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.RelaxedMock#_doSomethingElseReceiverWithTAny",
+    public val _doSomethingElseReceiverWithZTAny: KMockContract.SyncFunProxy<L, (kotlin.Any?) -> L> =
+        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.RelaxedMock#_doSomethingElseReceiverWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _doSomethingElse:
@@ -104,7 +104,7 @@ internal class RelaxedMock<L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> T.doSomethingElse(): L =
-        _doSomethingElseReceiverWithTAny.invoke(this@doSomethingElse,) {
+        _doSomethingElseReceiverWithZTAny.invoke(this@doSomethingElse,) {
             useRelaxerIf(relaxed) { proxyId -> relaxed(proxyId,
                 type0 = kotlin.Any::class,) as L }
         }
@@ -155,7 +155,7 @@ internal class RelaxedMock<L>(
         _equalsReceiver.clear()
         _doSomethingReceiver.clear()
         _doSomethingElseReceiverWithSomethingElse.clear()
-        _doSomethingElseReceiverWithTAny.clear()
+        _doSomethingElseReceiverWithZTAny.clear()
         _doSomethingElse.clear()
         _mutaborReceiver.clear()
         _mutabor.clear()

--- a/kmock-processor/src/test/resources/mock/expected/methodreceiver/Spied.kt
+++ b/kmock-processor/src/test/resources/mock/expected/methodreceiver/Spied.kt
@@ -41,8 +41,8 @@ internal class SpiedMock<L>(
         ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.SpiedMock#_doSomethingElseReceiverWithSomethingElse",
             collector = verifier, freeze = freeze)
 
-    public val _doSomethingElseReceiverWithTAny: KMockContract.SyncFunProxy<L, (kotlin.Any?) -> L> =
-        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.SpiedMock#_doSomethingElseReceiverWithTAny",
+    public val _doSomethingElseReceiverWithZTAny: KMockContract.SyncFunProxy<L, (kotlin.Any?) -> L> =
+        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.SpiedMock#_doSomethingElseReceiverWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _doSomethingElse:
@@ -127,7 +127,7 @@ internal class SpiedMock<L>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> T.doSomethingElse(): L =
-        _doSomethingElseReceiverWithTAny.invoke(this@doSomethingElse,) {
+        _doSomethingElseReceiverWithZTAny.invoke(this@doSomethingElse,) {
             useSpyIf(__spyOn) {    spyContext {
                 this@doSomethingElse.doSomethingElse()
             } as L }
@@ -221,7 +221,7 @@ internal class SpiedMock<L>(
         _equalsReceiver.clear()
         _doSomethingReceiver.clear()
         _doSomethingElseReceiverWithSomethingElse.clear()
-        _doSomethingElseReceiverWithTAny.clear()
+        _doSomethingElseReceiverWithZTAny.clear()
         _doSomethingElse.clear()
         _mutaborReceiver.clear()
         _mutabor.clear()

--- a/kmock-processor/src/test/resources/mock/expected/methodreceiver/SuperType.kt
+++ b/kmock-processor/src/test/resources/mock/expected/methodreceiver/SuperType.kt
@@ -38,8 +38,8 @@ internal class InheritedMock<P>(
         ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.InheritedMock#_doSomethingElseReceiverWithSomethingElse",
             collector = verifier, freeze = freeze)
 
-    public val _doSomethingElseReceiverWithTAny: KMockContract.SyncFunProxy<P, (kotlin.Any?) -> P> =
-        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.InheritedMock#_doSomethingElseReceiverWithTAny",
+    public val _doSomethingElseReceiverWithZTAny: KMockContract.SyncFunProxy<P, (kotlin.Any?) -> P> =
+        ProxyFactory.createSyncFunProxy("mock.template.methodreceiver.InheritedMock#_doSomethingElseReceiverWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _doSomethingElse:
@@ -95,7 +95,7 @@ internal class InheritedMock<P>(
         _doSomethingElseReceiverWithSomethingElse.invoke(this@doSomethingElse,)
 
     public override fun <T> T.doSomethingElse(): P =
-        _doSomethingElseReceiverWithTAny.invoke(this@doSomethingElse,)
+        _doSomethingElseReceiverWithZTAny.invoke(this@doSomethingElse,)
 
     public override fun doSomethingElse(x: SomethingElse<Any>): Unit = _doSomethingElse.invoke(x) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
@@ -135,7 +135,7 @@ internal class InheritedMock<P>(
         _equalsReceiver.clear()
         _doSomethingReceiver.clear()
         _doSomethingElseReceiverWithSomethingElse.clear()
-        _doSomethingElseReceiverWithTAny.clear()
+        _doSomethingElseReceiverWithZTAny.clear()
         _doSomethingElse.clear()
         _mutaborReceiver.clear()
         _mutabor.clear()

--- a/kmock-processor/src/test/resources/mock/expected/overloaded/Collision.kt
+++ b/kmock-processor/src/test/resources/mock/expected/overloaded/Collision.kt
@@ -70,8 +70,8 @@ internal class CollisionMock(
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.CollisionMock#_fooWithFunction1",
             collector = verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CollisionMock#_fooWithTAny",
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CollisionMock#_fooWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _fooWithTCollision:
@@ -103,7 +103,7 @@ internal class CollisionMock(
 
     public override fun foo(fuzz: Function1<Any, Unit>): Any = _fooWithFunction1.invoke(fuzz)
 
-    public override fun <T> foo(fuzz: T): Unit = _fooWithTAny.invoke(fuzz) {
+    public override fun <T> foo(fuzz: T): Unit = _fooWithZTAny.invoke(fuzz) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -127,7 +127,7 @@ internal class CollisionMock(
         _fooWithStringAbc.clear()
         _fooWithStringScopedAbc.clear()
         _fooWithFunction1.clear()
-        _fooWithTAny.clear()
+        _fooWithZTAny.clear()
         _fooWithTCollision.clear()
         _fooWithTLPG.clear()
         _fooWithAnys.clear()

--- a/kmock-processor/src/test/resources/mock/expected/overloaded/Common.kt
+++ b/kmock-processor/src/test/resources/mock/expected/overloaded/Common.kt
@@ -65,8 +65,8 @@ internal class CommonMock(
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithFunction1",
             collector = verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithTAny", collector
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.CommonMock#_fooWithZTAny", collector
         = verifier, freeze = freeze)
 
     public val _fooWithTCommon: KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.Common) ->
@@ -95,7 +95,7 @@ internal class CommonMock(
 
     public override fun foo(fuzz: Function1<Any, Unit>): Any = _fooWithFunction1.invoke(fuzz)
 
-    public override fun <T> foo(fuzz: T): Unit = _fooWithTAny.invoke(fuzz) {
+    public override fun <T> foo(fuzz: T): Unit = _fooWithZTAny.invoke(fuzz) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -118,7 +118,7 @@ internal class CommonMock(
         _fooWithStringAny.clear()
         _fooWithStringAbc.clear()
         _fooWithFunction1.clear()
-        _fooWithTAny.clear()
+        _fooWithZTAny.clear()
         _fooWithTCommon.clear()
         _fooWithTLPG.clear()
         _fooWithAnys.clear()

--- a/kmock-processor/src/test/resources/mock/expected/overloaded/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/overloaded/Platform.kt
@@ -65,8 +65,8 @@ internal class PlatformMock(
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithFunction1",
             collector = verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithTAny",
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.PlatformMock#_fooWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _fooWithTPlatform:
@@ -95,7 +95,7 @@ internal class PlatformMock(
 
     public override fun foo(fuzz: Function1<Any, Unit>): Any = _fooWithFunction1.invoke(fuzz)
 
-    public override fun <T> foo(fuzz: T): Unit = _fooWithTAny.invoke(fuzz) {
+    public override fun <T> foo(fuzz: T): Unit = _fooWithZTAny.invoke(fuzz) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -118,7 +118,7 @@ internal class PlatformMock(
         _fooWithStringAny.clear()
         _fooWithStringAbc.clear()
         _fooWithFunction1.clear()
-        _fooWithTAny.clear()
+        _fooWithZTAny.clear()
         _fooWithTPlatform.clear()
         _fooWithTLPG.clear()
         _fooWithAnys.clear()

--- a/kmock-processor/src/test/resources/mock/expected/overloaded/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/expected/overloaded/Shared.kt
@@ -65,8 +65,8 @@ internal class SharedMock(
         ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithFunction1",
             collector = verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithTAny", collector
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.overloaded.SharedMock#_fooWithZTAny", collector
         = verifier, freeze = freeze)
 
     public val _fooWithTShared: KMockContract.SyncFunProxy<Unit, (mock.template.overloaded.Shared) ->
@@ -91,7 +91,7 @@ internal class SharedMock(
 
     public override fun foo(fuzz: Function1<Any, Unit>): Any = _fooWithFunction1.invoke(fuzz)
 
-    public override fun <T> foo(fuzz: T): Unit = _fooWithTAny.invoke(fuzz) {
+    public override fun <T> foo(fuzz: T): Unit = _fooWithZTAny.invoke(fuzz) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -112,7 +112,7 @@ internal class SharedMock(
         _fooWithStringAny.clear()
         _fooWithStringAbc.clear()
         _fooWithFunction1.clear()
-        _fooWithTAny.clear()
+        _fooWithZTAny.clear()
         _fooWithTShared.clear()
         _fooWithTLPG.clear()
     }

--- a/kmock-processor/src/test/resources/mock/expected/spy/Alias.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Alias.kt
@@ -48,14 +48,14 @@ internal class AliasPlatformMock<K : Any, L>(
         ProxyFactory.createPropertyProxy("mock.template.spy.AliasPlatformMock#_ozz", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithTAny", collector
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithZTAny", collector
         = verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithTAnys", collector
-        = verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_fooWithZTAnys",
+            collector = verifier, freeze = freeze)
 
     public val _barWithInt: KMockContract.SyncFunProxy<Any, (kotlin.Int) -> kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_barWithInt", collector =
@@ -89,12 +89,12 @@ internal class AliasPlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.spy.AliasPlatformMock#_hashCode", collector =
         verifier, freeze = freeze, ignorableForVerification = true)
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(payload) }
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(*payload) }
     }
@@ -144,8 +144,8 @@ internal class AliasPlatformMock<K : Any, L>(
     public fun _clearMock(): Unit {
         _template.clear()
         _ozz.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _barWithInt.clear()
         _barWithInts.clear()
         _buzzWithString.clear()

--- a/kmock-processor/src/test/resources/mock/expected/spy/Platform.kt
+++ b/kmock-processor/src/test/resources/mock/expected/spy/Platform.kt
@@ -48,13 +48,14 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createPropertyProxy("mock.template.spy.PlatformMock#_ozz", collector = verifier,
             freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> = ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithTAnys",
-        collector = verifier, freeze = freeze)
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_fooWithZTAnys", collector =
+        verifier, freeze = freeze)
 
     public val _barWithInt: KMockContract.SyncFunProxy<Any, (kotlin.Int) -> kotlin.Any> =
         ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_barWithInt", collector =
@@ -88,12 +89,12 @@ internal class PlatformMock<K : Any, L>(
         ProxyFactory.createSyncFunProxy("mock.template.spy.PlatformMock#_hashCode", collector =
         verifier, freeze = freeze, ignorableForVerification = true)
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(payload) }
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(*payload) }
     }
@@ -143,8 +144,8 @@ internal class PlatformMock<K : Any, L>(
     public fun _clearMock(): Unit {
         _template.clear()
         _ozz.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _barWithInt.clear()
         _barWithInts.clear()
         _buzzWithString.clear()

--- a/kmock-processor/src/test/resources/mock/template/generic/Shared.kt
+++ b/kmock-processor/src/test/resources/mock/template/generic/Shared.kt
@@ -23,6 +23,9 @@ interface Shared<K, L> where L : Any, L : Comparable<L>, K : Any {
 
     fun <T : Int> bla(): T
     fun <T : Int> bla(payload: T)
+    fun <T : Int?> bla(payload: T)
+    fun <T> bla(payload: T) where T : CharSequence, T : Comparable<T>?
+    fun <T : K, K> bla(arg0: T, arg1: K) where K : CharSequence, K : Comparable<K>?
 
     fun <T : List<Array<String>>> bar(payload: T)
     fun <T : List<Array<String>>> bar(): T

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericMock.kt
@@ -60,12 +60,12 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithTAnys",
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithZTAnys",
         collector = verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
@@ -118,14 +118,14 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
-        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithTList",
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithZTList",
         collector = verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithTLists", collector =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithZTLists", collector =
         verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -198,15 +198,15 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -248,14 +248,14 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithTAnyRAny", collector =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithTAnyZRAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithRAnyTAnys", collector =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithZRAnyTAnys", collector =
         verifier, freeze = freeze)
 
     public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
@@ -272,13 +272,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_pss", collector = verifier,
             freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
@@ -295,11 +295,11 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -344,12 +344,12 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -409,12 +409,12 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -454,14 +454,15 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> oss(arg0: T): R = _ossWithTAny.invoke(arg0) as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -477,10 +478,10 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) as R
+        _xssWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -495,8 +496,8 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _template.clear()
         _lol.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -507,8 +508,8 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -522,8 +523,8 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -533,13 +534,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _rzz.clear()
         _izz.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kss.clear()
         _iss.clear()
         _pss.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
         _doSomething.clear()
         _compareTo.clear()
     }

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericMock.kt
@@ -68,12 +68,12 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithTAnys",
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_fooWithZTAnys",
         collector = verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
@@ -126,14 +126,14 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
-        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithTList",
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithZTList",
         collector = verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithTLists", collector =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_bussWithZTLists", collector =
         verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -206,15 +206,15 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -256,14 +256,14 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithTAnyRAny", collector =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithTAnyZRAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithRAnyTAnys", collector =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_ossWithZRAnyTAnys", collector =
         verifier, freeze = freeze)
 
     public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
@@ -280,13 +280,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_pss", collector = verifier,
             freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("multi.CommonGenericMultiMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
@@ -317,12 +317,12 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         useSpyIf(__spyOn) { __spyOn!!.foo() }
     } as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(payload) }
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(*payload) }
     }
@@ -382,13 +382,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     } as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.buss(payload) }
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.buss(*payload) }
         }
@@ -467,13 +467,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     } as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.bliss(payload) }
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.bliss(*payload) }
         }
@@ -529,16 +529,17 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         useSpyIf(__spyOn) { __spyOn!!.oss(arg0) }
     } as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.oss(arg0, arg1) }
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-        useSpyIf(__spyOn) { __spyOn!!.oss(arg0, *arg1) }
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.oss(arg0, *arg1) }
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -559,12 +560,12 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) {
+        _xssWithZTAny.invoke(arg0) {
             useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0) }
         } as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0, arg1) }
     }
@@ -604,8 +605,8 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _template.clear()
         _lol.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -616,8 +617,8 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -631,8 +632,8 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -642,13 +643,13 @@ GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _rzz.clear()
         _izz.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kss.clear()
         _iss.clear()
         _pss.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
         _doSomething.clear()
         _compareTo.clear()
         _toString.clear()

--- a/kmock-processor/src/test/resources/multi/expected/platformGeneric/GenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/platformGeneric/GenericMock.kt
@@ -60,13 +60,14 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithTAnys",
-        collector = verifier, freeze = freeze)
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithZTAnys", collector =
+        verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blaWithVoid", collector =
@@ -119,15 +120,15 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithTList", collector =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithZTList", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithTLists", collector =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithZTLists", collector =
         verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -202,15 +203,15 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -252,14 +253,14 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithTAnyRAny", collector =
-        verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithTAnyZRAny", collector
+        = verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithRAnyTAnys", collector
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithZRAnyTAnys", collector
         = verifier, freeze = freeze)
 
     public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
@@ -276,13 +277,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_pss", collector = verifier,
             freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
@@ -299,11 +300,11 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -348,12 +349,12 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -413,12 +414,12 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -458,14 +459,15 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> oss(arg0: T): R = _ossWithTAny.invoke(arg0) as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -481,10 +483,10 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) as R
+        _xssWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -499,8 +501,8 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _template.clear()
         _lol.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -511,8 +513,8 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -526,8 +528,8 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -537,13 +539,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _rzz.clear()
         _izz.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kss.clear()
         _iss.clear()
         _pss.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
         _doSomething.clear()
         _compareTo.clear()
     }

--- a/kmock-processor/src/test/resources/multi/expected/platformGeneric/SpiedGenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/platformGeneric/SpiedGenericMock.kt
@@ -68,13 +68,14 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithTAnys",
-        collector = verifier, freeze = freeze)
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_fooWithZTAnys", collector =
+        verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blaWithVoid", collector =
@@ -127,15 +128,15 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithTList", collector =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithZTList", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithTLists", collector =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_bussWithZTLists", collector =
         verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -210,15 +211,15 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -260,14 +261,14 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithTAnyRAny", collector =
-        verifier, freeze = freeze)
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithTAnyZRAny", collector
+        = verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithRAnyTAnys", collector
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_ossWithZRAnyTAnys", collector
         = verifier, freeze = freeze)
 
     public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
@@ -284,13 +285,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_pss", collector = verifier,
             freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("multi.PlatformGenericMultiMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
@@ -321,12 +322,12 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         useSpyIf(__spyOn) { __spyOn!!.foo() }
     } as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(payload) }
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(*payload) }
     }
@@ -386,13 +387,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     } as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.buss(payload) }
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.buss(*payload) }
         }
@@ -471,13 +472,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     } as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.bliss(payload) }
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.bliss(*payload) }
         }
@@ -533,16 +534,17 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         useSpyIf(__spyOn) { __spyOn!!.oss(arg0) }
     } as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.oss(arg0, arg1) }
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-        useSpyIf(__spyOn) { __spyOn!!.oss(arg0, *arg1) }
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.oss(arg0, *arg1) }
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -563,12 +565,12 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) {
+        _xssWithZTAny.invoke(arg0) {
             useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0) }
         } as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0, arg1) }
     }
@@ -608,8 +610,8 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _template.clear()
         _lol.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -620,8 +622,8 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -635,8 +637,8 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -646,13 +648,13 @@ GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _rzz.clear()
         _izz.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kss.clear()
         _iss.clear()
         _pss.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
         _doSomething.clear()
         _compareTo.clear()
         _toString.clear()

--- a/kmock-processor/src/test/resources/multi/expected/receiver/SpiedReceiverMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/receiver/SpiedReceiverMock.kt
@@ -214,9 +214,9 @@ internal class ReceiverMultiMock<KMockTypeParameter0, KMockTypeParameter1, Multi
         ProxyFactory.createSyncFunProxy("multi.ReceiverMultiMock#_doSomethingElseReceiverWithSomethingElse",
             collector = verifier, freeze = freeze)
 
-    public val _doSomethingElseReceiverWithTAny:
+    public val _doSomethingElseReceiverWithZTAny:
         KMockContract.SyncFunProxy<KMockTypeParameter1, (kotlin.Any?) -> KMockTypeParameter1> =
-        ProxyFactory.createSyncFunProxy("multi.ReceiverMultiMock#_doSomethingElseReceiverWithTAny",
+        ProxyFactory.createSyncFunProxy("multi.ReceiverMultiMock#_doSomethingElseReceiverWithZTAny",
             collector = verifier, freeze = freeze)
 
     public val _doSomethingElse:
@@ -303,7 +303,7 @@ internal class ReceiverMultiMock<KMockTypeParameter0, KMockTypeParameter1, Multi
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> T.doSomethingElse(): KMockTypeParameter1 =
-        _doSomethingElseReceiverWithTAny.invoke(this@doSomethingElse,) {
+        _doSomethingElseReceiverWithZTAny.invoke(this@doSomethingElse,) {
             useSpyIf(__spyOn) {    spyContext {
                 this@doSomethingElse.doSomethingElse()
             } as KMockTypeParameter1 }
@@ -410,7 +410,7 @@ internal class ReceiverMultiMock<KMockTypeParameter0, KMockTypeParameter1, Multi
         _equalsReceiver.clear()
         _doSomethingReceiver.clear()
         _doSomethingElseReceiverWithSomethingElse.clear()
-        _doSomethingElseReceiverWithTAny.clear()
+        _doSomethingElseReceiverWithZTAny.clear()
         _doSomethingElse.clear()
         _mutaborReceiver.clear()
         _mutabor.clear()

--- a/kmock-processor/src/test/resources/multi/expected/sharedGeneric/GenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/sharedGeneric/GenericMock.kt
@@ -60,12 +60,12 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithTAnys",
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithZTAnys",
         collector = verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
@@ -118,14 +118,14 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
-        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithTList",
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithZTList",
         collector = verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithTLists", collector =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithZTLists", collector =
         verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -198,15 +198,15 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -248,14 +248,14 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithTAnyRAny", collector =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithTAnyZRAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithRAnyTAnys", collector =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithZRAnyTAnys", collector =
         verifier, freeze = freeze)
 
     public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
@@ -272,13 +272,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_pss", collector = verifier,
             freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
@@ -295,11 +295,11 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T> foo(): T = _fooWithVoid.invoke() as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -344,12 +344,12 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     public override fun <T : List<Array<Int>>?> buss(): T = _bussWithVoid.invoke() as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -409,12 +409,12 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     public override fun <T : Comparable<List<Array<T>>>?> bliss(): T = _blissWithVoid.invoke() as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         }
 
@@ -454,14 +454,15 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> oss(arg0: T): R = _ossWithTAny.invoke(arg0) as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -477,10 +478,10 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) as R
+        _xssWithZTAny.invoke(arg0) as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
     }
 
@@ -495,8 +496,8 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _template.clear()
         _lol.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -507,8 +508,8 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -522,8 +523,8 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -533,13 +534,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _rzz.clear()
         _izz.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kss.clear()
         _iss.clear()
         _pss.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
         _doSomething.clear()
         _compareTo.clear()
     }

--- a/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericMock.kt
+++ b/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericMock.kt
@@ -68,12 +68,12 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithTAny", collector =
+    public val _fooWithZTAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?) -> kotlin.Unit> =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _fooWithTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
-    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithTAnys",
+    public val _fooWithZTAnys: KMockContract.SyncFunProxy<Unit, (Array<out kotlin.Any?>) ->
+    kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_fooWithZTAnys",
         collector = verifier, freeze = freeze)
 
     public val _blaWithVoid: KMockContract.SyncFunProxy<Int, () -> kotlin.Int> =
@@ -126,14 +126,14 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _bussWithTList:
+    public val _bussWithZTList:
         KMockContract.SyncFunProxy<Unit, (kotlin.collections.List<kotlin.Array<kotlin.Int>>?) ->
-        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithTList",
+        kotlin.Unit> = ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithZTList",
         collector = verifier, freeze = freeze)
 
-    public val _bussWithTLists: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _bussWithZTLists: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithTLists", collector =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_bussWithZTLists", collector =
         verifier, freeze = freeze)
 
     public val _bossWithVoid:
@@ -206,15 +206,15 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithVoid", collector =
         verifier, freeze = freeze)
 
-    public val _blissWithTComparable:
+    public val _blissWithZTComparable:
         KMockContract.SyncFunProxy<Unit, (kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?) ->
         kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithTComparable",
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithZTComparable",
             collector = verifier, freeze = freeze)
 
-    public val _blissWithTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
+    public val _blissWithZTComparables: KMockContract.SyncFunProxy<Unit, (Array<out
     kotlin.Comparable<kotlin.collections.List<kotlin.Array<Any?>>>?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithTComparables",
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_blissWithZTComparables",
             collector = verifier, freeze = freeze)
 
     public val _lossWithVoid: KMockContract.SyncFunProxy<kotlin.collections.Map<kotlin.String,
@@ -256,14 +256,14 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithTAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithTAnyRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
+    public val _ossWithTAnyZRAny: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, kotlin.Any?) ->
     kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithTAnyRAny", collector =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithTAnyZRAny", collector =
         verifier, freeze = freeze)
 
-    public val _ossWithRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
+    public val _ossWithZRAnyTAnys: KMockContract.SyncFunProxy<Unit, (kotlin.Any?, Array<out
     kotlin.Any?>) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithRAnyTAnys", collector =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_ossWithZRAnyTAnys", collector =
         verifier, freeze = freeze)
 
     public val _kss: KMockContract.SyncFunProxy<Any, (kotlin.Any) -> kotlin.Any> =
@@ -280,13 +280,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_pss", collector = verifier,
             freeze = freeze)
 
-    public val _xssWithTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithTAny", collector =
+    public val _xssWithZTAny: KMockContract.SyncFunProxy<Any, (kotlin.Any?) -> kotlin.Any> =
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithZTAny", collector =
         verifier, freeze = freeze)
 
-    public val _xssWithTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
+    public val _xssWithZTAnyRSequenceCharSequence: KMockContract.SyncFunProxy<Unit, (kotlin.Any?,
         kotlin.Any) -> kotlin.Unit> =
-        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithTAnyRSequenceCharSequence",
+        ProxyFactory.createSyncFunProxy("multi.SharedGenericMultiMock#_xssWithZTAnyRSequenceCharSequence",
             collector = verifier, freeze = freeze)
 
     public val _doSomething: KMockContract.SyncFunProxy<KMockTypeParameter5, (KMockTypeParameter4) ->
@@ -317,12 +317,12 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         useSpyIf(__spyOn) { __spyOn!!.foo() }
     } as T
 
-    public override fun <T> foo(payload: T): Unit = _fooWithTAny.invoke(payload) {
+    public override fun <T> foo(payload: T): Unit = _fooWithZTAny.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(payload) }
     }
 
-    public override fun <T> foo(vararg payload: T): Unit = _fooWithTAnys.invoke(payload) {
+    public override fun <T> foo(vararg payload: T): Unit = _fooWithZTAnys.invoke(payload) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.foo(*payload) }
     }
@@ -382,13 +382,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     } as T
 
     public override fun <T : List<Array<Int>>?> buss(payload: T): Unit =
-        _bussWithTList.invoke(payload) {
+        _bussWithZTList.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.buss(payload) }
         }
 
     public override fun <T : List<Array<Int>>?> buss(vararg payload: T): Unit =
-        _bussWithTLists.invoke(payload) {
+        _bussWithZTLists.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.buss(*payload) }
         }
@@ -467,13 +467,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
     } as T
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(payload: T): Unit =
-        _blissWithTComparable.invoke(payload) {
+        _blissWithZTComparable.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.bliss(payload) }
         }
 
     public override fun <T : Comparable<List<Array<T>>>?> bliss(vararg payload: T): Unit =
-        _blissWithTComparables.invoke(payload) {
+        _blissWithZTComparables.invoke(payload) {
             useUnitFunRelaxerIf(relaxUnitFun || relaxed)
             useSpyIf(__spyOn) { __spyOn!!.bliss(*payload) }
         }
@@ -529,16 +529,17 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         useSpyIf(__spyOn) { __spyOn!!.oss(arg0) }
     } as R
 
-    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyRAny.invoke(arg0, arg1) {
+    public override fun <T : R, R> oss(arg0: T, arg1: R): Unit = _ossWithTAnyZRAny.invoke(arg0, arg1)
+    {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.oss(arg0, arg1) }
     }
 
-    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit = _ossWithRAnyTAnys.invoke(arg0,
-        arg1) {
-        useUnitFunRelaxerIf(relaxUnitFun || relaxed)
-        useSpyIf(__spyOn) { __spyOn!!.oss(arg0, *arg1) }
-    }
+    public override fun <T : R, R> oss(arg0: R, vararg arg1: T): Unit =
+        _ossWithZRAnyTAnys.invoke(arg0, arg1) {
+            useUnitFunRelaxerIf(relaxUnitFun || relaxed)
+            useSpyIf(__spyOn) { __spyOn!!.oss(arg0, *arg1) }
+        }
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : R, R> kss(arg0: T): R where R : SomeGeneric<String>, R :
@@ -559,12 +560,12 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
 
     @Suppress("UNCHECKED_CAST")
     public override fun <R, T> xss(arg0: T): R where R : Sequence<Char>, R : CharSequence =
-        _xssWithTAny.invoke(arg0) {
+        _xssWithZTAny.invoke(arg0) {
             useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0) }
         } as R
 
     public override fun <R, T> xss(arg0: T, arg1: R): Unit where R : Sequence<Char>, R : CharSequence
-        = _xssWithTAnyRSequenceCharSequence.invoke(arg0, arg1) {
+        = _xssWithZTAnyRSequenceCharSequence.invoke(arg0, arg1) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
         useSpyIf(__spyOn) { __spyOn!!.xss<R, T>(arg0, arg1) }
     }
@@ -604,8 +605,8 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _template.clear()
         _lol.clear()
         _fooWithVoid.clear()
-        _fooWithTAny.clear()
-        _fooWithTAnys.clear()
+        _fooWithZTAny.clear()
+        _fooWithZTAnys.clear()
         _blaWithVoid.clear()
         _blaWithTInt.clear()
         _blaWithTInts.clear()
@@ -616,8 +617,8 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _blubbWithTList.clear()
         _blubbWithTLists.clear()
         _bussWithVoid.clear()
-        _bussWithTList.clear()
-        _bussWithTLists.clear()
+        _bussWithZTList.clear()
+        _bussWithZTLists.clear()
         _bossWithVoid.clear()
         _bossWithTList.clear()
         _bossWithTLists.clear()
@@ -631,8 +632,8 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _brassWithTComparable.clear()
         _brassWithTComparables.clear()
         _blissWithVoid.clear()
-        _blissWithTComparable.clear()
-        _blissWithTComparables.clear()
+        _blissWithZTComparable.clear()
+        _blissWithZTComparables.clear()
         _lossWithVoid.clear()
         _lossWithTMap.clear()
         _lossWithTMaps.clear()
@@ -642,13 +643,13 @@ GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5> {
         _rzz.clear()
         _izz.clear()
         _ossWithTAny.clear()
-        _ossWithTAnyRAny.clear()
-        _ossWithRAnyTAnys.clear()
+        _ossWithTAnyZRAny.clear()
+        _ossWithZRAnyTAnys.clear()
         _kss.clear()
         _iss.clear()
         _pss.clear()
-        _xssWithTAny.clear()
-        _xssWithTAnyRSequenceCharSequence.clear()
+        _xssWithZTAny.clear()
+        _xssWithZTAnyRSequenceCharSequence.clear()
         _doSomething.clear()
         _compareTo.clear()
         _toString.clear()


### PR DESCRIPTION
### :pushpin: References

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
Currently kmock cannot differentiate between nullable and non nullable generic methods if overloaded, which is fixed by this.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
