### PR TITLE
Fix Multi-Interface-Mock Factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * vararg eats specialised Array Types (e.g. IntArray) and covariant types when inherited
+* Factories for Multi-Interface-Mocks
 
 ### Security
 

--- a/detekt/config.yml
+++ b/detekt/config.yml
@@ -120,7 +120,7 @@ complexity:
     excludes: ['**/test/**', '**/androidTest/**', '**/androidAndroidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/nativeTest/**', '**/iosTest/**']
   LongParameterList:
     active: true
-    functionThreshold: 6
+    functionThreshold: 7
     constructorThreshold: 7
     ignoreDefaultParameters: false
     ignoreDataClasses: true

--- a/docs/src/howto/install.md
+++ b/docs/src/howto/install.md
@@ -286,7 +286,7 @@ However since this might cause problems or noise you can force a new version of 
         ...
         dependencies {
             classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
-            classpath("tech.antibytes.kmock:kmock-gradle:$KMockVersion-SNAPSHOT") {
+            classpath("tech.antibytes.kmock:kmock-gradle:$KMockVersion") {
                 exclude(
                     group = "com.google.devtools.ksp",
                     module = "symbol-processing-api"
@@ -308,7 +308,7 @@ However since this might cause problems or noise you can force a new version of 
     dependencies {
         ...
         implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
-        implementation("tech.antibytes.kmock:kmock-gradle:$KMockVersion-SNAPSHOT") {
+        implementation("tech.antibytes.kmock:kmock-gradle:$KMockVersion") {
             exclude(
                 group = "com.google.devtools.ksp",
                 module = "symbol-processing-api"

--- a/docs/src/howto/proxy.md
+++ b/docs/src/howto/proxy.md
@@ -177,7 +177,7 @@ Those type take the KClass of the Templates:
 @Test
 fun sampleTest() {
     // arrange
-    val genericThing: GenericMultiMock<Int, String> = kmock(
+    val genericThing: GenericMultiMock<Int, String, *> = kmock(
         templateType0 = SomethingGeneric::class,
         templateType1 = AnythingGeneric::class,
     )

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -32,6 +32,7 @@ ksp {
     arg("kmock_kspDir", "${project.buildDir.absolutePath.trimEnd('/')}/generated/ksp")
     arg("kmock_spyOn_0", "tech.antibytes.kmock.example.contract.ExampleContract.SampleDomainObject")
     arg("kmock_alternativeProxyAccess", "true")
+    arg("kmock_allowInterfaces", "true")
 }
 
 kotlin {

--- a/examples/src/commonTest/kotlin/tech/antibytes/kmock/example/SampleControllerAlternativeAccessSpec.kt
+++ b/examples/src/commonTest/kotlin/tech/antibytes/kmock/example/SampleControllerAlternativeAccessSpec.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import tech.antibytes.kmock.KMock
 import tech.antibytes.kmock.KMockExperimental
+import tech.antibytes.kmock.KMockMulti
 import tech.antibytes.kmock.example.contract.ExampleContract.DecoderFactory
 import tech.antibytes.kmock.example.contract.ExampleContract.GenericSampleDomainObject
 import tech.antibytes.kmock.example.contract.ExampleContract.SampleLocalRepository
@@ -54,6 +55,11 @@ import kotlin.test.Test
     DecoderFactory::class,
     SampleUselessObject::class,
 )
+@KMockMulti(
+    "MergedGeneric",
+    SampleLocalRepository::class,
+    GenericSampleDomainObject::class,
+)
 class SampleControllerAlternativeAccessSpec {
     private val fixture = kotlinFixture()
     private val collector = Asserter()
@@ -65,9 +71,13 @@ class SampleControllerAlternativeAccessSpec {
         relaxed = true,
         templateType = GenericSampleDomainObject::class
     )
-    private val uselessObjectObject: SampleUselessObjectMock = kmock(
+    private val uselessObject: SampleUselessObjectMock = kmock(
         collector,
         relaxed = true,
+    )
+    private val mergedGenericMock: MergedGenericMock<String, Int, *> = kmock(
+        templateType0 = SampleLocalRepository::class,
+        templateType1 = GenericSampleDomainObject::class
     )
 
     @BeforeTest
@@ -211,27 +221,42 @@ class SampleControllerAlternativeAccessSpec {
     @IgnoreJs
     fun `Given a mocked SampleUselessThing it does strange things`() {
         // Given
-        uselessObjectObject.syncFunProxyOf<Any?>(uselessObjectObject::doSomething, hint<Any>()).returnValue = 23
-        uselessObjectObject.syncFunProxyOf(uselessObjectObject::doSomething, hint<String>()).returnValue = 42
+        uselessObject.syncFunProxyOf<Any?>(uselessObject::doSomething, hint<Any>()).returnValue = 23
+        uselessObject.syncFunProxyOf(uselessObject::doSomething, hint<String>()).returnValue = 42
 
-        uselessObjectObject.syncFunProxyOf<Any?>(uselessObjectObject::doSomethingElse, hint<Any>()).returnValue = 107
-        uselessObjectObject.syncFunProxyOf(uselessObjectObject::doSomethingElse, hint<String>()).returnValue = 31
+        uselessObject.syncFunProxyOf<Any?>(uselessObject::doSomethingElse, hint<Any>()).returnValue = 107
+        uselessObject.syncFunProxyOf(uselessObject::doSomethingElse, hint<String>()).returnValue = 31
 
-        uselessObjectObject.syncFunProxyOf<Any>(uselessObjectObject::doSomething, hint<Any, String>()).returnValue = "works!"
-        uselessObjectObject.syncFunProxyOf<Any>(uselessObjectObject::doSomething, hint<Any, Int>()).returnValue = "It"
+        uselessObject.syncFunProxyOf<Any>(uselessObject::doSomething, hint<Any, String>()).returnValue = "works!"
+        uselessObject.syncFunProxyOf<Any>(uselessObject::doSomething, hint<Any, Int>()).returnValue = "It"
 
-        uselessObjectObject.syncFunProxyOf<Any>(uselessObjectObject::doSomethingElse, hint<Any, String>()).returnValue = "works!"
-        uselessObjectObject.syncFunProxyOf<Any>(uselessObjectObject::doSomethingElse, hint<Any, Int>()).returnValue = "It"
+        uselessObject.syncFunProxyOf<Any>(uselessObject::doSomethingElse, hint<Any, String>()).returnValue = "works!"
+        uselessObject.syncFunProxyOf<Any>(uselessObject::doSomethingElse, hint<Any, Int>()).returnValue = "It"
 
         // When & Then
-        uselessObjectObject.doSomething(null) mustBe 23
-        uselessObjectObject.doSomething("null") mustBe 42
-        uselessObjectObject.doSomething(Any(), 21) mustBe "It"
-        uselessObjectObject.doSomething(Any(), "argggg") mustBe "works!"
+        uselessObject.doSomething(null) mustBe 23
+        uselessObject.doSomething("null") mustBe 42
+        uselessObject.doSomething(Any(), 21) mustBe "It"
+        uselessObject.doSomething(Any(), "argggg") mustBe "works!"
 
-        uselessObjectObject.doSomethingElse("null") mustBe 31
-        uselessObjectObject.doSomethingElse(null) mustBe 107
-        uselessObjectObject.doSomethingElse(Any(), 21) mustBe "It"
-        uselessObjectObject.doSomethingElse(Any(), "argggg") mustBe "works!"
+        uselessObject.doSomethingElse("null") mustBe 31
+        uselessObject.doSomethingElse(null) mustBe 107
+        uselessObject.doSomethingElse(Any(), 21) mustBe "It"
+        uselessObject.doSomethingElse(Any(), "argggg") mustBe "works!"
+    }
+
+    @Test
+    @JsName("fnx6")
+    @IgnoreJs
+    fun `Given a mocked MergedGeneric it does strange things`() {
+        // Given
+        val id = fixture.fixture<String>()
+        mergedGenericMock.propertyProxyOf(mergedGenericMock::id).get = id
+
+        // When
+        val actual = mergedGenericMock.id
+
+        // Then
+        actual mustBe id
     }
 }

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/KMockGenerics.kt
@@ -22,6 +22,7 @@ import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toTypeVariableName
+import tech.antibytes.kmock.processor.ProcessorContract.Companion.TYPE_PARAMETER
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.any
 import tech.antibytes.kmock.processor.ProcessorContract.Companion.nullableAny
 import tech.antibytes.kmock.processor.ProcessorContract.GenericDeclaration
@@ -33,7 +34,6 @@ import tech.antibytes.kmock.processor.utils.rawType
 internal object KMockGenerics : GenericResolver {
     private val nullableAnys = listOf(nullableAny)
     private val nonNullableAnys = listOf(any)
-    private const val TYPE_PARAMETER = "KMockTypeParameter"
 
     private fun resolveBound(type: KSTypeParameter): List<KSTypeReference> = type.bounds.toList()
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/ProcessorContract.kt
@@ -577,12 +577,14 @@ internal interface ProcessorContract {
         fun generateSharedMockFactorySignature(
             mockType: TypeVariableName,
             spyType: TypeVariableName,
-            generics: List<TypeVariableName>,
+            boundaries: List<TypeName> = emptyList(),
+            generics: List<TypeVariableName> = emptyList(),
         ): FunSpec.Builder
 
         fun generateKmockSignature(
             type: TypeVariableName,
-            generics: List<TypeVariableName>,
+            boundaries: List<TypeName> = emptyList(),
+            generics: List<TypeVariableName> = emptyList(),
             hasDefault: Boolean,
             modifier: KModifier?
         ): FunSpec.Builder
@@ -590,7 +592,8 @@ internal interface ProcessorContract {
         fun generateKspySignature(
             mockType: TypeVariableName,
             spyType: TypeVariableName,
-            generics: List<TypeVariableName>,
+            boundaries: List<TypeName> = emptyList(),
+            generics: List<TypeVariableName> = emptyList(),
             hasDefault: Boolean,
             modifier: KModifier?
         ): FunSpec.Builder
@@ -602,6 +605,11 @@ internal interface ProcessorContract {
         fun resolveGenerics(templateSource: TemplateSource): List<TypeVariableName>
 
         fun <T : Source> resolveModifier(templateSource: T? = null): KModifier?
+
+        fun resolveMockType(
+            templateSource: TemplateMultiSource,
+            parameter: List<TypeName>,
+        ): TypeName
     }
 
     interface MockFactoryWithoutGenerics {
@@ -687,6 +695,8 @@ internal interface ProcessorContract {
         const val IGNORE_ARGUMENT = "ignorableForVerification"
 
         const val TEMPLATE_TYPE_ARGUMENT = "templateType"
+        const val TYPE_PARAMETER = "KMockTypeParameter"
+
         const val ARGUMENTS_WITH_RELAXER = "$COLLECTOR_ARGUMENT = $COLLECTOR_ARGUMENT, $RELAXER_ARGUMENT = $RELAXER_ARGUMENT, $UNIT_RELAXER_ARGUMENT = $UNIT_RELAXER_ARGUMENT, $FREEZE_ARGUMENT = $FREEZE_ARGUMENT, $SPY_ARGUMENT = $SPY_ARGUMENT"
         const val ARGUMENTS_WITHOUT_RELAXER = "$COLLECTOR_ARGUMENT = $COLLECTOR_ARGUMENT, $UNIT_RELAXER_ARGUMENT = $UNIT_RELAXER_ARGUMENT, $FREEZE_ARGUMENT = $FREEZE_ARGUMENT, $SPY_ARGUMENT = $SPY_ARGUMENT"
         const val UNKNOWN_INTERFACE = "throw RuntimeException(\"Unknown Interface \${$KMOCK_FACTORY_TYPE_NAME::class.simpleName}.\")"

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryEntryPointGenerator.kt
@@ -87,7 +87,6 @@ internal class KMockFactoryEntryPointGenerator(
             KSPY_FACTORY_TYPE_NAME,
             templateSource
         )
-
         val mockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME, bounds = listOf(spyType))
 
         return utils.generateKspySignature(
@@ -145,6 +144,7 @@ internal class KMockFactoryEntryPointGenerator(
         return utils.generateKspySignature(
             spyType = spyType,
             mockType = mockType,
+            boundaries = boundaries,
             generics = emptyList(),
             hasDefault = true,
             modifier = KModifier.EXPECT
@@ -152,13 +152,16 @@ internal class KMockFactoryEntryPointGenerator(
     }
 
     private fun buildMultiInterfaceGenericKMockFactory(
+        source: TemplateMultiSource,
         boundaries: List<TypeName>,
         generics: List<TypeVariableName>
     ): FunSpec {
-        val mockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME).copy(bounds = boundaries)
+        val mock = utils.resolveMockType(source, generics)
+        val mockType = TypeVariableName(KMOCK_FACTORY_TYPE_NAME).copy(bounds = listOf(mock))
 
         return utils.generateKmockSignature(
             type = mockType,
+            boundaries = boundaries,
             generics = emptyList(),
             hasDefault = true,
             modifier = KModifier.EXPECT
@@ -179,6 +182,7 @@ internal class KMockFactoryEntryPointGenerator(
         return utils.generateKspySignature(
             mockType = mockType,
             spyType = spyType,
+            boundaries = boundaries,
             generics = emptyList(),
             hasDefault = true,
             modifier = KModifier.EXPECT
@@ -195,9 +199,16 @@ internal class KMockFactoryEntryPointGenerator(
         generics: List<TypeVariableName>
     ): FunSpec {
         return if (templateSource.isSpyable()) {
-            buildMultiInterfaceGenericKSpyFactory(boundaries, generics)
+            buildMultiInterfaceGenericKSpyFactory(
+                boundaries = boundaries,
+                generics = generics,
+            )
         } else {
-            buildMultiInterfaceGenericKMockFactory(boundaries, generics)
+            buildMultiInterfaceGenericKMockFactory(
+                source = templateSource,
+                boundaries = boundaries,
+                generics = generics,
+            )
         }
     }
 

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithGenerics.kt
@@ -279,7 +279,6 @@ internal class KMockFactoryWithGenerics(
     }
 
     private companion object {
-
         private val factoryInvocationWithTemplate = """
                 |return $SHARED_MOCK_FACTORY(
                 |   $SPY_ARGUMENT = null,

--- a/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
+++ b/kmock-processor/src/main/kotlin/tech/antibytes/kmock/processor/factory/KMockFactoryWithoutGenerics.kt
@@ -179,7 +179,6 @@ internal class KMockFactoryWithoutGenerics(
         val mockFactory = utils.generateSharedMockFactorySignature(
             mockType = kspyMockType,
             spyType = kspyType,
-            generics = emptyList(),
         )
 
         if (templateSources.isEmpty() && templateMultiSources.isEmpty()) {
@@ -200,7 +199,6 @@ internal class KMockFactoryWithoutGenerics(
 
         return utils.generateKmockSignature(
             type = kmockType,
-            generics = emptyList(),
             hasDefault = !isKmp,
             modifier = modifier
         ).addCode(factoryInvocation)
@@ -214,7 +212,6 @@ internal class KMockFactoryWithoutGenerics(
         return utils.generateKspySignature(
             mockType = kspyMockType,
             spyType = kspyType,
-            generics = emptyList(),
             hasDefault = !isKmp,
             modifier = modifier
         ).addCode(spyFactoryInvocation)

--- a/kmock-processor/src/test/resources/factory/expected/alias/Generic.kt
+++ b/kmock-processor/src/test/resources/factory/expected/alias/Generic.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -39,7 +40,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Generic<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.alias.Generic<*, *>>,
+    templateType: KClass<Generic<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.alias.AliasGenericMock::class -> factory.template.alias.AliasGenericMock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -52,7 +53,7 @@ internal inline fun <reified Mock : Generic<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.alias.Generic<*, *>>,
+    templateType: KClass<Generic<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/customshared/SharedActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/customshared/SharedActual.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -43,7 +44,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.customshared.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.customshared.Shared1Mock::class -> factory.template.customshared.Shared1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -56,7 +57,7 @@ internal actual inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.customshared.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/customshared/SharedExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/customshared/SharedExpect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -16,5 +17,5 @@ internal expect inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.customshared.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/generic/CommonActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/generic/CommonActual.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -37,7 +38,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Common<K, L>, K : Any,
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Common<*, *>>,
+    templateType: KClass<Common<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.generic.CommonMock::class -> factory.template.generic.CommonMock<K, L>(collector
     = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -50,7 +51,7 @@ internal actual inline fun <reified Mock : Common<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Common<*, *>>,
+    templateType: KClass<Common<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/generic/CommonExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/generic/CommonExpect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -23,5 +24,5 @@ internal expect inline fun <reified Mock : Common<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Common<*, *>>,
+    templateType: KClass<Common<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/generic/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/expected/generic/Platform.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -39,7 +40,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Platform<K, L>, K : An
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Platform<*, *>>,
+    templateType: KClass<Platform<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.generic.PlatformMock::class -> factory.template.generic.PlatformMock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -52,7 +53,7 @@ internal inline fun <reified Mock : Platform<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Platform<*, *>>,
+    templateType: KClass<Platform<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/generic/Shared1Expect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/generic/Shared1Expect.kt
@@ -8,6 +8,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -17,7 +18,7 @@ internal expect inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>
 
 internal expect inline fun <reified Mock : Shared2<K, L>, K : Any, L> kmock(
@@ -25,5 +26,5 @@ internal expect inline fun <reified Mock : Shared2<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared2<*, *>>,
+    templateType: KClass<Shared2<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/generic/Shared2Expect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/generic/Shared2Expect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -16,5 +17,5 @@ internal expect inline fun <reified Mock : Shared3<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared3<*, *>>,
+    templateType: KClass<Shared3<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/generic/SharedActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/generic/SharedActual.kt
@@ -9,6 +9,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -40,7 +41,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.generic.Shared1Mock::class -> factory.template.generic.Shared1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -53,7 +54,7 @@ internal actual inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -70,7 +71,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared2<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared2<*, *>>,
+    templateType: KClass<Shared2<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.generic.Shared2Mock::class -> factory.template.generic.Shared2Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -83,7 +84,7 @@ internal actual inline fun <reified Mock : Shared2<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared2<*, *>>,
+    templateType: KClass<Shared2<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -100,7 +101,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared3<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared3<*, *>>,
+    templateType: KClass<Shared3<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.generic.Shared3Mock::class -> factory.template.generic.Shared3Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -113,7 +114,7 @@ internal actual inline fun <reified Mock : Shared3<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.generic.Shared3<*, *>>,
+    templateType: KClass<Shared3<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/Alias.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/Alias.kt
@@ -8,6 +8,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -72,7 +73,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Platform1::class -> factory.template.interfaze.AliasPlatformMock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -89,7 +90,7 @@ internal inline fun <reified Mock : Platform1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -103,7 +104,7 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : 
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,
@@ -120,7 +121,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, 
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+    templateType: KClass<Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Contract.Platform5::class ->
         factory.template.interfaze.Platform5Mock<K, L>(collector = collector, relaxUnitFun =
@@ -137,7 +138,7 @@ internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+    templateType: KClass<Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/CommonActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/CommonActual.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -58,7 +59,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Common1Mock::class -> factory.template.interfaze.Common1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -71,7 +72,7 @@ internal actual inline fun <reified Mock : Common1<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -85,7 +86,7 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/CommonExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/CommonExpect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -29,12 +30,12 @@ internal expect inline fun <reified Mock : Common1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>
 
 internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>, K : Any, L> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/NoSpy.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/NoSpy.kt
@@ -8,6 +8,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -60,7 +61,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Platform1::class -> factory.template.interfaze.Platform1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -76,7 +77,7 @@ internal inline fun <reified Mock : Platform1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -93,7 +94,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, 
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+    templateType: KClass<Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Contract.Platform5::class ->
         factory.template.interfaze.Platform5Mock<K, L>(collector = collector, relaxUnitFun =
@@ -110,7 +111,7 @@ internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+    templateType: KClass<Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/Platform.kt
@@ -8,6 +8,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -72,7 +73,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Platform1::class -> factory.template.interfaze.Platform1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -88,7 +89,7 @@ internal inline fun <reified Mock : Platform1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -102,7 +103,7 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : 
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,
@@ -119,7 +120,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Contract.Platform5<K, 
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+    templateType: KClass<Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Contract.Platform5::class ->
         factory.template.interfaze.Platform5Mock<K, L>(collector = collector, relaxUnitFun =
@@ -136,7 +137,7 @@ internal inline fun <reified Mock : Contract.Platform5<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Contract.Platform5<*, *>>,
+    templateType: KClass<Contract.Platform5<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/SharedActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/SharedActual.kt
@@ -8,6 +8,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -59,7 +60,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Shared1Mock::class -> factory.template.interfaze.Shared1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -72,7 +73,7 @@ internal actual inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -86,7 +87,7 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,
@@ -103,7 +104,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared.Shared4<K, L>, 
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
+    templateType: KClass<Shared.Shared4<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.interfaze.Shared4Mock::class -> factory.template.interfaze.Shared4Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -116,7 +117,7 @@ internal actual inline fun <reified Mock : Shared.Shared4<K, L>, K : Any, L> kmo
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
+    templateType: KClass<Shared.Shared4<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/interfaze/SharedExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/interfaze/SharedExpect.kt
@@ -8,6 +8,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -17,14 +18,14 @@ internal expect inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>
 
 internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>, K : Any, L> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>
 
 internal expect inline fun <reified Mock : Shared.Shared4<K, L>, K : Any, L> kmock(
@@ -32,5 +33,5 @@ internal expect inline fun <reified Mock : Shared.Shared4<K, L>, K : Any, L> kmo
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.interfaze.Shared.Shared4<*, *>>,
+    templateType: KClass<Shared.Shared4<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/mixed/Actual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/mixed/Actual.kt
@@ -10,6 +10,7 @@ import kotlin.Boolean
 import kotlin.CharSequence
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -40,7 +41,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Common<L>, L> getMockI
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.mixed.Common<*>>,
+    templateType: KClass<Common<*>>,
 ): Mock where L : Comparable<L>, L : CharSequence = when (Mock::class) {
     factory.template.mixed.CommonMock::class -> factory.template.mixed.CommonMock<L>(collector =
     collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -53,7 +54,7 @@ internal actual inline fun <reified Mock : Common<L>, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.mixed.Common<*>>,
+    templateType: KClass<Common<*>>,
 ): Mock where L : Comparable<L>, L : CharSequence = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -69,7 +70,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared<K>, K> getMockI
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.mixed.Shared<*>>,
+    templateType: KClass<Shared<*>>,
 ): Mock = when (Mock::class) {
     factory.template.mixed.SharedMock::class -> factory.template.mixed.SharedMock<K>(collector =
     collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -82,7 +83,7 @@ internal actual inline fun <reified Mock : Shared<K>, K> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.mixed.Shared<*>>,
+    templateType: KClass<Shared<*>>,
 ): Mock = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -98,7 +99,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Platform<P>, P : Any> 
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.mixed.Platform<*>>,
+    templateType: KClass<Platform<*>>,
 ): Mock = when (Mock::class) {
     factory.template.mixed.PlatformMock::class -> factory.template.mixed.PlatformMock<P>(collector =
     collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -111,7 +112,7 @@ internal inline fun <reified Mock : Platform<P>, P : Any> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.mixed.Platform<*>>,
+    templateType: KClass<Platform<*>>,
 ): Mock = getMockInstance(
     spyOn = null,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/spiesonly/CommonActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spiesonly/CommonActual.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -42,7 +43,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.spiesonly.Common1Mock::class -> factory.template.spiesonly.Common1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -54,7 +55,7 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/spiesonly/CommonExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spiesonly/CommonExpect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -21,5 +22,5 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/spiesonly/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spiesonly/Platform.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -46,7 +47,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.spiesonly.Platform1Mock::class -> factory.template.spiesonly.Platform1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -58,7 +59,7 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : 
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/spiesonly/SharedActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spiesonly/SharedActual.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -42,7 +43,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.spiesonly.Shared1Mock::class -> factory.template.spiesonly.Shared1Mock<K,
         L>(collector = collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -54,7 +55,7 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/spiesonly/SharedExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spiesonly/SharedExpect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -15,5 +16,5 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spiesonly.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/spy/CommonActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spy/CommonActual.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -55,7 +56,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.spy.Common1Mock::class -> factory.template.spy.Common1Mock<K, L>(collector =
     collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -68,7 +69,7 @@ internal actual inline fun <reified Mock : Common1<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -82,7 +83,7 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/spy/CommonExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spy/CommonExpect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -29,12 +30,12 @@ internal expect inline fun <reified Mock : Common1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>
 
 internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Common1<K, L>, K : Any, L> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Common1<*, *>>,
+    templateType: KClass<Common1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/factory/expected/spy/Platform.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spy/Platform.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -59,7 +60,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.spy.Platform1Mock::class -> factory.template.spy.Platform1Mock<K, L>(collector =
     collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -72,7 +73,7 @@ internal inline fun <reified Mock : Platform1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -86,7 +87,7 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn : Platform1<K, L>, K : 
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Platform1<*, *>>,
+    templateType: KClass<Platform1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/spy/SharedActual.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spy/SharedActual.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 
@@ -55,7 +56,7 @@ private inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>, K : Any
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = when (Mock::class) {
     factory.template.spy.Shared1Mock::class -> factory.template.spy.Shared1Mock<K, L>(collector =
     collector, relaxUnitFun = relaxUnitFun, freeze = freeze, spyOn = spyOn as
@@ -68,7 +69,7 @@ internal actual inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = null,
     collector = collector,
@@ -82,7 +83,7 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>,
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L> = getMockInstance(
     spyOn = spyOn,
     collector = collector,

--- a/kmock-processor/src/test/resources/factory/expected/spy/SharedExpect.kt
+++ b/kmock-processor/src/test/resources/factory/expected/spy/SharedExpect.kt
@@ -7,6 +7,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
@@ -16,12 +17,12 @@ internal expect inline fun <reified Mock : Shared1<K, L>, K : Any, L> kmock(
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>
 
 internal expect inline fun <reified Mock : SpyOn, reified SpyOn : Shared1<K, L>, K : Any, L> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType: kotlin.reflect.KClass<factory.template.spy.Shared1<*, *>>,
+    templateType: KClass<Shared1<*, *>>,
 ): Mock where L : Any, L : Comparable<L>

--- a/kmock-processor/src/test/resources/multi/expected/common/SpiedRegularActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/common/SpiedRegularActualFactory.kt
@@ -4,6 +4,7 @@ package multi
 
 import kotlin.Boolean
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.common.CommonContractRegular
 import multi.template.common.Regular1
 import multi.template.common.nested.Regular3
@@ -39,11 +40,8 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.common.Regular1>,
-    templateType1: kotlin.reflect.KClass<multi.template.common.CommonContractRegular.Regular2>,
-    templateType2: kotlin.reflect.KClass<multi.template.common.nested.Regular3>,
-): Mock where SpyOn : Regular1, SpyOn : CommonContractRegular.Regular2, SpyOn : Regular3 = if
-                                                                                               (Mock::class == multi.CommonMultiMock::class) {
+    templateType0: KClass<Regular1>,
+    templateType1: KClass<CommonContractRegular.Regular2>,
+    templateType2: KClass<Regular3>,
+): Mock where SpyOn : Regular1, SpyOn : CommonContractRegular.Regular2, SpyOn : Regular3 =
     multi.CommonMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}

--- a/kmock-processor/src/test/resources/multi/expected/common/SpiedRegularExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/common/SpiedRegularExpectFactory.kt
@@ -4,6 +4,7 @@ package multi
 
 import kotlin.Boolean
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.common.CommonContractRegular
 import multi.template.common.Regular1
 import multi.template.common.nested.Regular3
@@ -22,7 +23,7 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.common.Regular1>,
-    templateType1: kotlin.reflect.KClass<multi.template.common.CommonContractRegular.Regular2>,
-    templateType2: kotlin.reflect.KClass<multi.template.common.nested.Regular3>,
+    templateType0: KClass<Regular1>,
+    templateType1: KClass<CommonContractRegular.Regular2>,
+    templateType2: KClass<Regular3>,
 ): Mock where SpyOn : Regular1, SpyOn : CommonContractRegular.Regular2, SpyOn : Regular3

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericActualFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.commonGeneric.Generic1
 import multi.template.commonGeneric.GenericCommonContract
 import multi.template.commonGeneric.nested.Generic2
@@ -43,46 +44,36 @@ private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericCommonContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
               Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
-    multi.CommonGenericMultiMock::class) {
-    multi.CommonGenericMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as
-        Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = multi.CommonGenericMultiMock(collector =
+collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
 
-internal actual inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> kmock(
+internal actual inline fun <reified Mock :
+CommonGenericMultiMock<KMockTypeParameter0, KMockTypeParameter1, KMockTypeParameter2, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5, *>,
+    KMockTypeParameter0 : Any, KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3,
+    KMockTypeParameter4, KMockTypeParameter5> kmock(
     collector: KMockContract.Collector,
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
-): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
-Generic2<KMockTypeParameter2, KMockTypeParameter3>, Mock :
-              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
-              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = getMockInstance(
-    spyOn = null,
-    collector = collector,
-    relaxed = relaxed,
-    relaxUnitFun = relaxUnitFun,
-    freeze = freeze,
-    templateType0 = templateType0,
-    templateType1 = templateType1,
-    templateType2 = templateType2,
-)
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericCommonContract.Generic3<*, *>>,
+): Mock where KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+              KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3> =
+    getMockInstance(
+        spyOn = null,
+        collector = collector,
+        relaxed = relaxed,
+        relaxUnitFun = relaxUnitFun,
+        freeze = freeze,
+        templateType0 = templateType0,
+        templateType1 = templateType1,
+        templateType2 = templateType2,
+    )

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/GenericExpectFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.commonGeneric.Generic1
 import multi.template.commonGeneric.GenericCommonContract
 import multi.template.commonGeneric.nested.Generic2
@@ -20,20 +21,16 @@ internal expect inline fun <reified Mock> kmock(
     freeze: Boolean = true,
 ): Mock
 
-internal expect inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> kmock(
+internal expect inline fun <reified Mock :
+CommonGenericMultiMock<KMockTypeParameter0, KMockTypeParameter1, KMockTypeParameter2, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5, *>,
+    KMockTypeParameter0 : Any, KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3,
+    KMockTypeParameter4, KMockTypeParameter5> kmock(
     collector: KMockContract.Collector = NoopCollector,
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
-): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
-Generic2<KMockTypeParameter2, KMockTypeParameter3>, Mock :
-              GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
-              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3>
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericCommonContract.Generic3<*, *>>,
+): Mock where KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+              KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3>

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericActualFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.commonGeneric.Generic1
 import multi.template.commonGeneric.GenericCommonContract
 import multi.template.commonGeneric.nested.Generic2
@@ -42,22 +43,15 @@ private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericCommonContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
               Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
-    multi.CommonGenericMultiMock::class) {
-    multi.CommonGenericMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as
-        Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = multi.CommonGenericMultiMock(collector =
+collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
 
 internal actual inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : Any,
     KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4,
@@ -65,12 +59,9 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParame
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericCommonContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :

--- a/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/commonGeneric/SpiedGenericExpectFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.commonGeneric.Generic1
 import multi.template.commonGeneric.GenericCommonContract
 import multi.template.commonGeneric.nested.Generic2
@@ -25,12 +26,9 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParame
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.commonGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.commonGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.commonGeneric.GenericCommonContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericCommonContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericCommonContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :

--- a/kmock-processor/src/test/resources/multi/expected/custom/SpiedRegularActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/custom/SpiedRegularActualFactory.kt
@@ -4,6 +4,7 @@ package multi
 
 import kotlin.Boolean
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.custom.Regular1
 import multi.template.custom.SharedContractRegular
 import multi.template.custom.nested.Regular3
@@ -39,11 +40,8 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.custom.Regular1>,
-    templateType1: kotlin.reflect.KClass<multi.template.custom.SharedContractRegular.Regular2>,
-    templateType2: kotlin.reflect.KClass<multi.template.custom.nested.Regular3>,
-): Mock where SpyOn : Regular1, SpyOn : SharedContractRegular.Regular2, SpyOn : Regular3 = if
-                                                                                               (Mock::class == multi.SharedMultiMock::class) {
+    templateType0: KClass<Regular1>,
+    templateType1: KClass<SharedContractRegular.Regular2>,
+    templateType2: KClass<Regular3>,
+): Mock where SpyOn : Regular1, SpyOn : SharedContractRegular.Regular2, SpyOn : Regular3 =
     multi.SharedMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}

--- a/kmock-processor/src/test/resources/multi/expected/custom/SpiedRegularExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/custom/SpiedRegularExpectFactory.kt
@@ -4,6 +4,7 @@ package multi
 
 import kotlin.Boolean
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.custom.Regular1
 import multi.template.custom.SharedContractRegular
 import multi.template.custom.nested.Regular3
@@ -15,7 +16,7 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.custom.Regular1>,
-    templateType1: kotlin.reflect.KClass<multi.template.custom.SharedContractRegular.Regular2>,
-    templateType2: kotlin.reflect.KClass<multi.template.custom.nested.Regular3>,
+    templateType0: KClass<Regular1>,
+    templateType1: KClass<SharedContractRegular.Regular2>,
+    templateType2: KClass<Regular3>,
 ): Mock where SpyOn : Regular1, SpyOn : SharedContractRegular.Regular2, SpyOn : Regular3

--- a/kmock-processor/src/test/resources/multi/expected/mixed/ActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/mixed/ActualFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.mixed.Generic1
 import multi.template.mixed.GenericPlatformContract
 import multi.template.mixed.nested.Generic2
@@ -45,45 +46,36 @@ private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.mixed.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.mixed.GenericPlatformContract.Generic3<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.mixed.nested.Generic2<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<GenericPlatformContract.Generic3<*, *>>,
+    templateType2: KClass<Generic2<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 GenericPlatformContract.Generic3<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               Generic2<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 : Any,
               KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter5 : Any,
-              KMockTypeParameter5 : Comparable<KMockTypeParameter5> = if (Mock::class ==
-    multi.PlatformMultiMock::class) {
-    multi.PlatformMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+              KMockTypeParameter5 : Comparable<KMockTypeParameter5> = multi.PlatformMultiMock(collector =
+collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
 
-internal inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter2, KMockTypeParameter3, KMockTypeParameter4 : Any, KMockTypeParameter5> kmock(
+internal inline fun <reified Mock :
+PlatformMultiMock<KMockTypeParameter0, KMockTypeParameter1, KMockTypeParameter2, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5, *>,
+    KMockTypeParameter0 : Any, KMockTypeParameter1, KMockTypeParameter2, KMockTypeParameter3,
+    KMockTypeParameter4 : Any, KMockTypeParameter5> kmock(
     collector: KMockContract.Collector,
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.mixed.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.mixed.GenericPlatformContract.Generic3<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.mixed.nested.Generic2<KMockTypeParameter4,
-        KMockTypeParameter5>>,
-): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
-GenericPlatformContract.Generic3<KMockTypeParameter2, KMockTypeParameter3>, Mock :
-              Generic2<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 : Any,
-              KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter5 : Any,
-              KMockTypeParameter5 : Comparable<KMockTypeParameter5> = getMockInstance(
-    spyOn = null,
-    collector = collector,
-    relaxed = relaxed,
-    relaxUnitFun = relaxUnitFun,
-    freeze = freeze,
-    templateType0 = templateType0,
-    templateType1 = templateType1,
-    templateType2 = templateType2,
-)
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<GenericPlatformContract.Generic3<*, *>>,
+    templateType2: KClass<Generic2<*, *>>,
+): Mock where KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+              KMockTypeParameter5 : Any, KMockTypeParameter5 : Comparable<KMockTypeParameter5> =
+    getMockInstance(
+        spyOn = null,
+        collector = collector,
+        relaxed = relaxed,
+        relaxUnitFun = relaxUnitFun,
+        freeze = freeze,
+        templateType0 = templateType0,
+        templateType1 = templateType1,
+        templateType2 = templateType2,
+    )

--- a/kmock-processor/src/test/resources/multi/expected/platform/SpiedRegularActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/platform/SpiedRegularActualFactory.kt
@@ -4,6 +4,7 @@ package multi
 
 import kotlin.Boolean
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.platform.PlatformContractRegular
 import multi.template.platform.Regular1
 import multi.template.platform.nested.Regular3
@@ -40,11 +41,8 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.platform.Regular1>,
-    templateType1: kotlin.reflect.KClass<multi.template.platform.PlatformContractRegular.Regular2>,
-    templateType2: kotlin.reflect.KClass<multi.template.platform.nested.Regular3>,
-): Mock where SpyOn : Regular1, SpyOn : PlatformContractRegular.Regular2, SpyOn : Regular3 = if
-                                                                                                 (Mock::class == multi.PlatformMultiMock::class) {
+    templateType0: KClass<Regular1>,
+    templateType1: KClass<PlatformContractRegular.Regular2>,
+    templateType2: KClass<Regular3>,
+): Mock where SpyOn : Regular1, SpyOn : PlatformContractRegular.Regular2, SpyOn : Regular3 =
     multi.PlatformMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}

--- a/kmock-processor/src/test/resources/multi/expected/platformGeneric/GenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/platformGeneric/GenericActualFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.platformGeneric.Generic1
 import multi.template.platformGeneric.GenericPlatformContract
 import multi.template.platformGeneric.nested.Generic2
@@ -44,46 +45,36 @@ private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.platformGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.platformGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.platformGeneric.GenericPlatformContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericPlatformContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1
               : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
-    multi.PlatformGenericMultiMock::class) {
-    multi.PlatformGenericMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as
-        Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = multi.PlatformGenericMultiMock(collector
+= collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
 
-internal inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> kmock(
+internal inline fun <reified Mock :
+PlatformGenericMultiMock<KMockTypeParameter0, KMockTypeParameter1, KMockTypeParameter2, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5, *>,
+    KMockTypeParameter0 : Any, KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3,
+    KMockTypeParameter4, KMockTypeParameter5> kmock(
     collector: KMockContract.Collector = NoopCollector,
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.platformGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.platformGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.platformGeneric.GenericPlatformContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
-): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
-Generic2<KMockTypeParameter2, KMockTypeParameter3>, Mock :
-              GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1
-              : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = getMockInstance(
-    spyOn = null,
-    collector = collector,
-    relaxed = relaxed,
-    relaxUnitFun = relaxUnitFun,
-    freeze = freeze,
-    templateType0 = templateType0,
-    templateType1 = templateType1,
-    templateType2 = templateType2,
-)
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericPlatformContract.Generic3<*, *>>,
+): Mock where KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+              KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3> =
+    getMockInstance(
+        spyOn = null,
+        collector = collector,
+        relaxed = relaxed,
+        relaxUnitFun = relaxUnitFun,
+        freeze = freeze,
+        templateType0 = templateType0,
+        templateType1 = templateType1,
+        templateType2 = templateType2,
+    )

--- a/kmock-processor/src/test/resources/multi/expected/platformGeneric/SpiedGenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/platformGeneric/SpiedGenericActualFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.platformGeneric.Generic1
 import multi.template.platformGeneric.GenericPlatformContract
 import multi.template.platformGeneric.nested.Generic2
@@ -43,22 +44,15 @@ private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.platformGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.platformGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.platformGeneric.GenericPlatformContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericPlatformContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1
               : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
-    multi.PlatformGenericMultiMock::class) {
-    multi.PlatformGenericMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as
-        Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = multi.PlatformGenericMultiMock(collector
+= collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
 
 internal inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : Any,
     KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4,
@@ -66,12 +60,9 @@ internal inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : 
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.platformGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.platformGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.platformGeneric.GenericPlatformContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericPlatformContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericPlatformContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1

--- a/kmock-processor/src/test/resources/multi/expected/shared/SpiedRegularActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/shared/SpiedRegularActualFactory.kt
@@ -4,6 +4,7 @@ package multi
 
 import kotlin.Boolean
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.shared.Regular1
 import multi.template.shared.SharedContractRegular
 import multi.template.shared.nested.Regular3
@@ -39,11 +40,8 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.shared.Regular1>,
-    templateType1: kotlin.reflect.KClass<multi.template.shared.SharedContractRegular.Regular2>,
-    templateType2: kotlin.reflect.KClass<multi.template.shared.nested.Regular3>,
-): Mock where SpyOn : Regular1, SpyOn : SharedContractRegular.Regular2, SpyOn : Regular3 = if
-                                                                                               (Mock::class == multi.SharedMultiMock::class) {
+    templateType0: KClass<Regular1>,
+    templateType1: KClass<SharedContractRegular.Regular2>,
+    templateType2: KClass<Regular3>,
+): Mock where SpyOn : Regular1, SpyOn : SharedContractRegular.Regular2, SpyOn : Regular3 =
     multi.SharedMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}

--- a/kmock-processor/src/test/resources/multi/expected/shared/SpiedRegularExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/shared/SpiedRegularExpectFactory.kt
@@ -4,6 +4,7 @@ package multi
 
 import kotlin.Boolean
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.shared.Regular1
 import multi.template.shared.SharedContractRegular
 import multi.template.shared.nested.Regular3
@@ -15,7 +16,7 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn> kspy(
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.shared.Regular1>,
-    templateType1: kotlin.reflect.KClass<multi.template.shared.SharedContractRegular.Regular2>,
-    templateType2: kotlin.reflect.KClass<multi.template.shared.nested.Regular3>,
+    templateType0: KClass<Regular1>,
+    templateType1: KClass<SharedContractRegular.Regular2>,
+    templateType2: KClass<Regular3>,
 ): Mock where SpyOn : Regular1, SpyOn : SharedContractRegular.Regular2, SpyOn : Regular3

--- a/kmock-processor/src/test/resources/multi/expected/sharedGeneric/GenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/sharedGeneric/GenericActualFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.sharedGeneric.Generic1
 import multi.template.sharedGeneric.GenericSharedContract
 import multi.template.sharedGeneric.nested.Generic2
@@ -43,46 +44,36 @@ private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.sharedGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.sharedGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.sharedGeneric.GenericSharedContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericSharedContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
               Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
-    multi.SharedGenericMultiMock::class) {
-    multi.SharedGenericMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as
-        Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = multi.SharedGenericMultiMock(collector =
+collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
 
-internal actual inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> kmock(
+internal actual inline fun <reified Mock :
+SharedGenericMultiMock<KMockTypeParameter0, KMockTypeParameter1, KMockTypeParameter2, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5, *>,
+    KMockTypeParameter0 : Any, KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3,
+    KMockTypeParameter4, KMockTypeParameter5> kmock(
     collector: KMockContract.Collector,
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.sharedGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.sharedGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.sharedGeneric.GenericSharedContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
-): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
-Generic2<KMockTypeParameter2, KMockTypeParameter3>, Mock :
-              GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
-              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = getMockInstance(
-    spyOn = null,
-    collector = collector,
-    relaxed = relaxed,
-    relaxUnitFun = relaxUnitFun,
-    freeze = freeze,
-    templateType0 = templateType0,
-    templateType1 = templateType1,
-    templateType2 = templateType2,
-)
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericSharedContract.Generic3<*, *>>,
+): Mock where KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+              KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3> =
+    getMockInstance(
+        spyOn = null,
+        collector = collector,
+        relaxed = relaxed,
+        relaxUnitFun = relaxUnitFun,
+        freeze = freeze,
+        templateType0 = templateType0,
+        templateType1 = templateType1,
+        templateType2 = templateType2,
+    )

--- a/kmock-processor/src/test/resources/multi/expected/sharedGeneric/GenericExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/sharedGeneric/GenericExpectFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.sharedGeneric.Generic1
 import multi.template.sharedGeneric.GenericSharedContract
 import multi.template.sharedGeneric.nested.Generic2
@@ -13,20 +14,16 @@ import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockContract.Collector
 import tech.antibytes.kmock.proxy.NoopCollector
 
-internal expect inline fun <reified Mock, KMockTypeParameter0 : Any, KMockTypeParameter1,
-    KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5> kmock(
+internal expect inline fun <reified Mock :
+SharedGenericMultiMock<KMockTypeParameter0, KMockTypeParameter1, KMockTypeParameter2, KMockTypeParameter3, KMockTypeParameter4, KMockTypeParameter5, *>,
+    KMockTypeParameter0 : Any, KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3,
+    KMockTypeParameter4, KMockTypeParameter5> kmock(
     collector: KMockContract.Collector = NoopCollector,
     relaxed: Boolean = false,
     relaxUnitFun: Boolean = false,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.sharedGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.sharedGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.sharedGeneric.GenericSharedContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
-): Mock where Mock : Generic1<KMockTypeParameter0, KMockTypeParameter1>, Mock :
-Generic2<KMockTypeParameter2, KMockTypeParameter3>, Mock :
-              GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
-              Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3>
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericSharedContract.Generic3<*, *>>,
+): Mock where KMockTypeParameter1 : Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>,
+              KMockTypeParameter3 : Any, KMockTypeParameter3 : Comparable<KMockTypeParameter3>

--- a/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericActualFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericActualFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.sharedGeneric.Generic1
 import multi.template.sharedGeneric.GenericSharedContract
 import multi.template.sharedGeneric.nested.Generic2
@@ -42,22 +43,15 @@ private inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : A
     relaxed: Boolean,
     relaxUnitFun: Boolean,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.sharedGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.sharedGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.sharedGeneric.GenericSharedContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericSharedContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :
               Any, KMockTypeParameter1 : Comparable<KMockTypeParameter1>, KMockTypeParameter3 : Any,
-              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = if (Mock::class ==
-    multi.SharedGenericMultiMock::class) {
-    multi.SharedGenericMultiMock(collector = collector, freeze = freeze, spyOn = spyOn as SpyOn?) as
-        Mock
-} else {
-    throw RuntimeException("Unknown Interface ${Mock::class.simpleName}.")}
+              KMockTypeParameter3 : Comparable<KMockTypeParameter3> = multi.SharedGenericMultiMock(collector =
+collector, freeze = freeze, spyOn = spyOn as SpyOn?) as Mock
 
 internal actual inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParameter0 : Any,
     KMockTypeParameter1, KMockTypeParameter2 : Any, KMockTypeParameter3, KMockTypeParameter4,
@@ -65,12 +59,9 @@ internal actual inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParame
     spyOn: SpyOn,
     collector: KMockContract.Collector,
     freeze: Boolean,
-    templateType0: kotlin.reflect.KClass<multi.template.sharedGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.sharedGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.sharedGeneric.GenericSharedContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericSharedContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :

--- a/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericExpectFactory.kt
+++ b/kmock-processor/src/test/resources/multi/expected/sharedGeneric/SpiedGenericExpectFactory.kt
@@ -6,6 +6,7 @@ import kotlin.Any
 import kotlin.Boolean
 import kotlin.Comparable
 import kotlin.Suppress
+import kotlin.reflect.KClass
 import multi.template.sharedGeneric.Generic1
 import multi.template.sharedGeneric.GenericSharedContract
 import multi.template.sharedGeneric.nested.Generic2
@@ -19,12 +20,9 @@ internal expect inline fun <reified Mock : SpyOn, reified SpyOn, KMockTypeParame
     spyOn: SpyOn,
     collector: KMockContract.Collector = NoopCollector,
     freeze: Boolean = true,
-    templateType0: kotlin.reflect.KClass<multi.template.sharedGeneric.Generic1<KMockTypeParameter0,
-        KMockTypeParameter1>>,
-    templateType1: kotlin.reflect.KClass<multi.template.sharedGeneric.nested.Generic2<KMockTypeParameter2,
-        KMockTypeParameter3>>,
-    templateType2: kotlin.reflect.KClass<multi.template.sharedGeneric.GenericSharedContract.Generic3<KMockTypeParameter4,
-        KMockTypeParameter5>>,
+    templateType0: KClass<Generic1<*, *>>,
+    templateType1: KClass<Generic2<*, *>>,
+    templateType2: KClass<GenericSharedContract.Generic3<*, *>>,
 ): Mock where SpyOn : Generic1<KMockTypeParameter0, KMockTypeParameter1>, SpyOn :
 Generic2<KMockTypeParameter2, KMockTypeParameter3>, SpyOn :
               GenericSharedContract.Generic3<KMockTypeParameter4, KMockTypeParameter5>, KMockTypeParameter1 :


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #190 

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This fixes MockFactories for MultiInterfaceMocks for Generics due to referencing the Mock instead the templates.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
