### PR TITLE
Change plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+* The plugin can now applied directly while configuration must be done after the `kotlin` setup
+
 ### Deprecated
 
 ### Removed

--- a/docs/src/howto/install.md
+++ b/docs/src/howto/install.md
@@ -210,16 +210,14 @@ In case you need to consume snapshots:
         id("org.jetbrains.kotlin.js")
         ...
 
-        id("tech.antibytes.kmock.kmock-gradle") apply false
+        id("tech.antibytes.kmock.kmock-gradle")
     }
 
     kotlin {
         ...
     }
 
-    plugins.apply("tech.antibytes.kmock.kmock-gradle")
-
-    project.extensions.configure<KMockExtension>(KMockExtension::class.java) {
+    kmock {
         rootPackage = "my.root.package"
     }
 
@@ -238,7 +236,7 @@ In case you need to consume snapshots:
     plugins {
         ...
 
-        id("tech.antibytes.kmock.kmock-gradle") apply false
+        id("tech.antibytes.kmock.kmock-gradle")
     }
 
     kotlin {
@@ -258,15 +256,13 @@ In case you need to consume snapshots:
         ...
     }
 
-    plugins.apply("tech.antibytes.kmock.kmock-gradle")
-
-    project.extensions.configure<KMockExtension>("kmock") {
+    kmock {
         rootPackage = "my.root.package"
     }
     ```
 
 !!!warning
-    For KMP or KJs you must apply the plugin after your projects `kotlin` block has been set up as shown above.
+    For KMP or KJs it is mandatory to configure KMock after your projects `kotlin` block has been set up as shown above.
     This is due to the fact that Kotlin brings its own system of source sets and [Kotlin Symbol Processing (KSP)](https://github.com/google/ksp)
     must be configured during the evaluation of your project.
 

--- a/docs/src/howto/setup.md
+++ b/docs/src/howto/setup.md
@@ -1,31 +1,24 @@
 # Setup
 ## Mandatory Options
 KMock brings a variety of configuration options.
-In order to access KMock's extension in Gradle please do the following **after** it is applied:
+In order to access KMock's extension in Gradle please do the following:
 
-=== "Android/JVM"
-    ```kotlin
+
+```kotlin
     plugins {
         ...
 
         id("tech.antibytes.kmock.kmock-gradle")
     }
 
+    kotlin {
+        ...
+    }
+
     kmock {
         rootPackage = "my.root.package"
     }
-    ```
-=== "Kotlin Multiplatform/KJs"
-    ```kotlin
-    import tech.antibytes.gradle.kmock.KMockExtension
-    ...
-
-    plugins.apply("tech.antibytes.kmock.kmock-gradle")
-
-    project.extensions.configure<KMockExtension>(KMockExtension::class.java) {
-        rootPackage = "tech.antibytes.kmock.example"
-    }
-    ```
+```
 
 The only **mandatory option** is `rootPackage`,
 It expects the root package of **your project** as a String.

--- a/gradlePlugin/kmock-dependency/src/main/kotlin/tech/antibytes/gradle/kmock/dependency/Version.kt
+++ b/gradlePlugin/kmock-dependency/src/main/kotlin/tech/antibytes/gradle/kmock/dependency/Version.kt
@@ -20,7 +20,7 @@ object Version {
         /**
          * [AnitBytes GradlePlugins](https://github.com/bitPogo/gradle-plugins)
          */
-        const val antibytes = "558fe4c"
+        const val antibytes = "967d356"
 
         /**
          * [Spotless](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless)

--- a/kmock-gradle/build.gradle.kts
+++ b/kmock-gradle/build.gradle.kts
@@ -10,6 +10,9 @@ import tech.antibytes.gradle.kmock.dependency.Dependency as LocalDependency
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile as KotlinTaskCompile
 import tech.antibytes.gradle.configuration.runtime.AntiBytesMainConfigurationTask
+import tech.antibytes.gradle.kmock.config.KMockPublishingConfiguration
+import tech.antibytes.gradle.versioning.Versioning
+import org.gradle.api.tasks.Delete
 
 plugins {
     `kotlin-dsl`
@@ -70,20 +73,23 @@ tasks.test {
     useJUnitPlatform()
 }
 
-afterEvaluate {
-    val generateConfig by tasks.creating(AntiBytesMainConfigurationTask::class.java) {
-        packageName.set("tech.antibytes.gradle.kmock.config")
-        stringFields.set(
-            mapOf(
-                "version" to project.version as String,
-            )
+val generateConfig by tasks.creating(AntiBytesMainConfigurationTask::class.java) {
+    packageName.set("tech.antibytes.gradle.kmock.config")
+    stringFields.set(
+        mapOf(
+            "version" to Versioning.getInstance(
+                project = project,
+                configuration = KMockPublishingConfiguration().versioning
+            ).versionName()
         )
-    }
+    )
 
-    tasks.withType(KotlinCompile::class.java) {
-        this.dependsOn(generateConfig)
-        this.mustRunAfter(generateConfig)
-    }
+    mustRunAfter("clean")
+}
+
+tasks.withType(KotlinCompile::class.java) {
+    this.dependsOn(generateConfig)
+    this.mustRunAfter(generateConfig)
 }
 
 pluginBundle {

--- a/kmock-gradle/build.gradle.kts
+++ b/kmock-gradle/build.gradle.kts
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile as KotlinTaskCompile
 import tech.antibytes.gradle.configuration.runtime.AntiBytesMainConfigurationTask
 import tech.antibytes.gradle.kmock.config.KMockPublishingConfiguration
 import tech.antibytes.gradle.versioning.Versioning
-import org.gradle.api.tasks.Delete
 
 plugins {
     `kotlin-dsl`

--- a/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockExtension.kt
+++ b/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockExtension.kt
@@ -132,6 +132,7 @@ public abstract class KMockExtension(
             _typePrefixMapping = value
         }
 
+    @KMockGradleExperimental
     override var customMethodNames: Map<String, String>
         get() = _customMethodNames
         set(value) {

--- a/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockExtension.kt
+++ b/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockExtension.kt
@@ -6,7 +6,6 @@
 
 package tech.antibytes.gradle.kmock
 
-import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Project
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.ALIASES
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.ALTERNATIVE_PROXY_ACCESS
@@ -24,11 +23,13 @@ import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.SPY_ALL
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.SPY_ON
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.TYPE_PREFIXES
 import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.USE_BUILD_IN
+import tech.antibytes.gradle.kmock.source.KmpSourceSetsConfigurator
+import tech.antibytes.gradle.kmock.source.SingleSourceSetConfigurator
 
 public abstract class KMockExtension(
-    project: Project
+    project: Project,
 ) : KMockPluginContract.Extension {
-    private val ksp: KspExtension = project.extensions.getByType(KspExtension::class.java)
+    private val kspBridge = KSPBridge.getInstance(project, SingleSourceSetConfigurator, KmpSourceSetsConfigurator)
     private val illegalNames = setOf(
         ROOT_PACKAGE,
         KMP_FLAG,
@@ -63,7 +64,7 @@ public abstract class KMockExtension(
     private fun propagateValue(
         id: String,
         value: String
-    ) = ksp.arg(id, value)
+    ) = kspBridge.propagateValue(id, value)
 
     private fun guardMapping(qualifiedName: String, name: String) {
         when {
@@ -76,11 +77,11 @@ public abstract class KMockExtension(
         kmockKey: String,
         mapping: Map<String, String>
     ) {
-        mapping.forEach { (qualifiedName, value) ->
-            guardMapping(qualifiedName, value)
-
-            ksp.arg("$kmockKey$qualifiedName", value)
-        }
+        kspBridge.propagateMapping(
+            kmockKey,
+            mapping,
+            ::guardMapping,
+        )
     }
 
     override var rootPackage: String
@@ -105,9 +106,11 @@ public abstract class KMockExtension(
         values: Iterable<T>,
         action: (T) -> String = { it.toString() },
     ) {
-        values.forEachIndexed { idx, type ->
-            ksp.arg("$prefix$idx", action(type))
-        }
+        kspBridge.propagateIterable(
+            prefix,
+            values,
+            action,
+        )
     }
 
     override var useBuildInProxiesOn: Set<String>

--- a/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockPlugin.kt
+++ b/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockPlugin.kt
@@ -6,37 +6,14 @@
 
 package tech.antibytes.gradle.kmock
 
-import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.KMP_FLAG
-import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.KSP_DIR
-import tech.antibytes.gradle.kmock.source.KmpSourceSetsConfigurator
-import tech.antibytes.gradle.kmock.source.SingleSourceSetConfigurator
 import tech.antibytes.gradle.kmock.util.applyIfNotExists
-import tech.antibytes.gradle.kmock.util.isKmp
 
 public class KMockPlugin : Plugin<Project> {
-    private fun configureSources(
-        project: Project
-    ) {
-        val isKMP = project.isKmp()
-        val ksp = project.extensions.getByType(KspExtension::class.java)
-        ksp.arg(KMP_FLAG, isKMP.toString())
-        ksp.arg(KSP_DIR, "${project.buildDir.absolutePath.trimEnd('/')}/generated/ksp")
-
-        if (!isKMP) {
-            SingleSourceSetConfigurator.configure(project)
-        } else {
-            KmpSourceSetsConfigurator.configure(project)
-        }
-    }
-
     override fun apply(target: Project) {
         target.applyIfNotExists("com.google.devtools.ksp")
 
         target.extensions.create("kmock", KMockExtension::class.java)
-
-        configureSources(project = target)
     }
 }

--- a/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockPluginContract.kt
+++ b/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KMockPluginContract.kt
@@ -120,6 +120,33 @@ internal interface KMockPluginContract {
         fun configure(project: Project)
     }
 
+    interface KSPBridge {
+        fun propagateValue(
+            rootKey: String,
+            value: String
+        )
+
+        fun propagateMapping(
+            rootKey: String,
+            mapping: Map<String, String>,
+            onPropagation: (String, String) -> Unit = { _, _ -> Unit }
+        )
+
+        fun <T> propagateIterable(
+            rootKey: String,
+            values: Iterable<T>,
+            action: (T) -> String = { it.toString() },
+        )
+    }
+
+    interface KSPBridgeFactory {
+        fun getInstance(
+            project: Project,
+            singleSourceSetConfigurator: SourceSetConfigurator,
+            kmpSourceSetConfigurator: SourceSetConfigurator,
+        ): KSPBridge
+    }
+
     interface DependencyGraph {
         fun resolveAncestors(
             sourceDependencies: Map<String, Set<String>>,

--- a/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KSPBridge.kt
+++ b/kmock-gradle/src/main/kotlin/tech/antibytes/gradle/kmock/KSPBridge.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.gradle.kmock
+
+import com.google.devtools.ksp.gradle.KspExtension
+import org.gradle.api.Project
+import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.KMP_FLAG
+import tech.antibytes.gradle.kmock.KMockPluginContract.Companion.KSP_DIR
+import tech.antibytes.gradle.kmock.KMockPluginContract.SourceSetConfigurator
+import tech.antibytes.gradle.kmock.util.isKmp
+
+internal class KSPBridge private constructor(
+    private val project: Project,
+    private val singleSourceSetConfigurator: SourceSetConfigurator,
+    private val kmpSourceSetConfigurator: SourceSetConfigurator,
+) : KMockPluginContract.KSPBridge {
+    private var locked = false
+    private val ksp: KspExtension = project.extensions.getByType(KspExtension::class.java)
+
+    private fun configureSources() {
+        val isKMP = project.isKmp()
+        ksp.arg(KMP_FLAG, isKMP.toString())
+        ksp.arg(KSP_DIR, "${project.buildDir.absolutePath.trimEnd('/')}/generated/ksp")
+
+        if (!isKMP) {
+            singleSourceSetConfigurator.configure(project)
+        } else {
+            kmpSourceSetConfigurator.configure(project)
+        }
+    }
+
+    private fun configureOnce() {
+        if (!locked) {
+            configureSources()
+            locked = true
+        }
+    }
+
+    override fun propagateValue(rootKey: String, value: String) {
+        configureOnce()
+        ksp.arg(rootKey, value)
+    }
+
+    override fun propagateMapping(
+        rootKey: String,
+        mapping: Map<String, String>,
+        onPropagation: (String, String) -> Unit,
+    ) {
+        configureOnce()
+        mapping.forEach { (key, value) ->
+            onPropagation(key, value)
+
+            ksp.arg("$rootKey$key", value)
+        }
+    }
+
+    override fun <T> propagateIterable(
+        rootKey: String,
+        values: Iterable<T>,
+        action: (T) -> String
+    ) {
+        configureOnce()
+        values.forEachIndexed { idx, type ->
+            ksp.arg("$rootKey$idx", action(type))
+        }
+    }
+
+    companion object : KMockPluginContract.KSPBridgeFactory {
+        override fun getInstance(
+            project: Project,
+            singleSourceSetConfigurator: SourceSetConfigurator,
+            kmpSourceSetConfigurator: SourceSetConfigurator,
+        ): KMockPluginContract.KSPBridge {
+            return KSPBridge(
+                project = project,
+                singleSourceSetConfigurator = singleSourceSetConfigurator,
+                kmpSourceSetConfigurator = kmpSourceSetConfigurator,
+            )
+        }
+    }
+}

--- a/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/ExtensionSpec.kt
+++ b/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/ExtensionSpec.kt
@@ -15,6 +15,7 @@ import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.gradle.api.Project
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tech.antibytes.gradle.kmock.fixture.StringAlphaGenerator
@@ -39,12 +40,13 @@ class ExtensionSpec {
             qualifier = named("stringAlpha")
         )
     }
-    
+
     @BeforeEach
     fun setUp() {
         mockkObject(KSPBridge)
     }
 
+    @AfterEach
     fun tearDown() {
         unmockkObject(KSPBridge)
     }

--- a/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/KMockPluginSpec.kt
+++ b/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/KMockPluginSpec.kt
@@ -7,11 +7,8 @@
 package tech.antibytes.gradle.kmock
 
 import com.google.devtools.ksp.gradle.KspExtension
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.gradle.api.Plugin
@@ -20,9 +17,7 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.PluginContainer
 import org.junit.jupiter.api.Test
 import tech.antibytes.gradle.kmock.fixture.StringAlphaGenerator
-import tech.antibytes.gradle.kmock.source.KmpSourceSetsConfigurator
 import tech.antibytes.gradle.kmock.source.SingleSourceSetConfigurator
-import tech.antibytes.gradle.test.invokeGradleAction
 import tech.antibytes.util.test.fixture.fixture
 import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.qualifier.named
@@ -45,7 +40,6 @@ class KMockPluginSpec {
 
     @Test
     fun `Given apply is called it applies the gradle Ksp Plugin if it does not exists`() {
-        mockkObject(SingleSourceSetConfigurator)
         // Given
         val kmock = KMockPlugin()
         val project: Project = mockk()
@@ -63,20 +57,15 @@ class KMockPluginSpec {
         every { extensions.create(any(), KMockExtension::class.java) } returns mockk()
         every { extensions.getByType(KspExtension::class.java) } returns mockk(relaxed = true)
 
-        every { SingleSourceSetConfigurator.configure(any()) } just Runs
-
         // When
         kmock.apply(project)
 
         verify(exactly = 1) { plugins.hasPlugin("com.google.devtools.ksp") }
         verify(exactly = 1) { plugins.apply("com.google.devtools.ksp") }
-
-        unmockkObject(SingleSourceSetConfigurator)
     }
 
     @Test
     fun `Given apply is called it does not applies the gradle Ksp Plugin if it already exists`() {
-        mockkObject(SingleSourceSetConfigurator)
         // Given
         val kmock = KMockPlugin()
         val project: Project = mockk()
@@ -94,8 +83,6 @@ class KMockPluginSpec {
 
         every { extensions.create(any(), KMockExtension::class.java) } returns mockk()
         every { extensions.getByType(KspExtension::class.java) } returns mockk(relaxed = true)
-
-        every { SingleSourceSetConfigurator.configure(any()) } just Runs
 
         // When
         kmock.apply(project)
@@ -108,7 +95,6 @@ class KMockPluginSpec {
 
     @Test
     fun `Given apply is called it creates the KMockExtension`() {
-        mockkObject(SingleSourceSetConfigurator)
         // Given
         val kmock = KMockPlugin()
         val project: Project = mockk()
@@ -127,166 +113,9 @@ class KMockPluginSpec {
         every { extensions.create(any(), KMockExtension::class.java) } returns mockk()
         every { extensions.getByType(KspExtension::class.java) } returns mockk(relaxed = true)
 
-        every { SingleSourceSetConfigurator.configure(any()) } just Runs
-
         // When
         kmock.apply(project)
 
         verify(exactly = 1) { extensions.create("kmock", KMockExtension::class.java) }
-
-        unmockkObject(SingleSourceSetConfigurator)
-    }
-
-    @Test
-    fun `Given apply is called it delegates the call to the SingleSourceSetConfigurator if the Project is not Kmp`() {
-        mockkObject(SingleSourceSetConfigurator)
-        // Given
-        val kmock = KMockPlugin()
-        val project: Project = mockk()
-        val plugins: PluginContainer = mockk()
-        val extensions: ExtensionContainer = mockk()
-        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
-
-        every { project.plugins } returns plugins
-        every { project.extensions } returns extensions
-        every { project.buildDir } returns buildDir
-
-        every { plugins.hasPlugin(any<String>()) } returns true
-        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
-        every { plugins.apply(any()) } returns mockk()
-
-        every { extensions.create(any(), KMockExtension::class.java) } returns mockk()
-        every { extensions.getByType(KspExtension::class.java) } returns mockk(relaxed = true)
-
-        every { SingleSourceSetConfigurator.configure(any()) } just Runs
-
-        // When
-        kmock.apply(project)
-
-        verify(exactly = 1) { SingleSourceSetConfigurator.configure(project) }
-
-        unmockkObject(SingleSourceSetConfigurator)
-    }
-
-    @Test
-    fun `Given apply is called it delegates it sets up KSP and builds the Single Source Factories`() {
-        mockkObject(SingleSourceSetConfigurator)
-
-        // Given
-        val kmock = KMockPlugin()
-        val project: Project = mockk()
-        val plugins: PluginContainer = mockk()
-        val extensions: ExtensionContainer = mockk()
-        val kmockExtension: KMockExtension = mockk()
-        val kspExtension: KspExtension = mockk()
-        val rootPackage: String = fixture.fixture()
-        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
-
-        every { project.plugins } returns plugins
-        every { project.extensions } returns extensions
-        every { project.buildDir } returns buildDir
-
-        every { plugins.hasPlugin(any<String>()) } returns true
-        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
-        every { plugins.apply(any()) } returns mockk()
-
-        every { extensions.create(any(), KMockExtension::class.java) } returns kmockExtension
-
-        every { SingleSourceSetConfigurator.configure(any()) } just Runs
-
-        invokeGradleAction(
-            { probe -> project.afterEvaluate(probe) },
-            project
-        )
-
-        every { extensions.getByType(KspExtension::class.java) } returns kspExtension
-
-        every { kmockExtension.rootPackage } returns rootPackage
-        every { kspExtension.arg(any(), any()) } just Runs
-
-        // When
-        kmock.apply(project)
-
-        // Then
-        verify(exactly = 1) { kspExtension.arg("kmock_isKmp", "false") }
-        verify(exactly = 1) {
-            kspExtension.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp")
-        }
-
-        unmockkObject(SingleSourceSetConfigurator)
-    }
-
-    @Test
-    fun `Given apply is called it delegates the call to the KmpSourceSetsConfigurator if the Project is Kmp`() {
-        mockkObject(KmpSourceSetsConfigurator)
-        // Given
-        val kmock = KMockPlugin()
-        val project: Project = mockk()
-        val plugins: PluginContainer = mockk()
-        val extensions: ExtensionContainer = mockk()
-        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
-
-        every { project.plugins } returns plugins
-        every { project.extensions } returns extensions
-        every { project.buildDir } returns buildDir
-
-        every { plugins.hasPlugin(any<String>()) } returns true
-        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
-        every { plugins.apply(any()) } returns mockk()
-
-        every { extensions.create(any<String>(), KMockExtension::class.java) } returns mockk()
-        every { extensions.getByType<KspExtension>(KspExtension::class.java) } returns mockk(relaxed = true)
-
-        every { KmpSourceSetsConfigurator.configure(any()) } just Runs
-
-        // When
-        kmock.apply(project)
-
-        verify(exactly = 1) { KmpSourceSetsConfigurator.configure(project) }
-
-        unmockkObject(KmpSourceSetsConfigurator)
-    }
-
-    @Test
-    fun `Given apply is called it delegates it sets up KSP and builds the Kmp Factories`() {
-        mockkObject(KmpSourceSetsConfigurator)
-
-        // Given
-        val kmock = KMockPlugin()
-        val project: Project = mockk()
-        val plugins: PluginContainer = mockk()
-        val extensions: ExtensionContainer = mockk()
-        val kmockExtension: KMockExtension = mockk()
-        val kspExtension: KspExtension = mockk()
-        val rootPackage: String = fixture.fixture()
-        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
-
-        every { project.plugins } returns plugins
-        every { project.extensions } returns extensions
-        every { project.buildDir } returns buildDir
-
-        every { plugins.hasPlugin(any<String>()) } returns true
-        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
-        every { plugins.apply(any()) } returns mockk()
-
-        every { extensions.create(any(), KMockExtension::class.java) } returns kmockExtension
-
-        every { KmpSourceSetsConfigurator.configure(any()) } just Runs
-
-        every { extensions.getByType(KspExtension::class.java) } returns kspExtension
-
-        every { kmockExtension.rootPackage } returns rootPackage
-        every { kspExtension.arg(any(), any()) } just Runs
-
-        // When
-        kmock.apply(project)
-
-        // Then
-        verify(exactly = 1) { kspExtension.arg("kmock_isKmp", "true") }
-        verify(exactly = 1) {
-            kspExtension.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp")
-        }
-
-        unmockkObject(KmpSourceSetsConfigurator)
     }
 }

--- a/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/KSPBridgeSpec.kt
+++ b/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/KSPBridgeSpec.kt
@@ -1,0 +1,633 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache v2.0
+ */
+
+package tech.antibytes.gradle.kmock
+
+import com.google.devtools.ksp.gradle.KspExtension
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.plugins.PluginContainer
+import org.junit.jupiter.api.Test
+import tech.antibytes.util.test.fulfils
+import tech.antibytes.gradle.kmock.KMockPluginContract.SourceSetConfigurator
+import tech.antibytes.gradle.kmock.fixture.StringAlphaGenerator
+import tech.antibytes.util.test.fixture.fixture
+import tech.antibytes.util.test.fixture.kotlinFixture
+import tech.antibytes.util.test.fixture.listFixture
+import tech.antibytes.util.test.fixture.mapFixture
+import tech.antibytes.util.test.fixture.qualifier.named
+import tech.antibytes.util.test.mustBe
+import java.io.File
+
+class KSPBridgeSpec {
+    private val fixture = kotlinFixture {
+        it.addGenerator(
+            String::class,
+            StringAlphaGenerator,
+            named("stringAlpha")
+        )
+    }
+
+    @Test
+    fun `It fulfils KSPBridgeFactory`() {
+        KSPBridge fulfils KMockPluginContract.KSPBridgeFactory::class
+    }
+
+    @Test
+    fun `Given getInstance is called with a Project and a SingleSourceSetConfigurator and a KMPSourceSetConfigurator it returns a KSPBridgeFactory`() {
+        // Given
+        val project: Project = mockk(relaxed = true)
+        val singleSource: SourceSetConfigurator = mockk(relaxed = true)
+        val kmpSource: SourceSetConfigurator = mockk(relaxed = true)
+
+        val ksp: KspExtension = mockk()
+        val extensions: ExtensionContainer = mockk()
+
+        every { project.extensions } returns extensions
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        // When
+        val actual: Any = KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        )
+
+        // Then
+        actual fulfils KMockPluginContract.KSPBridge::class
+    }
+
+    @Test
+    fun `Given propagateValue is called with a key and value it propagates the source set config for single sources sets first`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { singleSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateValue(fixture.fixture(), fixture.fixture())
+
+        // Then
+        verify(exactly = 1) { singleSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "false") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateValue is called with a key and value it propagates the source set config for single sources sets first only once`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { singleSource.configure(any()) } just Runs
+
+        // When
+        val bridge = KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        )
+        bridge.propagateValue(fixture.fixture(), fixture.fixture())
+        bridge.propagateValue(fixture.fixture(), fixture.fixture())
+
+        // Then
+        verify(exactly = 1) { singleSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "false") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateValue is called with a key and value it propagates the source set config for kmp sources sets first`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateValue(fixture.fixture(), fixture.fixture())
+
+        // Then
+        verify(exactly = 1) { kmpSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "true") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateValue is called with a key and value it propagates the source set config for kmp sources sets first only once`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        val bridge = KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        )
+        bridge.propagateValue(fixture.fixture(), fixture.fixture())
+        bridge.propagateValue(fixture.fixture(), fixture.fixture())
+
+        // Then
+        verify(exactly = 1) { kmpSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "true") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateValue is called with a key and value it propagates the given key value pair to ksp`() {
+        // Given
+        val key: String = fixture.fixture()
+        val value: String = fixture.fixture()
+
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateValue(key, value)
+
+        // Then
+        verify(exactly = 1) { ksp.arg(key, value) }
+    }
+
+    @Test
+    fun `Given propagateMapping is called with a root key and mapping it propagates the source set config for single sources sets first`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { singleSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateMapping(fixture.fixture(), fixture.mapFixture())
+
+        // Then
+        verify(exactly = 1) { singleSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "false") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateMapping is called with a root key and mapping it propagates the source set config for single sources sets first only once`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { singleSource.configure(any()) } just Runs
+
+        // When
+        val bridge = KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        )
+        bridge.propagateMapping(fixture.fixture(), fixture.mapFixture())
+        bridge.propagateMapping(fixture.fixture(), fixture.mapFixture())
+
+        // Then
+        verify(exactly = 1) { singleSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "false") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateMapping is called with a root key and mapping it propagates the source set config for kmp sources sets first`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateMapping(fixture.fixture(), fixture.mapFixture())
+
+        // Then
+        verify(exactly = 1) { kmpSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "true") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateMapping is called with a root key and mapping it propagates the source set config for kmp sources sets first only once`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        val bridge = KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        )
+        bridge.propagateMapping(fixture.fixture(), fixture.mapFixture())
+        bridge.propagateMapping(fixture.fixture(), fixture.mapFixture())
+
+        // Then
+        verify(exactly = 1) { kmpSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "true") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateMapping is called with a root key and mapping it propagates the given key value pairs to ksp while delegating to a given action as well`() {
+        // Given
+        val rootKey: String = fixture.fixture()
+        val pairs: Map<String, String> = fixture.mapFixture(size = 3)
+
+        val captured: MutableMap<String, String> = mutableMapOf()
+        val action: (String, String) -> Unit = { givenKey, givenValue ->
+            captured[givenKey] = givenValue
+        }
+
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateMapping(
+            rootKey = rootKey,
+            mapping = pairs,
+            onPropagation = action
+        )
+
+        // Then
+        pairs.forEach { (key, value) ->
+            verify(exactly = 1) { ksp.arg("$rootKey$key", value) }
+        }
+        captured mustBe pairs
+    }
+
+    @Test
+    fun `Given propagateIterable is called with a rootKey and values it propagates the source set config for single sources sets first`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { singleSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateIterable(fixture.fixture(), fixture.listFixture<String>())
+
+        // Then
+        verify(exactly = 1) { singleSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "false") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateIterable is called with a rootKey and values it propagates the source set config for single sources sets first only once`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns false
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { singleSource.configure(any()) } just Runs
+
+        // When
+        val bridge = KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        )
+        bridge.propagateIterable(fixture.fixture(), fixture.listFixture<String>())
+        bridge.propagateIterable(fixture.fixture(), fixture.listFixture<String>())
+
+        // Then
+        verify(exactly = 1) { singleSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "false") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateIterable is called with a rootKey and values it propagates the source set config for kmp sources sets first`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateIterable(fixture.fixture(), fixture.listFixture<String>())
+
+        // Then
+        verify(exactly = 1) { kmpSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "true") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateIterable is called with a rootKey and values it propagates the source set config for kmp sources sets first only once`() {
+        // Given
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        val bridge = KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        )
+        bridge.propagateIterable(fixture.fixture(), fixture.listFixture<String>())
+        bridge.propagateIterable(fixture.fixture(), fixture.listFixture<String>())
+
+        // Then
+        verify(exactly = 1) { kmpSource.configure(project) }
+        verify(exactly = 1) { ksp.arg("kmock_isKmp", "true") }
+        verify(exactly = 1) { ksp.arg("kmock_kspDir", "${buildDir.absolutePath}/generated/ksp") }
+    }
+
+    @Test
+    fun `Given propagateIterable is called with a rootKey and values it propagates the given values to ksp while transforing it with the given action`() {
+        // Given
+        val rootKey: String = fixture.fixture()
+        val values: List<String> = fixture.listFixture(size = 3)
+
+        val captured: MutableList<String> = mutableListOf()
+        val action: (String) -> String = { givenValue ->
+            captured.add(givenValue)
+
+            "${givenValue}X"
+        }
+
+        val project: Project = mockk()
+        val singleSource: SourceSetConfigurator = mockk()
+        val kmpSource: SourceSetConfigurator = mockk()
+        val ksp: KspExtension = mockk()
+
+        val plugins: PluginContainer = mockk()
+        val extensions: ExtensionContainer = mockk()
+        val buildDir = File(fixture.fixture<String>(named("stringAlpha")))
+
+        every { project.plugins } returns plugins
+        every { project.extensions } returns extensions
+        every { project.buildDir } returns buildDir
+
+        every { plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") } returns true
+        every { extensions.getByType(KspExtension::class.java) } returns ksp
+
+        every { ksp.arg(any(), any()) } just Runs
+        every { kmpSource.configure(any()) } just Runs
+
+        // When
+        KSPBridge.getInstance(
+            project = project,
+            singleSourceSetConfigurator = singleSource,
+            kmpSourceSetConfigurator = kmpSource
+        ).propagateIterable(
+            rootKey = rootKey,
+            values = values,
+            action = action
+        )
+
+        // Then
+        values.forEachIndexed { idx, value ->
+            verify(exactly = 1) { ksp.arg("$rootKey$idx", "${value}X") }
+        }
+        captured mustBe values
+    }
+}

--- a/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/KSPBridgeSpec.kt
+++ b/kmock-gradle/src/test/kotlin/tech/antibytes/gradle/kmock/KSPBridgeSpec.kt
@@ -16,7 +16,6 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.PluginContainer
 import org.junit.jupiter.api.Test
-import tech.antibytes.util.test.fulfils
 import tech.antibytes.gradle.kmock.KMockPluginContract.SourceSetConfigurator
 import tech.antibytes.gradle.kmock.fixture.StringAlphaGenerator
 import tech.antibytes.util.test.fixture.fixture
@@ -24,6 +23,7 @@ import tech.antibytes.util.test.fixture.kotlinFixture
 import tech.antibytes.util.test.fixture.listFixture
 import tech.antibytes.util.test.fixture.mapFixture
 import tech.antibytes.util.test.fixture.qualifier.named
+import tech.antibytes.util.test.fulfils
 import tech.antibytes.util.test.mustBe
 import java.io.File
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #121

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This introduces the KSPBridge which now takes over as a central place to propagate values from the Extension to KSP.
This also allows to decouple the source set propagation from the Plugin.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [x] My changes update the documentation.
- [x] My changes are reflected in the changelog.
