### PR TITLE
Change ArgumentTypeVariable for AccessMethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Aliases as type arguments are not correctly resolved, if the Aliases have type arguments on their own
+* Generics cause AccessMethods to collide in their definition
 
 ### Security
 

--- a/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
+++ b/kmock-processor/src/test/kotlin/tech/antibytes/kmock/integration/KMockMocksSpec.kt
@@ -694,7 +694,6 @@ class KMockMocksSpec {
             isKmp = false,
         )
         val actual = resolveGenerated("NoBuildInsMock.kt")
-        println(actual!!.readText())
 
         // Then
         compilerResult.exitCode mustBe KotlinCompilation.ExitCode.OK

--- a/kmock-processor/src/test/resources/mock/expected/access/AsyncFun.kt
+++ b/kmock-processor/src/test/resources/mock/expected/access/AsyncFun.kt
@@ -11,6 +11,7 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import kotlin.collections.Map
+import tech.antibytes.kmock.Hint0
 import tech.antibytes.kmock.Hint1
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockExperimental
@@ -40,7 +41,7 @@ internal class AsyncFunMock<L, T>(
         ProxyFactory.createAsyncFunProxy("mock.template.access.AsyncFunMock#_ozz", collector =
         collector, freeze = freeze)
 
-    public val _izz: KMockContract.AsyncFunProxy<Any, suspend (Array<out Any>) -> Any> =
+    public val _izz: KMockContract.AsyncFunProxy<Any, suspend (Array<out L>) -> Any> =
         ProxyFactory.createAsyncFunProxy("mock.template.access.AsyncFunMock#_izz", collector =
         collector, freeze = freeze)
 
@@ -64,6 +65,10 @@ internal class AsyncFunMock<L, T>(
         ProxyFactory.createAsyncFunProxy("mock.template.access.AsyncFunMock#_lol", collector =
         collector, freeze = freeze)
 
+    public val _fol: KMockContract.AsyncFunProxy<Any, suspend () -> Any> =
+        ProxyFactory.createAsyncFunProxy("mock.template.access.AsyncFunMock#_fol", collector =
+        collector, freeze = freeze)
+
     public val _veryLongMethodNameWithABunchOfVariables: KMockContract.AsyncFunProxy<Unit, suspend (
         Int,
         Int,
@@ -72,9 +77,9 @@ internal class AsyncFunMock<L, T>(
         Int,
         Int,
         Int,
+        L,
         Int,
-        Int,
-        Int,
+        T,
     ) -> Unit> =
         ProxyFactory.createAsyncFunProxy("mock.template.access.AsyncFunMock#_veryLongMethodNameWithABunchOfVariables",
             collector = collector, freeze = freeze)
@@ -83,14 +88,15 @@ internal class AsyncFunMock<L, T>(
         "foo|suspend (kotlin.Int, kotlin.Any) -> kotlin.Any|[]" to _foo,
         "bar|suspend (kotlin.Int, kotlin.Any) -> kotlin.Any|[]" to _bar,
         "ozz|suspend (kotlin.IntArray) -> kotlin.Any|[]" to _ozz,
-        "izz|suspend (kotlin.Array<out kotlin.Any>) -> kotlin.Any|[]" to _izz,
+        "izz|suspend (kotlin.Array<L>) -> kotlin.Any|[]" to _izz,
         "uzz|suspend () -> kotlin.Unit|[]" to _uzz,
         "tuz|suspend () -> kotlin.Int|[]" to _tuz,
         "uz|suspend () -> L|[]" to _uz,
         "tzz|suspend () -> T|[]" to _tzz,
-        "veryLongMethodNameWithABunchOfVariables|suspend (  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,) -> kotlin.Unit|[]"
+        "veryLongMethodNameWithABunchOfVariables|suspend (  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  L,  kotlin.Int,  T,) -> kotlin.Unit|[]"
             to _veryLongMethodNameWithABunchOfVariables,
         "lol|suspend (kotlin.Any?) -> kotlin.Any?|[[kotlin.Any?]]" to _lol,
+        "fol|suspend () -> kotlin.Any|[[kotlin.Any]]" to _fol,
     )
 
     public override suspend fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
@@ -99,7 +105,7 @@ internal class AsyncFunMock<L, T>(
 
     public override suspend fun ozz(vararg buzz: Int): Any = _ozz.invoke(buzz)
 
-    public override suspend fun izz(vararg buzz: Any): Any = _izz.invoke(buzz)
+    public override suspend fun izz(vararg buzz: L): Any = _izz.invoke(buzz)
 
     public override suspend fun uzz(): Unit = _uzz.invoke() {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
@@ -114,6 +120,9 @@ internal class AsyncFunMock<L, T>(
     @Suppress("UNCHECKED_CAST")
     public override suspend fun <T> lol(arg: T): T = _lol.invoke(arg) as T
 
+    @Suppress("UNCHECKED_CAST")
+    public override suspend fun <T : Any> fol(): T = _fol.invoke() as T
+
     public override suspend fun veryLongMethodNameWithABunchOfVariables(
         arg0: Int,
         arg1: Int,
@@ -122,9 +131,9 @@ internal class AsyncFunMock<L, T>(
         arg4: Int,
         arg5: Int,
         arg6: Int,
-        arg7: Int,
+        arg7: L,
         arg8: Int,
-        arg9: Int,
+        arg9: T,
     ): Unit = _veryLongMethodNameWithABunchOfVariables.invoke(arg0, arg1, arg2, arg3, arg4, arg5,
         arg6, arg7, arg8, arg9) {
         useUnitFunRelaxerIf(relaxUnitFun || relaxed)
@@ -140,6 +149,7 @@ internal class AsyncFunMock<L, T>(
         _uz.clear()
         _tzz.clear()
         _lol.clear()
+        _fol.clear()
         _veryLongMethodNameWithABunchOfVariables.clear()
     }
 
@@ -168,13 +178,13 @@ internal class AsyncFunMock<L, T>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("asyncFunProxyOf2")
-    public fun asyncFunProxyOf(reference: suspend (Array<out Any>) -> Any):
-        KMockContract.FunProxy<Any, suspend (Array<out Any>) -> Any> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Array<out kotlin.Any>) -> kotlin.Any|[]"""]
+    public fun asyncFunProxyOf(reference: suspend (Array<out L>) -> Any):
+        KMockContract.FunProxy<Any, suspend (Array<L>) -> Any> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Array<L>) -> kotlin.Any|[]"""]
             ?: throw
-            IllegalStateException("""Unknown method ${reference.name} with signature suspend (kotlin.Array<out kotlin.Any>) -> kotlin.Any!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, suspend (kotlin.Array<out
-        kotlin.Any>) -> kotlin.Any>
+            IllegalStateException("""Unknown method ${reference.name} with signature suspend (kotlin.Array<out L>) -> kotlin.Any!"""))
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, suspend (kotlin.Array<L>) ->
+        kotlin.Any>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -225,9 +235,9 @@ internal class AsyncFunMock<L, T>(
         Int,
         Int,
         Int,
+        L,
         Int,
-        Int,
-        Int,
+        T,
     ) -> Unit): KMockContract.FunProxy<Unit, suspend (
         Int,
         Int,
@@ -236,13 +246,13 @@ internal class AsyncFunMock<L, T>(
         Int,
         Int,
         Int,
+        L,
         Int,
-        Int,
-        Int,
+        T,
     ) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,) -> kotlin.Unit|[]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  L,  kotlin.Int,  T,) -> kotlin.Unit|[]"""]
             ?: throw
-            IllegalStateException("""Unknown method ${reference.name} with signature suspend (  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,) -> kotlin.Unit!"""))
+            IllegalStateException("""Unknown method ${reference.name} with signature suspend (  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  L,  kotlin.Int,  T,) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, suspend (
             kotlin.Int,
             kotlin.Int,
@@ -251,9 +261,9 @@ internal class AsyncFunMock<L, T>(
             kotlin.Int,
             kotlin.Int,
             kotlin.Int,
+            L,
             kotlin.Int,
-            kotlin.Int,
-            kotlin.Int,
+            T,
         ) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -266,4 +276,14 @@ internal class AsyncFunMock<L, T>(
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (T) -> T!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any?, suspend (kotlin.Any?) ->
         kotlin.Any?>
+
+    @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
+    @KMockExperimental
+    @SafeJvmName("asyncFunProxyOf9")
+    public fun <T : Any> asyncFunProxyOf(reference: suspend () -> T, hint: Hint0):
+        KMockContract.FunProxy<Any, suspend () -> Any> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend () -> kotlin.Any|[[kotlin.Any]]"""]
+            ?: throw
+            IllegalStateException("""Unknown method ${reference.name} with signature suspend () -> T!"""))
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, suspend () -> kotlin.Any>
 }

--- a/kmock-processor/src/test/resources/mock/expected/access/Overloaded.kt
+++ b/kmock-processor/src/test/resources/mock/expected/access/Overloaded.kt
@@ -384,19 +384,19 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
         "foo|(kotlin.Any?) -> kotlin.Unit|[[kotlin.Any?]]" to _fooWithZTAny,
         "foo|(kotlin.Any) -> kotlin.String|[]" to _fooWithAny,
         "foo|() -> kotlin.Any?|[[kotlin.Any?]]" to _fooWithVoid,
-        "foo|(kotlin.Array<*>) -> kotlin.Unit|[[kotlin.Any?]]" to _fooWithZTAnys,
-        "lol|(kotlin.Array<out kotlin.Array<out kotlin.Any>>) -> kotlin.Unit|[]" to _lolWithArrays,
-        "brass|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"
+        "foo|(kotlin.Array<kotlin.Any?>) -> kotlin.Unit|[[kotlin.Any?]]" to _fooWithZTAnys,
+        "lol|(kotlin.Array<kotlin.Array<kotlin.Any>>) -> kotlin.Unit|[]" to _lolWithArrays,
+        "brass|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _brassWithVoid,
-        "brass|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"
+        "brass|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _brassWithTComparable,
-        "brass|(kotlin.Array<out kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"
+        "brass|(kotlin.Array<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _brassWithTComparables,
         "bar|() -> kotlin.collections.List<kotlin.Array<kotlin.String>>|[[kotlin.collections.List<kotlin.Array<kotlin.String>>]]"
             to _barWithVoid,
         "bar|(kotlin.collections.List<kotlin.Array<kotlin.String>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String>>]]"
             to _barWithTList,
-        "bar|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String>>]]"
+        "bar|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String>>]]"
             to _barWithTLists,
         "blubb|(  kotlin.String,  kotlin.CharArray,  kotlin.Boolean,  kotlin.Int,) -> kotlin.Unit|[]"
             to _blubbWithStringCharArrayBooleanInt,
@@ -404,68 +404,68 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
             to _blubbWithVoid,
         "blubb|(kotlin.collections.List<kotlin.Array<kotlin.String?>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String?>>]]"
             to _blubbWithTList,
-        "blubb|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String?>>]]"
+        "blubb|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String?>>]]"
             to _blubbWithTLists,
         "buss|() -> kotlin.collections.List<kotlin.Array<kotlin.Int>>?|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>?]]"
             to _bussWithVoid,
         "buss|(kotlin.collections.List<kotlin.Array<kotlin.Int>>?) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>?]]"
             to _bussWithZTList,
-        "buss|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>?]]"
+        "buss|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>?]]"
             to _bussWithZTLists,
         "boss|() -> kotlin.collections.List<kotlin.Array<kotlin.Int>?>|[[kotlin.collections.List<kotlin.Array<kotlin.Int>?>]]"
             to _bossWithVoid,
         "boss|(kotlin.collections.List<kotlin.Array<kotlin.Int>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>?>]]"
             to _bossWithTList,
-        "boss|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>?>]]"
+        "boss|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>?>]]"
             to _bossWithTLists,
         "buzz|() -> kotlin.collections.List<kotlin.Array<kotlin.Int>>?|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>]]"
             to _buzzWithVoid,
         "buzz|(kotlin.collections.List<kotlin.Array<kotlin.Int>>?) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>]]"
             to _buzzWithTList,
-        "buzz|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>]]"
+        "buzz|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>]]"
             to _buzzWithTLists,
-        "ozz|() -> L|[[L]]" to _ozzWithVoid,
-        "ozz|(L) -> kotlin.Unit|[[L]]" to _ozzWithTL,
-        "ozz|(kotlin.Array<out L>) -> kotlin.Unit|[[L]]" to _ozzWithTLs,
-        "bliss|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>?]]"
+        "ozz|() -> L|[[X]]" to _ozzWithVoid,
+        "ozz|(L) -> kotlin.Unit|[[X]]" to _ozzWithTL,
+        "ozz|(kotlin.Array<L>) -> kotlin.Unit|[[X]]" to _ozzWithTLs,
+        "bliss|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>?]]"
             to _blissWithVoid,
-        "bliss|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>?]]"
+        "bliss|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>?]]"
             to _blissWithZTComparable,
-        "bliss|(kotlin.Array<out kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>?]]"
+        "bliss|(kotlin.Array<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>?]]"
             to _blissWithZTComparables,
         "loss|() -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _lossWithVoid,
         "loss|(kotlin.collections.Map<kotlin.String, kotlin.String>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _lossWithTMap,
-        "loss|(kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
+        "loss|(kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _lossWithTMaps,
         "uzz|() -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>]]"
             to _uzzWithVoid,
         "uzz|(kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>]]"
             to _uzzWithTSomeGenericTList,
-        "uzz|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>]]"
+        "uzz|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>]]"
             to _uzzWithTSomeGenericTLists,
         "lzz|() -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>?]]"
             to _lzzWithVoid,
         "lzz|(kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>?]]"
             to _lzzWithTSomeGenericTList,
-        "lzz|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>?]]"
+        "lzz|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>?]]"
             to _lzzWithTSomeGenericTLists,
         "rzz|() -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _rzzWithVoid,
         "rzz|(kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _rzzWithTSomeGenericTMap,
-        "rzz|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.Map<kotlin.String, kotlin.String>]]"
+        "rzz|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _rzzWithTSomeGenericTMaps,
-        "izz|() -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"
+        "izz|() -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _izzWithVoid,
-        "izz|(kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"
+        "izz|(kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _izzWithTSomeGenericTComparable,
-        "izz|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"
+        "izz|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _izzWithTSomeGenericTComparables,
-        "kss|(kotlin.Any) -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>]]"
+        "kss|(kotlin.Any) -> kotlin.Any|[[X], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _kssWithTSomeGenericTComparable,
-        "kss|(kotlin.Any, kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>]]"
+        "kss|(kotlin.Any, kotlin.Any) -> kotlin.Unit|[[X], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"
             to _kssWithTSomeGenericTComparableRSomeGenericRComparable,
         "pss|(mock.template.access.SomeGeneric<kotlin.String>) -> mock.template.access.SomeGeneric<kotlin.String>|[[mock.template.access.SomeGeneric<kotlin.String>], [mock.template.access.SomeGeneric<kotlin.String>], [mock.template.access.SomeGeneric<kotlin.String>]]"
             to _pssWithTSomeGeneric,
@@ -482,16 +482,16 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
             to _tzzWithVoid,
         "tzz|suspend (kotlin.Any?) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String>? & kotlin.collections.List<kotlin.String>?]]"
             to _tzzWithZTSomeGenericZTList,
-        "tzz|suspend (kotlin.Array<*>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String>? & kotlin.collections.List<kotlin.String>?]]"
+        "tzz|suspend (kotlin.Array<kotlin.Any?>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String>? & kotlin.collections.List<kotlin.String>?]]"
             to _tzzWithZTSomeGenericZTLists,
-        "oss|suspend (kotlin.Any?) -> kotlin.Any?|[[kotlin.Any?], [kotlin.Any?]]" to _ossWithZTAny,
-        "oss|suspend (kotlin.Any?, kotlin.Any?) -> kotlin.Unit|[[kotlin.Any?], [kotlin.Any?]]" to
+        "oss|suspend (kotlin.Any?) -> kotlin.Any?|[[X], [kotlin.Any?]]" to _ossWithZTAny,
+        "oss|suspend (kotlin.Any?, kotlin.Any?) -> kotlin.Unit|[[X], [kotlin.Any?]]" to
             _ossWithZTAnyZRAny,
-        "oss|suspend (kotlin.Any?, kotlin.Array<*>) -> kotlin.Unit|[[kotlin.Any?], [kotlin.Any?]]" to
+        "oss|suspend (kotlin.Any?, kotlin.Array<kotlin.Any?>) -> kotlin.Unit|[[X], [kotlin.Any?]]" to
             _ossWithZRAnyZTAnys,
-        "iss|suspend (kotlin.Any?) -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>], [kotlin.Any?]]"
+        "iss|suspend (kotlin.Any?) -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>], [kotlin.Any?]]"
             to _issWithZTAny,
-        "iss|suspend (kotlin.Any?, kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>], [kotlin.Any?]]"
+        "iss|suspend (kotlin.Any?, kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>], [kotlin.Any?]]"
             to _issWithZTAnyRSomeGenericRComparable,
     )
 
@@ -1010,31 +1010,31 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf11")
-    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<*>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<*>) -> kotlin.Unit|[[kotlin.Any?]]"""]
+    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<Any?>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Any?>) -> kotlin.Unit|[[kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<*>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<kotlin.Any?>) ->
+        kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf12")
-    public fun syncFunProxyOf(reference: (Array<out Array<out Any>>) -> Unit,
-        hint: Hint1<Array<out Array<out Any>>>):
-        KMockContract.FunProxy<Unit, (Array<out Array<out Any>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Array<out kotlin.Any>>) -> kotlin.Unit|[]"""]
+    public fun syncFunProxyOf(reference: (Array<out Array<Any>>) -> Unit,
+        hint: Hint1<Array<Array<Any>>>): KMockContract.FunProxy<Unit, (Array<Array<Any>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Array<kotlin.Any>>) -> kotlin.Unit|[]"""]
             ?: throw
-            IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out kotlin.Array<out kotlin.Any>>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out kotlin.Array<out
-        kotlin.Any>>) -> kotlin.Unit>
+            IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out kotlin.Array<kotlin.Any>>) -> kotlin.Unit!"""))
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.Array<kotlin.Any>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf13")
     public fun <T : Comparable<List<Array<T>>>> syncFunProxyOf(reference: () -> T, hint: Hint0):
         KMockContract.FunProxy<Comparable<List<Array<Any>>>, () -> Comparable<List<Array<Any>>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature () -> T!""")) as
             tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>,
@@ -1045,7 +1045,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @SafeJvmName("syncFunProxyOf14")
     public fun <T : Comparable<List<Array<T>>>> syncFunProxyOf(reference: (T) -> Unit,
         hint: Hint1<T>): KMockContract.FunProxy<Unit, (Comparable<List<Array<Any>>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
@@ -1055,13 +1055,14 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf15")
     public fun <T : Comparable<List<Array<T>>>> syncFunProxyOf(reference: (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out Comparable<List<Array<Any>>>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"""]
+        hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<Comparable<List<Array<Any>>>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any>>>>) ->
+        kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1089,13 +1090,12 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf18")
     public fun <T : List<Array<String>>> syncFunProxyOf(reference: (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out List<Array<String>>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String>>]]"""]
+        hint: Hint1<Array<T>>): KMockContract.FunProxy<Unit, (Array<List<Array<String>>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.String>>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1147,13 +1147,12 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf22")
     public fun <T : List<Array<String?>>> syncFunProxyOf(reference: (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out List<Array<String?>>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String?>>]]"""]
+        hint: Hint1<Array<T>>): KMockContract.FunProxy<Unit, (Array<List<Array<String?>>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.String?>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.String?>>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1181,13 +1180,12 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf25")
     public fun <T : List<Array<Int>>?> syncFunProxyOf(reference: (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out List<Array<Int>>?>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>?]]"""]
+        hint: Hint1<Array<T>>): KMockContract.FunProxy<Unit, (Array<List<Array<Int>>?>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1215,13 +1213,12 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf28")
     public fun <T : List<Array<Int>?>> syncFunProxyOf(reference: (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out List<Array<Int>?>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>?>]]"""]
+        hint: Hint1<Array<T>>): KMockContract.FunProxy<Unit, (Array<List<Array<Int>?>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>?>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>?>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1249,20 +1246,19 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf31")
     public fun <T : List<Array<Int>>> syncFunProxyOf(reference: (Array<out T?>) -> Unit,
-        hint: Hint1<Array<out T?>>):
-        KMockContract.FunProxy<Unit, (Array<out List<Array<Int>>?>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>]]"""]
+        hint: Hint1<Array<T?>>): KMockContract.FunProxy<Unit, (Array<List<Array<Int>>?>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit|[[kotlin.collections.List<kotlin.Array<kotlin.Int>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T?>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.collections.List<kotlin.Array<kotlin.Int>>?>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf32")
     public fun <T : L> syncFunProxyOf(reference: () -> T, hint: Hint0):
         KMockContract.FunProxy<L, () -> L> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> L|[[L]]"""] ?:
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> L|[[X]]"""] ?:
         throw IllegalStateException("""Unknown method ${reference.name} with signature () -> T!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<L, () -> L>
 
@@ -1271,7 +1267,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @SafeJvmName("syncFunProxyOf33")
     public fun <T : L> syncFunProxyOf(reference: (T) -> Unit, hint: Hint1<T>):
         KMockContract.FunProxy<Unit, (L) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(L) -> kotlin.Unit|[[L]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(L) -> kotlin.Unit|[[X]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (L) -> kotlin.Unit>
@@ -1279,20 +1275,19 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf34")
-    public fun <T : L> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out L>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out L>) -> kotlin.Unit|[[L]]"""]
+    public fun <T : L> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<L>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<L>) -> kotlin.Unit|[[X]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out L>) ->
-        kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<L>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf35")
     public fun <T : Comparable<List<Array<T>>>?> syncFunProxyOf(reference: () -> T, hint: Hint0):
         KMockContract.FunProxy<Comparable<List<Array<Any?>>>?, () -> Comparable<List<Array<Any?>>>?> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature () -> T!""")) as
             tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?,
@@ -1304,7 +1299,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     public fun <T : Comparable<List<Array<T>>>?> syncFunProxyOf(reference: (T) -> Unit,
         hint: Hint1<Comparable<List<Array<T>>>>):
         KMockContract.FunProxy<Unit, (Comparable<List<Array<Any?>>>?) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
@@ -1314,13 +1309,14 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf37")
     public fun <T : Comparable<List<Array<T>>>?> syncFunProxyOf(reference: (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out Comparable<List<Array<Any?>>>?>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>?]]"""]
+        hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<Comparable<List<Array<Any?>>>?>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) -> kotlin.Unit|[[kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.Comparable<kotlin.collections.List<kotlin.Array<kotlin.Any?>>>?>) ->
+        kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1348,13 +1344,12 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf40")
     public fun <T : Map<String, String>> syncFunProxyOf(reference: (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out Map<String, String>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
+        hint: Hint1<Array<T>>): KMockContract.FunProxy<Unit, (Array<Map<String, String>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out
-        kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
+                (kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1379,13 +1374,13 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf43")
-    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out Any>) -> Unit> where T : SomeGeneric<String>, T :
+    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<Any>) -> Unit> where T : SomeGeneric<String>, T :
     List<String> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out kotlin.Any>) ->
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<kotlin.Any>) ->
         kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -1411,13 +1406,13 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf46")
-    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out Any>) -> Unit> where T : SomeGeneric<String>, T :
+    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<Any>) -> Unit> where T : SomeGeneric<String>, T :
     List<String>? =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.List<kotlin.String>?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out kotlin.Any>) ->
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<kotlin.Any>) ->
         kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -1445,13 +1440,13 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf49")
-    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out Any>) -> Unit> where T : SomeGeneric<String>, T :
+    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<Any>) -> Unit> where T : SomeGeneric<String>, T :
     Map<String, String> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out kotlin.Any>) ->
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<kotlin.Any>) ->
         kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -1460,7 +1455,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     public fun <T> syncFunProxyOf(reference: () -> T, hint: Hint0):
         KMockContract.FunProxy<Any, () -> Any> where T : SomeGeneric<String>, T :
     Comparable<List<Array<T>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature () -> T!""")) as
             tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, () -> kotlin.Any>
@@ -1471,7 +1466,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     public fun <T> syncFunProxyOf(reference: (T) -> Unit, hint: Hint1<T>):
         KMockContract.FunProxy<Unit, (Any) -> Unit> where T : SomeGeneric<String>, T :
     Comparable<List<Array<T>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Any) -> kotlin.Unit>
@@ -1479,13 +1474,13 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf52")
-    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Unit, (Array<out Any>) -> Unit> where T : SomeGeneric<String>, T :
+    public fun <T> syncFunProxyOf(reference: (Array<out T>) -> Unit, hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, (Array<Any>) -> Unit> where T : SomeGeneric<String>, T :
     Comparable<List<Array<T>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Any>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<out kotlin.Any>) ->
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Array<kotlin.Any>) ->
         kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -1494,7 +1489,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     public fun <T : R, R> syncFunProxyOf(reference: (T) -> R, hint: Hint1<T>):
         KMockContract.FunProxy<Any, (Any) -> Any> where R : SomeGeneric<String>, R :
     Comparable<List<Array<R>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Any) -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Any) -> kotlin.Any|[[X], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> R!""")) as
             tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, (kotlin.Any) -> kotlin.Any>
@@ -1505,7 +1500,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     public fun <T : R, R> syncFunProxyOf(reference: (T, R) -> Unit, hint: Hint2<T, R>):
         KMockContract.FunProxy<Unit, (Any, Any) -> Unit> where R : SomeGeneric<String>, R :
     Comparable<List<Array<R>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Any, kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<R>>>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Any, kotlin.Any) -> kotlin.Unit|[[X], [mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T, R) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Any, kotlin.Any) ->
@@ -1584,7 +1579,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("asyncFunProxyOf61")
     public fun <T : Int> asyncFunProxyOf(reference: suspend (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>): KMockContract.FunProxy<Unit, suspend (IntArray) -> Unit> =
+        hint: Hint1<Array<T>>): KMockContract.FunProxy<Unit, suspend (IntArray) -> Unit> =
         (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.IntArray) -> kotlin.Unit|[[kotlin.Int]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (kotlin.Array<out T>) -> kotlin.Unit!"""))
@@ -1617,21 +1612,21 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("asyncFunProxyOf64")
-    public fun <T> asyncFunProxyOf(reference: suspend (Array<out T>) -> Unit,
-        hint: Hint1<Array<out T>>): KMockContract.FunProxy<Unit, suspend (Array<*>) -> Unit> where T :
-                                                                                                   SomeGeneric<String>?, T : List<String>? =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Array<*>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String>? & kotlin.collections.List<kotlin.String>?]]"""]
+    public fun <T> asyncFunProxyOf(reference: suspend (Array<out T>) -> Unit, hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Unit, suspend (Array<Any?>) -> Unit> where T : SomeGeneric<String>?, T
+    : List<String>? =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Array<kotlin.Any?>) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String>? & kotlin.collections.List<kotlin.String>?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, suspend (kotlin.Array<*>) ->
-        kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, suspend
+            (kotlin.Array<kotlin.Any?>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("asyncFunProxyOf65")
     public fun <T : R, R> asyncFunProxyOf(reference: suspend (T) -> R, hint: Hint1<Any>):
         KMockContract.FunProxy<Any?, suspend (Any?) -> Any?> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?) -> kotlin.Any?|[[kotlin.Any?], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?) -> kotlin.Any?|[[X], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (T) -> R!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any?, suspend (kotlin.Any?) ->
@@ -1642,7 +1637,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @SafeJvmName("asyncFunProxyOf66")
     public fun <T : R, R> asyncFunProxyOf(reference: suspend (T, R) -> Unit, hint: Hint2<Any, Any>):
         KMockContract.FunProxy<Unit, suspend (Any?, Any?) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?, kotlin.Any?) -> kotlin.Unit|[[kotlin.Any?], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?, kotlin.Any?) -> kotlin.Unit|[[X], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (T, R) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, suspend (kotlin.Any?,
@@ -1652,13 +1647,13 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     @KMockExperimental
     @SafeJvmName("asyncFunProxyOf67")
     public fun <T : R, R> asyncFunProxyOf(reference: suspend (R, Array<out T>) -> Unit,
-        hint: Hint2<Any, Array<out T>>): KMockContract.FunProxy<Unit, suspend (Any?,
-        Array<*>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?, kotlin.Array<*>) -> kotlin.Unit|[[kotlin.Any?], [kotlin.Any?]]"""]
+        hint: Hint2<Any, Array<T>>): KMockContract.FunProxy<Unit, suspend (Any?, Array<Any?>) -> Unit>
+        =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?, kotlin.Array<kotlin.Any?>) -> kotlin.Unit|[[X], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (R, kotlin.Array<out T>) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, suspend (kotlin.Any?,
-            kotlin.Array<*>) -> kotlin.Unit>
+            kotlin.Array<kotlin.Any?>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
@@ -1666,7 +1661,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     public fun <R, T> asyncFunProxyOf(reference: suspend (T) -> R, hint: Hint1<Any>):
         KMockContract.FunProxy<Any, suspend (Any?) -> Any> where R : SomeGeneric<String>, R :
     Comparable<List<Array<T>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?) -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?) -> kotlin.Any|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (T) -> R!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, suspend (kotlin.Any?) ->
@@ -1678,7 +1673,7 @@ internal class OverloadedMock<K : Any, L, U : Int?, W>(
     public fun <R, T> asyncFunProxyOf(reference: suspend (T, R) -> Unit, hint: Hint2<Any, R>):
         KMockContract.FunProxy<Unit, suspend (Any?, Any) -> Unit> where R : SomeGeneric<String>, R :
     Comparable<List<Array<T>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?, kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<T>>>], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|suspend (kotlin.Any?, kotlin.Any) -> kotlin.Unit|[[mock.template.access.SomeGeneric<kotlin.String> & kotlin.Comparable<kotlin.collections.List<kotlin.Array<X>>>], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature suspend (T, R) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, suspend (kotlin.Any?,

--- a/kmock-processor/src/test/resources/mock/expected/access/SyncFun.kt
+++ b/kmock-processor/src/test/resources/mock/expected/access/SyncFun.kt
@@ -11,6 +11,7 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
 import kotlin.collections.Map
+import tech.antibytes.kmock.Hint0
 import tech.antibytes.kmock.Hint1
 import tech.antibytes.kmock.KMockContract
 import tech.antibytes.kmock.KMockExperimental
@@ -64,6 +65,10 @@ internal class SyncFunMock<L, T>(
         ProxyFactory.createSyncFunProxy("mock.template.access.SyncFunMock#_lol", collector =
         collector, freeze = freeze)
 
+    public val _fol: KMockContract.SyncFunProxy<Any, () -> Any> =
+        ProxyFactory.createSyncFunProxy("mock.template.access.SyncFunMock#_fol", collector =
+        collector, freeze = freeze)
+
     public val _veryLongMethodNameWithABunchOfVariables: KMockContract.SyncFunProxy<Unit, (
         Int,
         Int,
@@ -83,7 +88,7 @@ internal class SyncFunMock<L, T>(
         "foo|(kotlin.Int, kotlin.Any) -> kotlin.Any|[]" to _foo,
         "bar|(kotlin.Int, kotlin.Any) -> kotlin.Any|[]" to _bar,
         "ozz|(kotlin.IntArray) -> kotlin.Any|[]" to _ozz,
-        "izz|(kotlin.Array<out kotlin.Any>) -> kotlin.Any|[]" to _izz,
+        "izz|(kotlin.Array<kotlin.Any>) -> kotlin.Any|[]" to _izz,
         "uzz|() -> kotlin.Unit|[]" to _uzz,
         "tuz|() -> kotlin.Int|[]" to _tuz,
         "uz|() -> L|[]" to _uz,
@@ -91,6 +96,7 @@ internal class SyncFunMock<L, T>(
         "veryLongMethodNameWithABunchOfVariables|(  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,  kotlin.Int,) -> kotlin.Unit|[]"
             to _veryLongMethodNameWithABunchOfVariables,
         "lol|(kotlin.Any?) -> kotlin.Any?|[[kotlin.Any?]]" to _lol,
+        "fol|() -> kotlin.Any|[[kotlin.Any]]" to _fol,
     )
 
     public override fun foo(fuzz: Int, ozz: Any): Any = _foo.invoke(fuzz, ozz)
@@ -113,6 +119,9 @@ internal class SyncFunMock<L, T>(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T> lol(arg: T): T = _lol.invoke(arg) as T
+
+    @Suppress("UNCHECKED_CAST")
+    public override fun <T : Any> fol(): T = _fol.invoke() as T
 
     public override fun veryLongMethodNameWithABunchOfVariables(
         arg0: Int,
@@ -140,6 +149,7 @@ internal class SyncFunMock<L, T>(
         _uz.clear()
         _tzz.clear()
         _lol.clear()
+        _fol.clear()
         _veryLongMethodNameWithABunchOfVariables.clear()
     }
 
@@ -168,11 +178,11 @@ internal class SyncFunMock<L, T>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf2")
     public fun syncFunProxyOf(reference: (Array<out Any>) -> Any):
-        KMockContract.FunProxy<Any, (Array<out Any>) -> Any> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.Any>) -> kotlin.Any|[]"""]
+        KMockContract.FunProxy<Any, (Array<Any>) -> Any> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.Any>) -> kotlin.Any|[]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out kotlin.Any>) -> kotlin.Any!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, (kotlin.Array<out kotlin.Any>) ->
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, (kotlin.Array<kotlin.Any>) ->
         kotlin.Any>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -260,4 +270,14 @@ internal class SyncFunMock<L, T>(
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> T!""")) as
             tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any?, (kotlin.Any?) -> kotlin.Any?>
+
+    @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
+    @KMockExperimental
+    @SafeJvmName("syncFunProxyOf9")
+    public fun <T : Any> syncFunProxyOf(reference: () -> T, hint: Hint0):
+        KMockContract.FunProxy<Any, () -> Any> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|() -> kotlin.Any|[[kotlin.Any]]"""]
+            ?: throw
+            IllegalStateException("""Unknown method ${reference.name} with signature () -> T!""")) as
+            tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Any, () -> kotlin.Any>
 }

--- a/kmock-processor/src/test/resources/mock/expected/typealiaz/Access.kt
+++ b/kmock-processor/src/test/resources/mock/expected/typealiaz/Access.kt
@@ -150,27 +150,27 @@ internal class AccessMock<L : Alias623>(
             to _doSomethingElseWithTAlias621LAlias623,
         "doMoreElse|(kotlin.Function1<kotlin.Any, kotlin.Unit>, kotlin.Function1<kotlin.Any, kotlin.Any>) -> kotlin.Unit|[[kotlin.Function1<kotlin.Any, kotlin.Unit>], [kotlin.Function1<kotlin.Any, kotlin.Any>]]"
             to _doMoreElse,
-        "doSomethingElse|(mock.template.typealiaz.Generics<kotlin.Any?>) -> mock.template.typealiaz.Generics<kotlin.Any?>|[[mock.template.typealiaz.Generics<K>], [kotlin.Any?]]"
+        "doSomethingElse|(mock.template.typealiaz.Generics<kotlin.Any?>) -> mock.template.typealiaz.Generics<kotlin.Any?>|[[mock.template.typealiaz.Generics<X>], [kotlin.Any?]]"
             to _doSomethingElseWithTAlias677,
-        "foo|(kotlin.collections.Map<kotlin.String, kotlin.Any?>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, K>], [kotlin.Any?]]"
+        "foo|(kotlin.collections.Map<kotlin.String, kotlin.Any?>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, X>], [kotlin.Any?]]"
             to _fooWithTAlias673,
         "foo|(kotlin.Any, kotlin.collections.Map<kotlin.String, kotlin.String>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[]"
             to _fooWithAnyAlias673,
-        "foo|(kotlin.Char, kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.IntArray>>) -> kotlin.Unit|[]"
+        "foo|(kotlin.Char, kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.IntArray>>) -> kotlin.Unit|[]"
             to _fooWithCharAlias673s,
-        "foo|(kotlin.Int, kotlin.Array<out kotlin.collections.Map<kotlin.String, out kotlin.String>>) -> kotlin.Unit|[]"
+        "foo|(kotlin.Int, kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit|[]"
             to _fooWithIntAlias673s,
-        "foo|(kotlin.Long, kotlin.Array<out kotlin.collections.Map<kotlin.String, out mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, out mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>]]"
+        "foo|(kotlin.Long, kotlin.Array<kotlin.collections.Map<kotlin.String, mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>]]"
             to _fooWithLongTAlias673s,
         "bar|(kotlin.collections.Map<kotlin.String, kotlin.String>) -> kotlin.Unit|[]" to
             _barWithAlias699,
-        "bar|(kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
+        "bar|(kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _barWithTAlias699s,
-        "bar|(kotlin.Long, kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
+        "bar|(kotlin.Long, kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"
             to _barWithLongTAlias699s,
         "rol|(kotlin.collections.Map<kotlin.String, kotlin.String>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, kotlin.String>], [kotlin.Any?]]"
             to _rol,
-        "toll|(mock.template.typealiaz.Generics<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Generics<K>], [kotlin.CharSequence & kotlin.Comparable<K>]]"
+        "toll|(mock.template.typealiaz.Generics<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Generics<X>], [kotlin.CharSequence & kotlin.Comparable<X>]]"
             to _toll,
     )
 
@@ -389,7 +389,7 @@ internal class AccessMock<L : Alias623>(
     @SafeJvmName("syncFunProxyOf7")
     public fun <T : Generics<K>, K> syncFunProxyOf(reference: (T) -> T, hint: Hint1<T>):
         KMockContract.FunProxy<Generics<Any?>, (Generics<Any?>) -> Generics<Any?>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Generics<kotlin.Any?>) -> mock.template.typealiaz.Generics<kotlin.Any?>|[[mock.template.typealiaz.Generics<K>], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Generics<kotlin.Any?>) -> mock.template.typealiaz.Generics<kotlin.Any?>|[[mock.template.typealiaz.Generics<X>], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> T!""")) as
             tech.antibytes.kmock.KMockContract.FunProxy<mock.template.typealiaz.Generics<kotlin.Any?>,
@@ -401,7 +401,7 @@ internal class AccessMock<L : Alias623>(
     @SafeJvmName("syncFunProxyOf8")
     public fun <T : Map<String, K>, K> syncFunProxyOf(reference: (T) -> Unit, hint: Hint1<T>):
         KMockContract.FunProxy<Unit, (Map<String, Any?>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.collections.Map<kotlin.String, kotlin.Any?>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, K>], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.collections.Map<kotlin.String, kotlin.Any?>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, X>], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
@@ -424,38 +424,38 @@ internal class AccessMock<L : Alias623>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf10")
     public fun syncFunProxyOf(reference: (Char, Array<out Map<String, IntArray>>) -> Unit,
-        hint: Hint2<Char, Array<out Map<String, IntArray>>>): KMockContract.FunProxy<Unit, (Char,
-        Array<out Map<String, IntArray>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Char, kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.IntArray>>) -> kotlin.Unit|[]"""]
+        hint: Hint2<Char, Array<Map<String, IntArray>>>): KMockContract.FunProxy<Unit, (Char,
+        Array<Map<String, IntArray>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Char, kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.IntArray>>) -> kotlin.Unit|[]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Char, kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.IntArray>>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Char, kotlin.Array<out
-        kotlin.collections.Map<kotlin.String, kotlin.IntArray>>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Char,
+            kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.IntArray>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf11")
-    public fun syncFunProxyOf(reference: (Int, Array<out Map<String, out String>>) -> Unit,
-        hint: Hint2<Int, Array<out Map<String, out String>>>): KMockContract.FunProxy<Unit, (Int,
-        Array<out Map<String, out String>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Int, kotlin.Array<out kotlin.collections.Map<kotlin.String, out kotlin.String>>) -> kotlin.Unit|[]"""]
+    public fun syncFunProxyOf(reference: (Int, Array<out Map<String, String>>) -> Unit,
+        hint: Hint2<Int, Array<Map<String, String>>>): KMockContract.FunProxy<Unit, (Int,
+        Array<Map<String, String>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Int, kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit|[]"""]
             ?: throw
-            IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Int, kotlin.Array<out kotlin.collections.Map<kotlin.String, out kotlin.String>>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Int, kotlin.Array<out
-        kotlin.collections.Map<kotlin.String, out kotlin.String>>) -> kotlin.Unit>
+            IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Int, kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit!"""))
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Int,
+            kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf12")
-    public fun <T : Map<String, out Generics<Map<String, Int>>>> syncFunProxyOf(reference: (Long,
-        Array<out T>) -> Unit, hint: Hint2<Long, Array<out T>>): KMockContract.FunProxy<Unit, (Long,
-        Array<out Map<String, out Generics<Map<String, Int>>>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<out kotlin.collections.Map<kotlin.String, out mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, out mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>]]"""]
+    public fun <T : Map<String, Generics<Map<String, Int>>>> syncFunProxyOf(reference: (Long,
+        Array<out T>) -> Unit, hint: Hint2<Long, Array<T>>): KMockContract.FunProxy<Unit, (Long,
+        Array<Map<String, Generics<Map<String, Int>>>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<kotlin.collections.Map<kotlin.String, mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>>) -> kotlin.Unit|[[kotlin.collections.Map<kotlin.String, mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Long, kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Long, kotlin.Array<out
-        kotlin.collections.Map<kotlin.String, out
-        mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>>) ->
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Long,
+            kotlin.Array<kotlin.collections.Map<kotlin.String,
+                mock.template.typealiaz.Generics<kotlin.collections.Map<kotlin.String, kotlin.Int>>>>) ->
         kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -474,27 +474,27 @@ internal class AccessMock<L : Alias623>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf14")
     public fun <T : Map<String, String>> syncFunProxyOf(reference: (Array<out T>) -> T,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Map<String, String>, (Array<out Map<String, String>>) -> Map<String, String>>
+        hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Map<String, String>, (Array<Map<String, String>>) -> Map<String, String>>
         =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> T!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.collections.Map<kotlin.String,
-            kotlin.String>, (kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) ->
+            kotlin.String>, (kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) ->
         kotlin.collections.Map<kotlin.String, kotlin.String>>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf15")
     public fun <T : Map<String, String>> syncFunProxyOf(reference: (Long, Array<out T>) -> T,
-        hint: Hint2<Long, Array<out T>>): KMockContract.FunProxy<Map<String, String>, (Long,
-        Array<out Map<String, String>>) -> Map<String, String>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<out kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
+        hint: Hint2<Long, Array<T>>): KMockContract.FunProxy<Map<String, String>, (Long,
+        Array<Map<String, String>>) -> Map<String, String>> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>|[[kotlin.collections.Map<kotlin.String, kotlin.String>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Long, kotlin.Array<out T>) -> T!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.collections.Map<kotlin.String,
-            kotlin.String>, (kotlin.Long, kotlin.Array<out kotlin.collections.Map<kotlin.String,
+            kotlin.String>, (kotlin.Long, kotlin.Array<kotlin.collections.Map<kotlin.String,
             kotlin.String>>) -> kotlin.collections.Map<kotlin.String, kotlin.String>>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -514,7 +514,7 @@ internal class AccessMock<L : Alias623>(
     public fun <T : Generics<K>, K> syncFunProxyOf(reference: (T) -> Unit, hint: Hint1<T>):
         KMockContract.FunProxy<Unit, (Generics<Any>) -> Unit> where K : CharSequence, K :
     Comparable<K> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Generics<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Generics<K>], [kotlin.CharSequence & kotlin.Comparable<K>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Generics<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Generics<X>], [kotlin.CharSequence & kotlin.Comparable<X>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,

--- a/kmock-processor/src/test/resources/mock/expected/typealiaz/PreventResolving.kt
+++ b/kmock-processor/src/test/resources/mock/expected/typealiaz/PreventResolving.kt
@@ -150,28 +150,28 @@ internal class PreventResolvingMock<L : Alias923>(
             to _doOtherThing,
         "doSomethingElse|(mock.template.typealiaz.Alias921, mock.template.typealiaz.Alias923) -> kotlin.Unit|[[mock.template.typealiaz.Alias921], [mock.template.typealiaz.Alias923]]"
             to _doSomethingElseWithTAlias921LAlias923,
-        "doSomethingElse|(mock.template.typealiaz.Alias977<kotlin.Any?>) -> mock.template.typealiaz.Alias977<kotlin.Any?>|[[mock.template.typealiaz.Alias977<K>], [kotlin.Any?]]"
+        "doSomethingElse|(mock.template.typealiaz.Alias977<kotlin.Any?>) -> mock.template.typealiaz.Alias977<kotlin.Any?>|[[mock.template.typealiaz.Alias977<X>], [kotlin.Any?]]"
             to _doSomethingElseWithTAlias977,
         "doMoreElse|(kotlin.Function1<kotlin.Any, kotlin.Unit>, kotlin.Function1<kotlin.Any, kotlin.Any>) -> kotlin.Unit|[[kotlin.Function1<kotlin.Any, kotlin.Unit>], [kotlin.Function1<kotlin.Any, kotlin.Any>]]"
             to _doMoreElse,
-        "foo|(mock.template.typealiaz.Alias973<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<K>], [kotlin.Any?]]"
+        "foo|(mock.template.typealiaz.Alias973<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<X>], [kotlin.Any?]]"
             to _fooWithTAlias973,
         "foo|(kotlin.Any, mock.template.typealiaz.Alias973<kotlin.String>?) -> mock.template.typealiaz.Alias973<kotlin.String>|[]"
             to _fooWithAnyAlias973,
-        "foo|(kotlin.Char, kotlin.Array<out mock.template.typealiaz.Alias973<kotlin.IntArray>>) -> kotlin.Unit|[]"
+        "foo|(kotlin.Char, kotlin.Array<mock.template.typealiaz.Alias973<kotlin.IntArray>>) -> kotlin.Unit|[]"
             to _fooWithCharAlias973s,
-        "foo|(kotlin.Int, kotlin.Array<out mock.template.typealiaz.Alias973<out kotlin.String>>) -> kotlin.Unit|[]"
+        "foo|(kotlin.Int, kotlin.Array<mock.template.typealiaz.Alias973<kotlin.String>>) -> kotlin.Unit|[]"
             to _fooWithIntAlias973s,
-        "foo|(kotlin.Long, kotlin.Array<out mock.template.typealiaz.Alias973<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"
+        "foo|(kotlin.Long, kotlin.Array<mock.template.typealiaz.Alias973<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"
             to _fooWithLongTAlias973s,
         "bar|(mock.template.typealiaz.Alias999<kotlin.String>) -> kotlin.Unit|[]" to _barWithAlias999,
-        "bar|(kotlin.Array<out mock.template.typealiaz.Alias999<kotlin.String>>) -> mock.template.typealiaz.Alias999<kotlin.String>|[[mock.template.typealiaz.Alias999<kotlin.String>]]"
+        "bar|(kotlin.Array<mock.template.typealiaz.Alias999<kotlin.String>>) -> mock.template.typealiaz.Alias999<kotlin.String>|[[mock.template.typealiaz.Alias999<kotlin.String>]]"
             to _barWithTAlias999s,
-        "bar|(kotlin.Long, kotlin.Array<out mock.template.typealiaz.Alias999<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> mock.template.typealiaz.Alias999<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>|[[mock.template.typealiaz.Alias999<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"
+        "bar|(kotlin.Long, kotlin.Array<mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>|[[mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"
             to _barWithLongTAlias999s,
-        "rol|(mock.template.typealiaz.Alias1000<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias1000<K>], [kotlin.Any?]]"
+        "rol|(mock.template.typealiaz.Alias1000<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias1000<X>], [kotlin.Any?]]"
             to _rol,
-        "toll|(mock.template.typealiaz.Alias977<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Alias977<K>], [kotlin.CharSequence & kotlin.Comparable<K>]]"
+        "toll|(mock.template.typealiaz.Alias977<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Alias977<X>], [kotlin.CharSequence & kotlin.Comparable<X>]]"
             to _toll,
     )
 
@@ -386,7 +386,7 @@ internal class PreventResolvingMock<L : Alias923>(
     @SafeJvmName("syncFunProxyOf7")
     public fun <T : Alias977<K>, K> syncFunProxyOf(reference: (T) -> T, hint: Hint1<T>):
         KMockContract.FunProxy<Alias977<Any?>, (Alias977<Any?>) -> Alias977<Any?>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias977<kotlin.Any?>) -> mock.template.typealiaz.Alias977<kotlin.Any?>|[[mock.template.typealiaz.Alias977<K>], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias977<kotlin.Any?>) -> mock.template.typealiaz.Alias977<kotlin.Any?>|[[mock.template.typealiaz.Alias977<X>], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> T!""")) as
             tech.antibytes.kmock.KMockContract.FunProxy<mock.template.typealiaz.Alias977<kotlin.Any?>,
@@ -410,7 +410,7 @@ internal class PreventResolvingMock<L : Alias923>(
     @SafeJvmName("syncFunProxyOf9")
     public fun <T : Alias973<K>, K> syncFunProxyOf(reference: (T) -> Unit, hint: Hint1<T>):
         KMockContract.FunProxy<Unit, (Alias973<Any?>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias973<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<K>], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias973<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<X>], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
@@ -434,38 +434,37 @@ internal class PreventResolvingMock<L : Alias923>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf11")
     public fun syncFunProxyOf(reference: (Char, Array<out Alias973<IntArray>>) -> Unit,
-        hint: Hint2<Char, Array<out Alias973<IntArray>>>): KMockContract.FunProxy<Unit, (Char,
-        Array<out Alias973<IntArray>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Char, kotlin.Array<out mock.template.typealiaz.Alias973<kotlin.IntArray>>) -> kotlin.Unit|[]"""]
+        hint: Hint2<Char, Array<Alias973<IntArray>>>): KMockContract.FunProxy<Unit, (Char,
+        Array<Alias973<IntArray>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Char, kotlin.Array<mock.template.typealiaz.Alias973<kotlin.IntArray>>) -> kotlin.Unit|[]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Char, kotlin.Array<out mock.template.typealiaz.Alias973<kotlin.IntArray>>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Char, kotlin.Array<out
-        mock.template.typealiaz.Alias973<kotlin.IntArray>>) -> kotlin.Unit>
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Char,
+            kotlin.Array<mock.template.typealiaz.Alias973<kotlin.IntArray>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf12")
-    public fun syncFunProxyOf(reference: (Int, Array<out Alias973<out String>>) -> Unit,
-        hint: Hint2<Int, Array<out Alias973<out String>>>): KMockContract.FunProxy<Unit, (Int,
-        Array<out Alias973<out String>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Int, kotlin.Array<out mock.template.typealiaz.Alias973<out kotlin.String>>) -> kotlin.Unit|[]"""]
+    public fun syncFunProxyOf(reference: (Int, Array<out Alias973<String>>) -> Unit,
+        hint: Hint2<Int, Array<Alias973<String>>>): KMockContract.FunProxy<Unit, (Int,
+        Array<Alias973<String>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Int, kotlin.Array<mock.template.typealiaz.Alias973<kotlin.String>>) -> kotlin.Unit|[]"""]
             ?: throw
-            IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Int, kotlin.Array<out mock.template.typealiaz.Alias973<out kotlin.String>>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Int, kotlin.Array<out
-        mock.template.typealiaz.Alias973<out kotlin.String>>) -> kotlin.Unit>
+            IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Int, kotlin.Array<out mock.template.typealiaz.Alias973<kotlin.String>>) -> kotlin.Unit!"""))
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Int,
+            kotlin.Array<mock.template.typealiaz.Alias973<kotlin.String>>) -> kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf13")
-    public fun <T : Alias973<out Alias977<Alias973<Int>>>> syncFunProxyOf(reference: (Long,
-        Array<out T>) -> Unit, hint: Hint2<Long, Array<out T>>): KMockContract.FunProxy<Unit, (Long,
-        Array<out Alias973<out Alias977<Alias973<Int>>>>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<out mock.template.typealiaz.Alias973<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"""]
+    public fun <T : Alias973<Alias977<Alias973<Int>>>> syncFunProxyOf(reference: (Long,
+        Array<out T>) -> Unit, hint: Hint2<Long, Array<T>>): KMockContract.FunProxy<Unit, (Long,
+        Array<Alias973<Alias977<Alias973<Int>>>>) -> Unit> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<mock.template.typealiaz.Alias973<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> kotlin.Unit|[[mock.template.typealiaz.Alias973<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Long, kotlin.Array<out T>) -> kotlin.Unit!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Long, kotlin.Array<out
-        mock.template.typealiaz.Alias973<out
-        mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) ->
+            as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit, (kotlin.Long,
+            kotlin.Array<mock.template.typealiaz.Alias973<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) ->
         kotlin.Unit>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
@@ -483,39 +482,38 @@ internal class PreventResolvingMock<L : Alias923>(
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf15")
     public fun <T : Alias999<String>> syncFunProxyOf(reference: (Array<out T>) -> T,
-        hint: Hint1<Array<out T>>):
-        KMockContract.FunProxy<Alias999<String>, (Array<out Alias999<String>>) -> Alias999<String>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<out mock.template.typealiaz.Alias999<kotlin.String>>) -> mock.template.typealiaz.Alias999<kotlin.String>|[[mock.template.typealiaz.Alias999<kotlin.String>]]"""]
+        hint: Hint1<Array<T>>):
+        KMockContract.FunProxy<Alias999<String>, (Array<Alias999<String>>) -> Alias999<String>> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Array<mock.template.typealiaz.Alias999<kotlin.String>>) -> mock.template.typealiaz.Alias999<kotlin.String>|[[mock.template.typealiaz.Alias999<kotlin.String>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Array<out T>) -> T!"""))
             as
             tech.antibytes.kmock.KMockContract.FunProxy<mock.template.typealiaz.Alias999<kotlin.String>,
-                    (kotlin.Array<out mock.template.typealiaz.Alias999<kotlin.String>>) ->
+                    (kotlin.Array<mock.template.typealiaz.Alias999<kotlin.String>>) ->
             mock.template.typealiaz.Alias999<kotlin.String>>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf16")
-    public fun <T : Alias999<out Alias977<Alias973<Int>>>> syncFunProxyOf(reference: (Long,
-        Array<out T>) -> T, hint: Hint2<Long, Array<out T>>):
-        KMockContract.FunProxy<Alias999<out Alias977<Alias973<Int>>>, (Long,
-            Array<out Alias999<out Alias977<Alias973<Int>>>>) -> Alias999<out Alias977<Alias973<Int>>>> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<out mock.template.typealiaz.Alias999<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> mock.template.typealiaz.Alias999<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>|[[mock.template.typealiaz.Alias999<out mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"""]
+    public fun <T : Alias999<Alias977<Alias973<Int>>>> syncFunProxyOf(reference: (Long,
+        Array<out T>) -> T, hint: Hint2<Long, Array<T>>):
+        KMockContract.FunProxy<Alias999<Alias977<Alias973<Int>>>, (Long,
+            Array<Alias999<Alias977<Alias973<Int>>>>) -> Alias999<Alias977<Alias973<Int>>>> =
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(kotlin.Long, kotlin.Array<mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) -> mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>|[[mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (kotlin.Long, kotlin.Array<out T>) -> T!"""))
-            as tech.antibytes.kmock.KMockContract.FunProxy<mock.template.typealiaz.Alias999<out
-        mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>, (kotlin.Long,
-            kotlin.Array<out mock.template.typealiaz.Alias999<out
-            mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) ->
-        mock.template.typealiaz.Alias999<out
-        mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>
+            as
+            tech.antibytes.kmock.KMockContract.FunProxy<mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>,
+                    (kotlin.Long,
+                kotlin.Array<mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>) ->
+            mock.template.typealiaz.Alias999<mock.template.typealiaz.Alias977<mock.template.typealiaz.Alias973<kotlin.Int>>>>
 
     @Suppress("UNUSED_PARAMETER", "UNUSED_EXPRESSION", "UNCHECKED_CAST")
     @KMockExperimental
     @SafeJvmName("syncFunProxyOf17")
     public fun <T : Alias1000<K>, K> syncFunProxyOf(reference: (T) -> Unit, hint: Hint1<T>):
         KMockContract.FunProxy<Unit, (Alias1000<Any?>) -> Unit> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias1000<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias1000<K>], [kotlin.Any?]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias1000<kotlin.Any?>) -> kotlin.Unit|[[mock.template.typealiaz.Alias1000<X>], [kotlin.Any?]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,
@@ -527,7 +525,7 @@ internal class PreventResolvingMock<L : Alias923>(
     public fun <T : Alias977<K>, K> syncFunProxyOf(reference: (T) -> Unit, hint: Hint1<T>):
         KMockContract.FunProxy<Unit, (Alias977<Any>) -> Unit> where K : CharSequence, K :
     Comparable<K> =
-        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias977<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Alias977<K>], [kotlin.CharSequence & kotlin.Comparable<K>]]"""]
+        (referenceStore["""${(reference as kotlin.reflect.KFunction<*>).name}|(mock.template.typealiaz.Alias977<kotlin.Any>) -> kotlin.Unit|[[mock.template.typealiaz.Alias977<X>], [kotlin.CharSequence & kotlin.Comparable<X>]]"""]
             ?: throw
             IllegalStateException("""Unknown method ${reference.name} with signature (T) -> kotlin.Unit!"""))
             as tech.antibytes.kmock.KMockContract.FunProxy<kotlin.Unit,

--- a/kmock-processor/src/test/resources/mock/template/access/AsyncFun.kt
+++ b/kmock-processor/src/test/resources/mock/template/access/AsyncFun.kt
@@ -16,7 +16,7 @@ interface AsyncFun<L, T> where T : CharSequence, T : Comparable<T> {
 
     suspend fun ozz(vararg buzz: Int): Any
 
-    suspend fun izz(vararg buzz: Any): Any
+    suspend fun izz(vararg buzz: L): Any
 
     suspend fun uzz()
 
@@ -27,6 +27,7 @@ interface AsyncFun<L, T> where T : CharSequence, T : Comparable<T> {
     suspend fun tzz(): T
 
     suspend fun <T> lol(arg: T): T
+    suspend fun <T : Any> fol(): T
 
     suspend fun veryLongMethodNameWithABunchOfVariables(
         arg0: Int,
@@ -36,8 +37,8 @@ interface AsyncFun<L, T> where T : CharSequence, T : Comparable<T> {
         arg4: Int,
         arg5: Int,
         arg6: Int,
-        arg7: Int,
+        arg7: L,
         arg8: Int,
-        arg9: Int
+        arg9: T
     )
 }

--- a/kmock-processor/src/test/resources/mock/template/access/SyncFun.kt
+++ b/kmock-processor/src/test/resources/mock/template/access/SyncFun.kt
@@ -27,6 +27,7 @@ interface SyncFun<L, T> where T : CharSequence, T : Comparable<T> {
     fun tzz(): T
 
     fun <T> lol(arg: T): T
+    fun <T : Any> fol(): T
 
     fun veryLongMethodNameWithABunchOfVariables(
         arg0: Int,


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #231

### What does the PR achieve/Which part improves the PR?
<!-- Provide a description of the improvements/features/fixes the pull-request seeks.-->
This resolves collisions of generics by unify the Generic TypeVariableName.

### :thinking: DOD Checklist

- [x] My code passes the lint checks.
- [x] My changes are covered with proper tests.
- [x] All tests are pass.
- [ ] My changes update the documentation.
- [x] My changes are reflected in the changelog.
